### PR TITLE
 Add filtering option for listing builds by commit

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -109,7 +109,7 @@ type BuildsListOptions struct {
 	Branch string `url:"branch,omitempty"`
 
 	// Filters the results by builds for the specific commit SHA (full, not shortened). Default is "".
-	Commit string `url:"commit,omitempty`
+	Commit string `url:"commit,omitempty"`
 
 	ListOptions
 }

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -108,7 +108,7 @@ type BuildsListOptions struct {
 	// Branch filter by the name of the branch. Default is "".
 	Branch string `url:"branch,omitempty"`
 
-	// Filters the results by builds for the specific commit SHA (full, not shortened). Default is ""/
+	// Filters the results by builds for the specific commit SHA (full, not shortened). Default is "".
 	Commit string `url:"commit,omitempty`
 
 	ListOptions

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -108,6 +108,9 @@ type BuildsListOptions struct {
 	// Branch filter by the name of the branch. Default is "".
 	Branch string `url:"branch,omitempty"`
 
+	// Filters the results by builds for the specific commit SHA (full, not shortened). Default is ""/
+	Commit string `url:"commit,omitempty`
+
 	ListOptions
 }
 

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -182,6 +182,35 @@ func TestBuildsService_ListByOrg(t *testing.T) {
 	}
 }
 
+func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"branch": "my-great-branch",
+			"commit": "my-commit-sha1",
+		})
+		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
+	})
+
+	opt := &BuildsListOptions{
+		Branch: "my-great-branch",
+		Commit: "my-commit-sha1",
+	}
+
+	builds, _, err := client.Builds.ListByOrg("my-great-org", opt)
+	if err != nil {
+		t.Errorf("Builds.List returned error: %v", err)
+	}
+
+	want := []Build{{ID: String("123")}, {ID: String("1234")}}
+	if !reflect.DeepEqual(builds, want) {
+		t.Errorf("Builds.List returned %+v, want %+v", builds, want)
+	}
+}
+
 func TestBuildsService_ListByPipeline(t *testing.T) {
 	setup()
 	defer teardown()


### PR DESCRIPTION
Adds an option to filter builds by commit which is supported by the API.
https://buildkite.com/docs/apis/rest-api/builds#list-builds-for-an-organization