### PR TITLE
Parse AgentQueryRules and TimeoutInMinutes for Steps

### DIFF
--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -75,8 +75,8 @@ type Step struct {
 	ArtifactPaths       *string           `json:"artifact_paths,omitempty"`
 	BranchConfiguration *string           `json:"branch_configuration,omitempty"`
 	Env                 map[string]string `json:"env,omitempty"`
-	TimeoutInMinutes    interface{}       `json:"timeout_in_minutes,omitempty"` // *shrug*
-	AgentQueryRules     interface{}       `json:"agent_query_rules,omitempty"`  // *shrug*
+	TimeoutInMinutes    *int              `json:"timeout_in_minutes,omitempty"`
+	AgentQueryRules     []string          `json:"agent_query_rules,omitempty"`
 }
 
 // PipelineListOptions specifies the optional parameters to the

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -86,7 +86,12 @@ func TestPipelinesService_Get(t *testing.T) {
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"id":"123",
-						"slug":"my-great-pipeline-slug"}`)
+						"slug":"my-great-pipeline-slug",
+						"timeout_in_minutes": "1",
+						"agent_query_rules": [
+							"queue=default",
+							"llamas=true"
+						]}`)
 	})
 
 	pipeline, _, err := client.Pipelines.Get("my-great-org", "my-great-pipeline-slug")


### PR DESCRIPTION
This provides some types for `AgentQueryRules` and `TimeoutInMinutes`.

@keithpitt / @sj26 can you think of any times that these would not be nilable `[]string` and `int` respectively? 

Extracted from https://github.com/buildkite/go-buildkite/pull/23