### PR TITLE
Add Artifacts Service

### DIFF
--- a/buildkite/artifacts.go
+++ b/buildkite/artifacts.go
@@ -1,0 +1,84 @@
+// Copyright 2014 Mark Wolfe. All rights reserved.
+//
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package buildkite
+
+import (
+	"fmt"
+	"io"
+)
+
+// ArtifactsService handles communication with the artifact related
+// methods of the buildkite API.
+//
+// buildkite API docs: https://buildkite.com/docs/api/artifacts
+type ArtifactsService struct {
+	client *Client
+}
+
+// Artifact represents an artifact which has been stored from a build
+type Artifact struct {
+	ID           *string `json:"id,omitempty"`
+	JobID        *string `json:"job_id,omitempty"`
+	URL          *string `json:"url,omitempty"`
+	DownloadURL  *string `json:"download_url,omitempty"`
+	State        *string `json:"state,omitempty"`
+	Path         *string `json:"path,omitempty"`
+	Dirname      *string `json:"dirname,omitempty"`
+	Filename     *string `json:"filename,omitempty"`
+	MimeType     *string `json:"mime_type,omitempty"`
+	FileSize     *int64  `json:"file_size,omitempty"`
+	GlobPath     *string `json:"glob_path,omitempty"`
+	OriginalPath *string `json:"original_path,omitempty"`
+	SHA1         *string `json:"sha1sum,omitempty"`
+}
+
+// ArtifactListOptions specifies the optional parameters to the
+// ArtifactsService.List method.
+type ArtifactListOptions struct {
+	ListOptions
+}
+
+// ListByBuild gets artifacts for a specific build
+//
+// buildkite API docs: https://buildkite.com/docs/api/artifacts#list-artifacts-for-a-build
+func (as *ArtifactsService) ListByBuild(org string, pipeline string, build string, opt *ArtifactListOptions) ([]Artifact, *Response, error) {
+	var u string
+
+	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/artifacts", org, pipeline, build)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := as.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	artifacts := new([]Artifact)
+	resp, err := as.client.Do(req, artifacts)
+	if err != nil {
+		return nil, resp, err
+	}
+	return *artifacts, resp, err
+}
+
+// ListByBuild gets artifacts for a specific build
+//
+// buildkite API docs: https://buildkite.com/docs/api/artifacts#list-artifacts-for-a-build
+func (as *ArtifactsService) DownloadArtifactByURL(url string, w io.Writer) (*Response, error) {
+	req, err := as.client.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := as.client.Do(req, w)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/buildkite"
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	apiToken     = kingpin.Flag("token", "API token").Required().String()
+	org          = kingpin.Flag("org", "Orginization slug").Required().String()
+	pipeline     = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+	build        = kingpin.Flag("build", "Build Number slug").Required().String()
+	artifactName = kingpin.Flag("artifact", "Artifact to download").String()
+	debug        = kingpin.Flag("debug", "Enable debugging").Bool()
+)
+
+func main() {
+	kingpin.Parse()
+
+	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
+
+	if err != nil {
+		log.Fatalf("client config failed: %s", err)
+	}
+
+	client := buildkite.NewClient(config.Client())
+
+	artifacts, _, err := client.Artifacts.ListByBuild(*org, *pipeline, *build, nil)
+
+	if err != nil {
+		log.Fatalf("list artifacts failed: %s", err)
+	}
+
+	for _, artifact := range artifacts {
+		if *artifactName == "" {
+			data, err := json.MarshalIndent(artifact, "", "\t")
+
+			if err != nil {
+				log.Fatalf("json encode failed: %s", err)
+			}
+
+			fmt.Fprintf(os.Stdout, "%s\n", string(data))
+		} else {
+			if *artifactName == *artifact.Filename || *artifactName == *artifact.ID {
+				_, err := client.Artifacts.DownloadArtifactByURL(*artifact.DownloadURL, os.Stdout)
+				if err != nil {
+					log.Fatalf("DownloadArtifactByURL failed: %s", err)
+				}
+				os.Exit(0)
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Adds `ArtifactsService` struct to Client.
- Changes behavior of the Auth RoundTrippers, to only pass in Authorization headers if the `.Host` matches the original API host.  This is because we were unconditionally adding the Authorization Headers on redirects to an s3 URL.  This has two bad things:
  * Leaking auth headers to Amazon S3
  * This would cause Amazon to 400, because the redirect URL includes Amz params:
```xml
<Error>
<Code>InvalidArgument</Code>
<Message>Only one auth mechanism allowed;
only the X-Amz-Algorithm query parameter,
Signature query string parameter or the Authorization header should be specified</Message>
```

So, I did a horrible hack on the auth round trippers, open to another idea, but basically anything I could think of would break the existing API.  I did try using the `CheckRedirect` on the http.Client, but it is invoked *before* the Transport, so deleting the Authorization header has no effect, as the transport would just add the Authorization header afterwards