### PR TITLE
Added support for rebuilding builds

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -46,6 +46,13 @@ type Creator struct {
 	Name      string     `json:"name"`
 }
 
+// PullRequest represents a Github PR
+type PullRequest struct {
+	ID          *string    `json:"id,omitempty"`
+	Base        *string    `json:"base,omitempty"`
+	Repository  *string    `json:"repository,omitempty"`
+}
+
 // Build represents a build which has run in buildkite
 type Build struct {
 	ID          *string                `json:"id,omitempty"`
@@ -69,6 +76,9 @@ type Build struct {
 
 	// the pipeline this build is associated with
 	Pipeline *Pipeline `json:"pipeline,omitempty"`
+
+	// the pull request this build is associated with
+	PullRequest *PullRequest `json:"pull_request,omitempty"`
 }
 
 // Job represents a job run during a build in buildkite

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -245,3 +245,20 @@ func (bs *BuildsService) ListByPipeline(org string, pipeline string, opt *Builds
 
 	return *orgs, resp, err
 }
+
+// Rebuild triggers a rebuild for the target build
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/builds#rebuild-a-build
+func (bs *BuildsService) Rebuild(build Build) (*Build, error) {
+	u := fmt.Sprintf("%s/rebuild", *(build.URL))
+	req, err := bs.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	result := Build{}
+	_, err = bs.client.Do(req, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -249,8 +249,8 @@ func (bs *BuildsService) ListByPipeline(org string, pipeline string, opt *Builds
 // Rebuild triggers a rebuild for the target build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/builds#rebuild-a-build
-func (bs *BuildsService) Rebuild(build Build) (*Build, error) {
-	u := fmt.Sprintf("%s/rebuild", *(build.URL))
+func (bs *BuildsService) Rebuild(org, pipeline, build string) (*Build, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/rebuild", org, pipeline, build)
 	req, err := bs.client.NewRequest("PUT", u, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We're using go-buildkite as part of a CLI tool and needed support for triggering rebuilds. This PR adds a `Rebuild()` function to `BuildsService`.