### PR TITLE
Add typed provider settings

### DIFF
--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -27,7 +27,7 @@ type CreatePipeline struct {
 	// Optional fields
 	Description                     string            `json:"description,omitempty"`
 	Env                             map[string]string `json:"env,omitempty"`
-	ProviderSettings                map[string]bool   `json:"provider_settings,omitempty"`
+	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty"`
 	BranchConfiguration             string            `json:"branch_configuration,omitempty"`
 	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty"`
 	SkipQueuedBranchBuildsFilter    string            `json:"skip_queued_branch_builds_filter,omitempty"`
@@ -61,12 +61,6 @@ type Pipeline struct {
 	Steps []*Step `json:"steps,omitempty"`
 }
 
-// Provider represents a source code provider.
-type Provider struct {
-	ID         *string `json:"id,omitempty"`
-	WebhookURL *string `json:"webhook_url,omitempty"`
-}
-
 // Step represents a build step in buildkites build pipeline
 type Step struct {
 	Type                *string           `json:"type,omitempty"`
@@ -75,8 +69,8 @@ type Step struct {
 	ArtifactPaths       *string           `json:"artifact_paths,omitempty"`
 	BranchConfiguration *string           `json:"branch_configuration,omitempty"`
 	Env                 map[string]string `json:"env,omitempty"`
-	TimeoutInMinutes    interface{}       `json:"timeout_in_minutes,omitempty"` // *shrug*
-	AgentQueryRules     interface{}       `json:"agent_query_rules,omitempty"`  // *shrug*
+	TimeoutInMinutes    *int              `json:"timeout_in_minutes,omitempty"`
+	AgentQueryRules     []string          `json:"agent_query_rules,omitempty"`
 }
 
 // PipelineListOptions specifies the optional parameters to the

--- a/buildkite/providers.go
+++ b/buildkite/providers.go
@@ -1,0 +1,93 @@
+package buildkite
+
+import "encoding/json"
+
+// Provider represents a source code provider. It is read-only, but settings may be written using Pipeline.ProviderSettings.
+type Provider struct {
+	ID         string           `json:"id"`
+	WebhookURL *string          `json:"webhook_url"`
+	Settings   ProviderSettings `json:"settings"`
+}
+
+// UnmarshalJSON decodes the Provider, choosing the type of the Settings from the ID.
+func (p *Provider) UnmarshalJSON(data []byte) error {
+	type provider Provider
+	var v struct {
+		provider
+		Settings json.RawMessage `json:"settings"`
+	}
+
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+	*p = Provider(v.provider)
+
+	var settings ProviderSettings
+	switch v.ID {
+	case "bitbucket":
+		settings = &BitbucketSettings{}
+	case "github":
+		settings = &GitHubSettings{}
+	case "gitlab":
+		settings = &GitLabSettings{}
+	default:
+		return nil
+	}
+
+	err = json.Unmarshal(v.Settings, settings)
+	if err != nil {
+		return err
+	}
+	p.Settings = settings
+
+	return nil
+}
+
+// ProviderSettings represents the sum type of the settings for different source code providers.
+type ProviderSettings interface {
+	isProviderSettings()
+}
+
+// BitbucketSettings are settings for pipelines building from Bitbucket repositories.
+type BitbucketSettings struct {
+	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
+	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildTags                               *bool   `json:"build_tags,omitempty"`
+	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
+
+	// Read-only
+	Repository *string `json:"repository,omitempty"`
+}
+
+func (s *BitbucketSettings) isProviderSettings() {}
+
+// GitHubSettings are settings for pipelines building from GitHub repositories.
+type GitHubSettings struct {
+	TriggerMode                             *string `json:"trigger_mode,omitempty"`
+	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
+	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildPullRequestForks                   *bool   `json:"build_pull_request_forks,omitempty"`
+	PrefixPullRequestForkBranchNames        *bool   `json:"prefix_pull_request_fork_branch_names,omitempty"`
+	BuildTags                               *bool   `json:"build_tags,omitempty"`
+	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
+
+	// Read-only
+	Repository *string `json:"repository,omitempty"`
+}
+
+func (s *GitHubSettings) isProviderSettings() {}
+
+// GitLabSettings are settings for pipelines building from GitLab repositories.
+type GitLabSettings struct {
+	// Read-only
+	Repository *string `json:"repository,omitempty"`
+}
+
+func (s *GitLabSettings) isProviderSettings() {}

--- a/buildkite/providers_test.go
+++ b/buildkite/providers_test.go
@@ -1,0 +1,75 @@
+package buildkite
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestUnmarshalBitbucketProvider(t *testing.T) {
+	var provider Provider
+	err := json.Unmarshal([]byte(`{"id": "bitbucket", "settings": {"repository": "my-bitbucket-repo"}}`), &provider)
+	if err != nil {
+		t.Errorf("Error unmarshalling Bitbucket provider: %v", err)
+	}
+
+	want := Provider{
+		ID:       "bitbucket",
+		Settings: &BitbucketSettings{Repository: String("my-bitbucket-repo")},
+	}
+
+	if !reflect.DeepEqual(provider, want) {
+		t.Errorf("Failed to unmarshal Bitbucket provider: got %+v, want %+v", provider, want)
+	}
+}
+
+func TestUnmarshalGitHubProvider(t *testing.T) {
+	var provider Provider
+	err := json.Unmarshal([]byte(`{"id": "github", "settings": {"repository": "my-github-repo"}}`), &provider)
+	if err != nil {
+		t.Errorf("Error unmarshalling GitHub provider: %v", err)
+	}
+
+	want := Provider{
+		ID:       "github",
+		Settings: &GitHubSettings{Repository: String("my-github-repo")},
+	}
+
+	if !reflect.DeepEqual(provider, want) {
+		t.Errorf("Failed to unmarshal GitHub provider: got %+v, want %+v", provider, want)
+	}
+}
+
+func TestUnmarshalGitLabProvider(t *testing.T) {
+	var provider Provider
+	err := json.Unmarshal([]byte(`{"id": "gitlab", "settings": {"repository": "my-gitlab-repo"}}`), &provider)
+	if err != nil {
+		t.Errorf("Error unmarshalling GitLab provider: %v", err)
+	}
+
+	want := Provider{
+		ID:       "gitlab",
+		Settings: &GitLabSettings{Repository: String("my-gitlab-repo")},
+	}
+
+	if !reflect.DeepEqual(provider, want) {
+		t.Errorf("Failed to unmarshal GitLab provider: got %+v, want %+v", provider, want)
+	}
+}
+
+func TestUnmarshalUnknownProvider(t *testing.T) {
+	var provider Provider
+	err := json.Unmarshal([]byte(`{"id": "unknown", "settings": {"emoji": ":shrug:"}}`), &provider)
+	if err != nil {
+		t.Errorf("Error unmarshalling unknown provider: %v", err)
+	}
+
+	want := Provider{
+		ID:       "unknown",
+		Settings: nil,
+	}
+
+	if !reflect.DeepEqual(provider, want) {
+		t.Errorf("Failed to unmarshal unknown provider: got %+v, want %+v", provider, want)
+	}
+}


### PR DESCRIPTION
Extracted from #21, this adds types for the different providers' settings. As before, I'd appreciate some help from someone who knows what the API offers for things like GitHub Enterprise.