### PR TITLE
Explicitly set JSON content-type on API requests

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -126,6 +126,8 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		return nil, err
 	}
 
+	req.Header.Set("Content-Type", "application/json")
+
 	if c.UserAgent != "" {
 		req.Header.Add("User-Agent", c.UserAgent)
 	}

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -102,6 +102,11 @@ func TestNewRequest(t *testing.T) {
 		t.Errorf("NewRequest(%v) Body is %v, want %v", inBody, got, want)
 	}
 
+	// test that content-type said it was JSON too
+	if got, want := req.Header.Get("Content-Type"), "application/json"; got != want {
+		t.Errorf("NewRequest() Content-Type is %v, want %v", got, want)
+	}
+
 	// test that default user-agent is attached to the request
 	if got, want := req.Header.Get("User-Agent"), c.UserAgent; got != want {
 		t.Errorf("NewRequest() User-Agent is %v, want %v", got, want)


### PR DESCRIPTION
Without this, things can go Less Than Well if a submitted string contains a `%`, and falls afoul of `application/x-www-form-urlencoded` interpretation.