### PR TITLE
Add YAML support to types

### DIFF
--- a/buildkite/agents.go
+++ b/buildkite/agents.go
@@ -17,25 +17,25 @@ type AgentsService struct {
 
 // Agent represents a buildkite build agent.
 type Agent struct {
-	ID                *string    `json:"id,omitempty"`
-	URL               *string    `json:"url,omitempty"`
-	WebURL            *string    `json:"web_url,omitempty"`
-	Name              *string    `json:"name,omitempty"`
-	ConnectedState    *string    `json:"connection_state,omitempty"`
-	AgentToken        *string    `json:"access_token,omitempty"`
-	Hostname          *string    `json:"hostname,omitempty"`
-	IPAddress         *string    `json:"ip_address,omitempty"`
-	UserAgent         *string    `json:"user_agent,omitempty"`
-	Version           *string    `json:"version,omitempty"`
-	CreatedAt         *Timestamp `json:"created_at,omitempty"`
-	LastJobFinishedAt *Timestamp `json:"last_job_finished_at,omitempty"`
-	Priority          *int       `json:"priority,omitempty"`
-	Metadata          []string   `json:"meta_data,omitempty"`
+	ID                *string    `json:"id,omitempty" yaml:"id,omitempty"`
+	URL               *string    `json:"url,omitempty" yaml:"url,omitempty"`
+	WebURL            *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
+	Name              *string    `json:"name,omitempty" yaml:"name,omitempty"`
+	ConnectedState    *string    `json:"connection_state,omitempty" yaml:"connection_state,omitempty"`
+	AgentToken        *string    `json:"access_token,omitempty" yaml:"access_token,omitempty"`
+	Hostname          *string    `json:"hostname,omitempty" yaml:"hostname,omitempty"`
+	IPAddress         *string    `json:"ip_address,omitempty" yaml:"ip_address,omitempty"`
+	UserAgent         *string    `json:"user_agent,omitempty" yaml:"user_agent,omitempty"`
+	Version           *string    `json:"version,omitempty" yaml:"version,omitempty"`
+	CreatedAt         *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	LastJobFinishedAt *Timestamp `json:"last_job_finished_at,omitempty" yaml:"last_job_finished_at,omitempty"`
+	Priority          *int       `json:"priority,omitempty" yaml:"priority,omitempty"`
+	Metadata          []string   `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
 
 	// the user that created the agent
-	Creator *User `json:"creator,omitempty"`
+	Creator *User `json:"creator,omitempty" yaml:"creator,omitempty"`
 
-	Job *Job `json:"job,omitempty"`
+	Job *Job `json:"job,omitempty" yaml:"job,omitempty"`
 }
 
 // AgentListOptions specifies the optional parameters to the

--- a/buildkite/artifacts.go
+++ b/buildkite/artifacts.go
@@ -20,19 +20,19 @@ type ArtifactsService struct {
 
 // Artifact represents an artifact which has been stored from a build
 type Artifact struct {
-	ID           *string `json:"id,omitempty"`
-	JobID        *string `json:"job_id,omitempty"`
-	URL          *string `json:"url,omitempty"`
-	DownloadURL  *string `json:"download_url,omitempty"`
-	State        *string `json:"state,omitempty"`
-	Path         *string `json:"path,omitempty"`
-	Dirname      *string `json:"dirname,omitempty"`
-	Filename     *string `json:"filename,omitempty"`
-	MimeType     *string `json:"mime_type,omitempty"`
-	FileSize     *int64  `json:"file_size,omitempty"`
-	GlobPath     *string `json:"glob_path,omitempty"`
-	OriginalPath *string `json:"original_path,omitempty"`
-	SHA1         *string `json:"sha1sum,omitempty"`
+	ID           *string `json:"id,omitempty" yaml:"id,omitempty"`
+	JobID        *string `json:"job_id,omitempty" yaml:"job_id,omitempty"`
+	URL          *string `json:"url,omitempty" yaml:"url,omitempty"`
+	DownloadURL  *string `json:"download_url,omitempty" yaml:"download_url,omitempty"`
+	State        *string `json:"state,omitempty" yaml:"state,omitempty"`
+	Path         *string `json:"path,omitempty" yaml:"path,omitempty"`
+	Dirname      *string `json:"dirname,omitempty" yaml:"dirname,omitempty"`
+	Filename     *string `json:"filename,omitempty" yaml:"filename,omitempty"`
+	MimeType     *string `json:"mime_type,omitempty" yaml:"mime_type,omitempty"`
+	FileSize     *int64  `json:"file_size,omitempty" yaml:"file_size,omitempty"`
+	GlobPath     *string `json:"glob_path,omitempty" yaml:"glob_path,omitempty"`
+	OriginalPath *string `json:"original_path,omitempty" yaml:"original_path,omitempty"`
+	SHA1         *string `json:"sha1sum,omitempty" yaml:"sha1sum,omitempty"`
 }
 
 // ArtifactListOptions specifies the optional parameters to the

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -281,8 +281,8 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 // ErrorResponse provides a message.
 type ErrorResponse struct {
 	Response *http.Response // HTTP response that caused this error
-	Message  string         `json:"message"` // error message
-	RawBody  []byte         `json:"-"`       // Raw Response Body
+	Message  string         `json:"message" yaml:"message"` // error message
+	RawBody  []byte         `json:"-" yaml:"-"`       // Raw Response Body
 }
 
 func (r *ErrorResponse) Error() string {

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -20,69 +20,69 @@ type BuildsService struct {
 
 // Author of a commit (used in CreateBuild)
 type Author struct {
-	Name  string `json:"name,omitempty"`
-	Email string `json:"email,omitempty"`
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
 }
 
 // CreateBuild - Create a build.
 type CreateBuild struct {
-	Commit  string `json:"commit"`
-	Branch  string `json:"branch"`
-	Message string `json:"message"`
+	Commit  string `json:"commit" yaml:"commit"`
+	Branch  string `json:"branch" yaml:"branch"`
+	Message string `json:"message" yaml:"message"`
 
 	// Optional fields
-	Author                      Author            `json:"author,omitempty"`
-	Env                         map[string]string `json:"env,omitempty"`
-	MetaData                    map[string]string `json:"meta_data,omitempty"`
-	IgnorePipelineBranchFilters bool              `json:"ignore_pipeline_branch_filters,omitempty"`
-	PullRequestBaseBranch       string            `json:"pull_request_base_branch,omitempty"`
-	PullRequestID               int64             `json:"pull_request_id,omitempty"`
-	PullRequestRepository       string            `json:"pull_request_repository,omitempty"`
+	Author                      Author            `json:"author,omitempty" yaml:"author,omitempty"`
+	Env                         map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	MetaData                    map[string]string `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
+	IgnorePipelineBranchFilters bool              `json:"ignore_pipeline_branch_filters,omitempty" yaml:"ignore_pipeline_branch_filters,omitempty"`
+	PullRequestBaseBranch       string            `json:"pull_request_base_branch,omitempty" yaml:"pull_request_base_branch,omitempty"`
+	PullRequestID               int64             `json:"pull_request_id,omitempty" yaml:"pull_request_id,omitempty"`
+	PullRequestRepository       string            `json:"pull_request_repository,omitempty" yaml:"pull_request_repository,omitempty"`
 }
 
 // Creator represents who created a build
 type Creator struct {
-	AvatarURL string     `json:"avatar_url"`
-	CreatedAt *Timestamp `json:"created_at"`
-	Email     string     `json:"email"`
-	ID        string     `json:"id"`
-	Name      string     `json:"name"`
+	AvatarURL string     `json:"avatar_url" yaml:"avatar_url"`
+	CreatedAt *Timestamp `json:"created_at" yaml:"created_at"`
+	Email     string     `json:"email" yaml:"email"`
+	ID        string     `json:"id" yaml:"id"`
+	Name      string     `json:"name" yaml:"name"`
 }
 
 // PullRequest represents a Github PR
 type PullRequest struct {
-	ID         *string `json:"id,omitempty"`
-	Base       *string `json:"base,omitempty"`
-	Repository *string `json:"repository,omitempty"`
+	ID         *string `json:"id,omitempty" yaml:"id,omitempty"`
+	Base       *string `json:"base,omitempty" yaml:"base,omitempty"`
+	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
 }
 
 // Build represents a build which has run in buildkite
 type Build struct {
-	ID          *string                `json:"id,omitempty"`
-	URL         *string                `json:"url,omitempty"`
-	WebURL      *string                `json:"web_url,omitempty"`
-	Number      *int                   `json:"number,omitempty"`
-	State       *string                `json:"state,omitempty"`
-	Blocked     *bool                  `json:"blocked,omitempty"`
-	Message     *string                `json:"message,omitempty"`
-	Commit      *string                `json:"commit,omitempty"`
-	Branch      *string                `json:"branch,omitempty"`
-	Env         map[string]interface{} `json:"env,omitempty"`
-	CreatedAt   *Timestamp             `json:"created_at,omitempty"`
-	ScheduledAt *Timestamp             `json:"scheduled_at,omitempty"`
-	StartedAt   *Timestamp             `json:"started_at,omitempty"`
-	FinishedAt  *Timestamp             `json:"finished_at,omitempty"`
-	MetaData    interface{}            `json:"meta_data,omitempty"`
-	Creator     *Creator               `json:"creator,omitempty"`
+	ID          *string                `json:"id,omitempty" yaml:"id,omitempty"`
+	URL         *string                `json:"url,omitempty" yaml:"url,omitempty"`
+	WebURL      *string                `json:"web_url,omitempty" yaml:"web_url,omitempty"`
+	Number      *int                   `json:"number,omitempty" yaml:"number,omitempty"`
+	State       *string                `json:"state,omitempty" yaml:"state,omitempty"`
+	Blocked     *bool                  `json:"blocked,omitempty" yaml:"blocked,omitempty"`
+	Message     *string                `json:"message,omitempty" yaml:"message,omitempty"`
+	Commit      *string                `json:"commit,omitempty" yaml:"commit,omitempty"`
+	Branch      *string                `json:"branch,omitempty" yaml:"branch,omitempty"`
+	Env         map[string]interface{} `json:"env,omitempty" yaml:"env,omitempty"`
+	CreatedAt   *Timestamp             `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ScheduledAt *Timestamp             `json:"scheduled_at,omitempty" yaml:"scheduled_at,omitempty"`
+	StartedAt   *Timestamp             `json:"started_at,omitempty" yaml:"started_at,omitempty"`
+	FinishedAt  *Timestamp             `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
+	MetaData    interface{}            `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
+	Creator     *Creator               `json:"creator,omitempty" yaml:"creator,omitempty"`
 
 	// jobs run during the build
-	Jobs []*Job `json:"jobs,omitempty"`
+	Jobs []*Job `json:"jobs,omitempty" yaml:"jobs,omitempty"`
 
 	// the pipeline this build is associated with
-	Pipeline *Pipeline `json:"pipeline,omitempty"`
+	Pipeline *Pipeline `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
 
 	// the pull request this build is associated with
-	PullRequest *PullRequest `json:"pull_request,omitempty"`
+	PullRequest *PullRequest `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
 }
 
 // BuildsListOptions specifies the optional parameters to the

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -14,28 +14,28 @@ type JobsService struct {
 
 // Job represents a job run during a build in buildkite
 type Job struct {
-	ID              *string    `json:"id,omitempty"`
-	Type            *string    `json:"type,omitempty"`
-	Name            *string    `json:"name,omitempty"`
-	State           *string    `json:"state,omitempty"`
-	LogsURL         *string    `json:"logs_url,omitempty"`
-	RawLogsURL      *string    `json:"raw_log_url,omitempty"`
-	Command         *string    `json:"command,omitempty"`
-	ExitStatus      *int       `json:"exit_status,omitempty"`
-	ArtifactPaths   *string    `json:"artifact_paths,omitempty"`
-	CreatedAt       *Timestamp `json:"created_at,omitempty"`
-	ScheduledAt     *Timestamp `json:"scheduled_at,omitempty"`
-	RunnableAt      *Timestamp `json:"runnable_at,omitempty"`
-	StartedAt       *Timestamp `json:"started_at,omitempty"`
-	FinishedAt      *Timestamp `json:"finished_at,omitempty"`
-	Agent           Agent      `json:"agent,omitempty"`
-	AgentQueryRules []string   `json:"agent_query_rules,omitempty"`
-	WebURL          string     `json:"web_url"`
+	ID              *string    `json:"id,omitempty" yaml:"id,omitempty"`
+	Type            *string    `json:"type,omitempty" yaml:"type,omitempty"`
+	Name            *string    `json:"name,omitempty" yaml:"name,omitempty"`
+	State           *string    `json:"state,omitempty" yaml:"state,omitempty"`
+	LogsURL         *string    `json:"logs_url,omitempty" yaml:"logs_url,omitempty"`
+	RawLogsURL      *string    `json:"raw_log_url,omitempty" yaml:"raw_log_url,omitempty"`
+	Command         *string    `json:"command,omitempty" yaml:"command,omitempty"`
+	ExitStatus      *int       `json:"exit_status,omitempty" yaml:"exit_status,omitempty"`
+	ArtifactPaths   *string    `json:"artifact_paths,omitempty" yaml:"artifact_paths,omitempty"`
+	CreatedAt       *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ScheduledAt     *Timestamp `json:"scheduled_at,omitempty" yaml:"scheduled_at,omitempty"`
+	RunnableAt      *Timestamp `json:"runnable_at,omitempty" yaml:"runnable_at,omitempty"`
+	StartedAt       *Timestamp `json:"started_at,omitempty" yaml:"started_at,omitempty"`
+	FinishedAt      *Timestamp `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
+	Agent           Agent      `json:"agent,omitempty" yaml:"agent,omitempty"`
+	AgentQueryRules []string   `json:"agent_query_rules,omitempty" yaml:"agent_query_rules,omitempty"`
+	WebURL          string     `json:"web_url" yaml:"web_url"`
 }
 
 // JobUnblockOptions specifies the optional parameters to UnblockJob
 type JobUnblockOptions struct {
-	Fields map[string]string `json:"fields,omitempty"`
+	Fields map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
 }
 
 // UnblockJob - unblock a job

--- a/buildkite/misc.go
+++ b/buildkite/misc.go
@@ -9,8 +9,8 @@ import "fmt"
 
 // Emoji emoji, what else can you say?
 type Emoji struct {
-	Name *string `json:"name,omitempty"`
-	URL  *string `json:"url,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL  *string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
 // ListEmojis list all the emojis for a given account, including custom emojis and aliases.
@@ -38,6 +38,6 @@ func (c *Client) ListEmojis(org string) ([]Emoji, *Response, error) {
 
 // Token an oauth access token for the buildkite service
 type Token struct {
-	AccessToken *string `json:"access_token,omitempty"`
-	Type        *string `json:"token_type,omitempty"`
+	AccessToken *string `json:"access_token,omitempty" yaml:"access_token,omitempty"`
+	Type        *string `json:"token_type,omitempty" yaml:"token_type,omitempty"`
 }

--- a/buildkite/organizations.go
+++ b/buildkite/organizations.go
@@ -17,15 +17,15 @@ type OrganizationsService struct {
 
 // Organization represents a buildkite organization.
 type Organization struct {
-	ID           *string    `json:"id,omitempty"`
-	URL          *string    `json:"url,omitempty"`
-	WebURL       *string    `json:"web_url,omitempty"`
-	Name         *string    `json:"name,omitempty"`
-	Slug         *string    `json:"slug,omitempty"`
-	Repository   *string    `json:"repository,omitempty"`
-	PipelinesURL *string    `json:"pipelines_url,omitempty"`
-	AgentsURL    *string    `json:"agents_url,omitempty"`
-	CreatedAt    *Timestamp `json:"created_at,omitempty"`
+	ID           *string    `json:"id,omitempty" yaml:"id,omitempty"`
+	URL          *string    `json:"url,omitempty" yaml:"url,omitempty"`
+	WebURL       *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
+	Name         *string    `json:"name,omitempty" yaml:"name,omitempty"`
+	Slug         *string    `json:"slug,omitempty" yaml:"slug,omitempty"`
+	Repository   *string    `json:"repository,omitempty" yaml:"repository,omitempty"`
+	PipelinesURL *string    `json:"pipelines_url,omitempty" yaml:"pipelines_url,omitempty"`
+	AgentsURL    *string    `json:"agents_url,omitempty" yaml:"agents_url,omitempty"`
+	CreatedAt    *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }
 
 // OrganizationListOptions specifies the optional parameters to the

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -20,57 +20,57 @@ type PipelinesService struct {
 
 // CreatePipeline - Create a Pipeline.
 type CreatePipeline struct {
-	Name       string `json:"name"`
-	Repository string `json:"repository"`
-	Steps      []Step `json:"steps"`
+	Name       string `json:"name" yaml:"name"`
+	Repository string `json:"repository" yaml:"repository"`
+	Steps      []Step `json:"steps" yaml:"steps"`
 
 	// Optional fields
-	Description                     string            `json:"description,omitempty"`
-	Env                             map[string]string `json:"env,omitempty"`
-	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty"`
-	BranchConfiguration             string            `json:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty"`
-	SkipQueuedBranchBuildsFilter    string            `json:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds,omitempty"`
-	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty"`
-	TeamUuids                       []string          `json:"team_uuids,omitempty"`
+	Description                     string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Env                             map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty" yaml:"provider_settings,omitempty"`
+	BranchConfiguration             string            `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
+	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty" yaml:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuildsFilter    string            `json:"skip_queued_branch_builds_filter,omitempty" yaml:"skip_queued_branch_builds_filter,omitempty"`
+	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds,omitempty" yaml:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty" yaml:"cancel_running_branch_builds_filter,omitempty"`
+	TeamUuids                       []string          `json:"team_uuids,omitempty" yaml:"team_uuids,omitempty"`
 }
 
 // Pipeline represents a buildkite pipeline.
 type Pipeline struct {
-	ID         *string    `json:"id,omitempty"`
-	URL        *string    `json:"url,omitempty"`
-	WebURL     *string    `json:"web_url,omitempty"`
-	Name       *string    `json:"name,omitempty"`
-	Slug       *string    `json:"slug,omitempty"`
-	Repository *string    `json:"repository,omitempty"`
-	BuildsURL  *string    `json:"builds_url,omitempty"`
-	BadgeURL   *string    `json:"badge_url,omitempty"`
-	CreatedAt  *Timestamp `json:"created_at,omitempty"`
+	ID         *string    `json:"id,omitempty" yaml:"id,omitempty"`
+	URL        *string    `json:"url,omitempty" yaml:"url,omitempty"`
+	WebURL     *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
+	Name       *string    `json:"name,omitempty" yaml:"name,omitempty"`
+	Slug       *string    `json:"slug,omitempty" yaml:"slug,omitempty"`
+	Repository *string    `json:"repository,omitempty" yaml:"repository,omitempty"`
+	BuildsURL  *string    `json:"builds_url,omitempty" yaml:"builds_url,omitempty"`
+	BadgeURL   *string    `json:"badge_url,omitempty" yaml:"badge_url,omitempty"`
+	CreatedAt  *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 
-	ScheduledBuildsCount *int `json:"scheduled_builds_count,omitempty"`
-	RunningBuildsCount   *int `json:"running_builds_count,omitempty"`
-	ScheduledJobsCount   *int `json:"scheduled_jobs_count,omitempty"`
-	RunningJobsCount     *int `json:"running_jobs_count,omitempty"`
-	WaitingJobsCount     *int `json:"waiting_jobs_count,omitempty"`
+	ScheduledBuildsCount *int `json:"scheduled_builds_count,omitempty" yaml:"scheduled_builds_count,omitempty"`
+	RunningBuildsCount   *int `json:"running_builds_count,omitempty" yaml:"running_builds_count,omitempty"`
+	ScheduledJobsCount   *int `json:"scheduled_jobs_count,omitempty" yaml:"scheduled_jobs_count,omitempty"`
+	RunningJobsCount     *int `json:"running_jobs_count,omitempty" yaml:"running_jobs_count,omitempty"`
+	WaitingJobsCount     *int `json:"waiting_jobs_count,omitempty" yaml:"waiting_jobs_count,omitempty"`
 
 	// the provider of sources
-	Provider *Provider `json:"provider,omitempty"`
+	Provider *Provider `json:"provider,omitempty" yaml:"provider,omitempty"`
 
 	// build steps
-	Steps []*Step `json:"steps,omitempty"`
+	Steps []*Step `json:"steps,omitempty" yaml:"steps,omitempty"`
 }
 
 // Step represents a build step in buildkites build pipeline
 type Step struct {
-	Type                *string           `json:"type,omitempty"`
-	Name                *string           `json:"name,omitempty"`
-	Command             *string           `json:"command,omitempty"`
-	ArtifactPaths       *string           `json:"artifact_paths,omitempty"`
-	BranchConfiguration *string           `json:"branch_configuration,omitempty"`
-	Env                 map[string]string `json:"env,omitempty"`
-	TimeoutInMinutes    *int              `json:"timeout_in_minutes,omitempty"`
-	AgentQueryRules     []string          `json:"agent_query_rules,omitempty"`
+	Type                *string           `json:"type,omitempty" yaml:"type,omitempty"`
+	Name                *string           `json:"name,omitempty" yaml:"name,omitempty"`
+	Command             *string           `json:"command,omitempty" yaml:"command,omitempty"`
+	ArtifactPaths       *string           `json:"artifact_paths,omitempty" yaml:"artifact_paths,omitempty"`
+	BranchConfiguration *string           `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
+	Env                 map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	TimeoutInMinutes    *int              `json:"timeout_in_minutes,omitempty" yaml:"timeout_in_minutes,omitempty"`
+	AgentQueryRules     []string          `json:"agent_query_rules,omitempty" yaml:"agent_query_rules,omitempty"`
 }
 
 // PipelineListOptions specifies the optional parameters to the

--- a/buildkite/providers.go
+++ b/buildkite/providers.go
@@ -4,9 +4,9 @@ import "encoding/json"
 
 // Provider represents a source code provider. It is read-only, but settings may be written using Pipeline.ProviderSettings.
 type Provider struct {
-	ID         string           `json:"id"`
-	WebhookURL *string          `json:"webhook_url"`
-	Settings   ProviderSettings `json:"settings"`
+	ID         string           `json:"id" yaml:"id"`
+	WebhookURL *string          `json:"webhook_url" yaml:"webhook_url"`
+	Settings   ProviderSettings `json:"settings" yaml:"settings"`
 }
 
 // UnmarshalJSON decodes the Provider, choosing the type of the Settings from the ID.
@@ -14,7 +14,7 @@ func (p *Provider) UnmarshalJSON(data []byte) error {
 	type provider Provider
 	var v struct {
 		provider
-		Settings json.RawMessage `json:"settings"`
+		Settings json.RawMessage `json:"settings" yaml:"settings"`
 	}
 
 	err := json.Unmarshal(data, &v)
@@ -51,35 +51,35 @@ type ProviderSettings interface {
 
 // BitbucketSettings are settings for pipelines building from Bitbucket repositories.
 type BitbucketSettings struct {
-	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
-	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
-	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildTags                               *bool   `json:"build_tags,omitempty"`
-	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
+	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty" yaml:"build_pull_requests,omitempty"`
+	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty" yaml:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty" yaml:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty" yaml:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildTags                               *bool   `json:"build_tags,omitempty" yaml:"build_tags,omitempty"`
+	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty" yaml:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty" yaml:"publish_commit_status_per_step,omitempty"`
 
 	// Read-only
-	Repository *string `json:"repository,omitempty"`
+	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
 }
 
 func (s *BitbucketSettings) isProviderSettings() {}
 
 // GitHubSettings are settings for pipelines building from GitHub repositories.
 type GitHubSettings struct {
-	TriggerMode                             *string `json:"trigger_mode,omitempty"`
-	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
-	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
-	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildPullRequestForks                   *bool   `json:"build_pull_request_forks,omitempty"`
-	PrefixPullRequestForkBranchNames        *bool   `json:"prefix_pull_request_fork_branch_names,omitempty"`
-	BuildTags                               *bool   `json:"build_tags,omitempty"`
-	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
+	TriggerMode                             *string `json:"trigger_mode,omitempty" yaml:"trigger_mode,omitempty"`
+	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty" yaml:"build_pull_requests,omitempty"`
+	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty" yaml:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty" yaml:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty" yaml:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildPullRequestForks                   *bool   `json:"build_pull_request_forks,omitempty" yaml:"build_pull_request_forks,omitempty"`
+	PrefixPullRequestForkBranchNames        *bool   `json:"prefix_pull_request_fork_branch_names,omitempty" yaml:"prefix_pull_request_fork_branch_names,omitempty"`
+	BuildTags                               *bool   `json:"build_tags,omitempty" yaml:"build_tags,omitempty"`
+	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty" yaml:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty" yaml:"publish_commit_status_per_step,omitempty"`
 
 	// Read-only
-	Repository *string `json:"repository,omitempty"`
+	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
 }
 
 func (s *GitHubSettings) isProviderSettings() {}
@@ -87,7 +87,7 @@ func (s *GitHubSettings) isProviderSettings() {}
 // GitLabSettings are settings for pipelines building from GitLab repositories.
 type GitLabSettings struct {
 	// Read-only
-	Repository *string `json:"repository,omitempty"`
+	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
 }
 
 func (s *GitLabSettings) isProviderSettings() {}

--- a/buildkite/user.go
+++ b/buildkite/user.go
@@ -17,10 +17,10 @@ type UserService struct {
 
 // User represents a buildkite user.
 type User struct {
-	ID        *string    `json:"id,omitempty"`
-	Name      *string    `json:"name,omitempty"`
-	Email     *string    `json:"email,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty"`
+	ID        *string    `json:"id,omitempty" yaml:"id,omitempty"`
+	Name      *string    `json:"name,omitempty" yaml:"name,omitempty"`
+	Email     *string    `json:"email,omitempty" yaml:"email,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }
 
 // Get the current user.


### PR DESCRIPTION
This PR adds YAML unmarshalling specs to the go-buildkite types.

I discovered that when decoding a YAML file that matched the JSON specs I was missing some fields.  Adding these rules fixed that issue.