### PR TITLE
Allow updating pipeline provider settings

### DIFF
--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -175,9 +175,10 @@ func (ps *PipelinesService) Update(org string, p *Pipeline) (*Response, error) {
 	// There is quite a lot of properties that are not represented by the Client-side
 	// Pipeline abstraction hence only a subset can be updated.
 	cp := &CreatePipeline{
-		Name:       *p.Name,
-		Repository: *p.Repository,
-		Steps:      make([]Step, len(p.Steps)),
+		Name:             *p.Name,
+		Repository:       *p.Repository,
+		Steps:            make([]Step, len(p.Steps)),
+		ProviderSettings: p.Provider.Settings,
 	}
 
 	for i := range p.Steps {


### PR DESCRIPTION
Current implementation does not allow the client to update the provider settings of a pipeline.  This simple fix allows those modifications.