### PR TITLE
Changed the wolfeidau refs to buildkite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOPATH := $(shell pwd)/.gopath
-STAGING_PATH = $(shell pwd)/.gopath/src/github.com/wolfeidau
+STAGING_PATH = $(shell pwd)/.gopath/src/github.com/buildkite
 DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
 
 all: deps test

--- a/examples/projects/main.go
+++ b/examples/projects/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/wolfeidau/go-buildkite/buildkite"
+	"github.com/buildkite/go-buildkite/buildkite"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )


### PR DESCRIPTION
The ```makefile``` and ```main.go``` files had refs to ```github.com/wolfeidau``` still, so I changed them to ```github.com/buildkite``` 