### PR TITLE
Add cancel build function

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -111,6 +111,23 @@ type BuildsListOptions struct {
 	ListOptions
 }
 
+// Cancel triggers a canel for the tagrget build
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/builds#cancel-a-build
+func (bs *BuildsService) Cancel(org, pipeline, build string) (*Build, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/cancel", org, pipeline, build)
+	req, err := bs.client.NewRequest("PUT", u, nil)
+	if err != nil {
+		return nil, err
+	}
+	result := Build{}
+	_, err = bs.client.Do(req, &result)
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
 // Create - Create a pipeline
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#create-a-build

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -9,6 +9,29 @@ import (
 	"time"
 )
 
+func TestBuildsService_Cancel(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/1/cancel", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		fmt.Fprint(w, `{
+  "id": "1",
+  "state": "cancelled"
+}`)
+	})
+
+	build, err := client.Builds.Cancel("my-great-org", "sup-keith", "1")
+	if err != nil {
+		t.Errorf("Cancel returned error: %v", err)
+	}
+
+	want := &Build{ID: String("1"), State: String("cancelled")}
+	if !reflect.DeepEqual(build, want) {
+		t.Errorf("Cancel returned %+v, want %+v", build, want)
+	}
+}
+
 func TestBuildsService_List(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Tried to keep things in alphabetical order. I wanted to be able to cancel a build with the go client

I wrote the test and cancelled a build with this implementation.