### PR TITLE
 Parse the timestamp format webhooks use

### DIFF
--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -175,5 +176,44 @@ func TestBuildsService_ListByPipeline(t *testing.T) {
 	want := []Build{{ID: String("123")}, {ID: String("1234")}}
 	if !reflect.DeepEqual(builds, want) {
 		t.Errorf("Builds.List returned %+v, want %+v", builds, want)
+	}
+}
+
+func TestBuildsUnmarshalWebhook(t *testing.T) {
+	// payload taken from buildkite services console
+	sampleData := `{
+  "event": "build.scheduled",
+  "build": {
+    "id": "foo",
+    "url": "https://api.buildkite.com/v2/organizations/org/pipelines/greenpipe/builds/1",
+    "web_url": "https://buildkite.com/org/greenpipe/builds/1",
+    "number": 1,
+    "state": "scheduled",
+    "blocked": false,
+    "message": "doot",
+    "commit": "HEAD",
+    "branch": "master",
+    "tag": null,
+    "source": "ui",
+    "creator": {
+      "id": "foo",
+      "name": "Uhh, Jim",
+      "email": "slam@space.jam",
+      "created_at": "2018-03-22 23:13:16 UTC"
+    },
+    "created_at": "2018-03-25 03:58:14 UTC",
+    "scheduled_at": "2018-03-25 03:58:14 UTC"
+  }
+}`
+
+	type webhookPayload struct {
+		Event string
+		Build Build
+	}
+
+	var payload webhookPayload
+
+	if err := json.Unmarshal([]byte(sampleData), &payload); err != nil {
+		t.Fatalf("could not unmarshal: %v", err)
 	}
 }

--- a/buildkite/timestamp.go
+++ b/buildkite/timestamp.go
@@ -11,6 +11,9 @@ import "time"
 // api, note this odd string is used to parse/format dates in go
 const BuildKiteDateFormat = time.RFC3339Nano
 
+// BuildKiteEventDateFormat is the format of the dates used in webhook events.
+const BuildKiteEventDateFormat = "2006-01-02 15:04:05 MST"
+
 // Timestamp custom timestamp to support buildkite api timestamps
 type Timestamp struct {
 	time.Time
@@ -33,6 +36,14 @@ func (ts Timestamp) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (ts *Timestamp) UnmarshalJSON(data []byte) (err error) {
 	(*ts).Time, err = time.Parse(`"`+BuildKiteDateFormat+`"`, string(data))
+	if err != nil {
+		// try the webhook format too; avoid clobbering the error if both fail
+		t, err2 := time.Parse(`"`+BuildKiteEventDateFormat+`"`, string(data))
+		if err2 == nil {
+			(*ts).Time = t
+			err = err2
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
This allows the structs in this package to be reused in go code meant to accept and unmarshal buildkite webhooks.

With this change, I'm able to successfully unmarshal a webhook event using these types.