### PR TITLE
Removed the deprecated/dead featured_build pipeline property

### DIFF
--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -35,9 +35,6 @@ type Pipeline struct {
 	// the provider of sources
 	Provider *Provider `json:"provider,omitempty"`
 
-	// build featured when you view the pipeline
-	FeaturedBuild *Build `json:"featured_build,omitempty"`
-
 	// build steps
 	Steps []*Step `json:"steps,omitempty"`
 }


### PR DESCRIPTION
From what I can tell, the ```featured_build``` attribute from the pipeline API is no longer with us, so I removed it off the v2.0.0 tag.

:skull: 