### PR TITLE
Add support for getting a job's log output

### DIFF
--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -38,6 +38,13 @@ type JobUnblockOptions struct {
 	Fields map[string]string `json:"fields,omitempty"`
 }
 
+// JobLog represents a job log output
+type JobLog struct {
+	URL     *string `json:"url"`
+	Content *string `json:"content"`
+	Size    *int    `json:"size"`
+}
+
 // UnblockJob - unblock a job
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#unblock-a-job
@@ -63,4 +70,27 @@ func (js *JobsService) UnblockJob(org string, pipeline string, buildNumber strin
 	}
 
 	return job, resp, err
+}
+
+// GetJobLog - get a job’s log output
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-log-output
+func (js *JobsService) GetJobLog(org string, pipeline string, buildNumber string, jobID string) (*JobLog, *Response, error) {
+	var u string
+
+	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/log", org, pipeline, buildNumber, jobID)
+	req, err := js.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+
+	jobLog := new(JobLog)
+	resp, err := js.client.Do(req, jobLog)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return jobLog, resp, err
 }

--- a/buildkite/jobs_test.go
+++ b/buildkite/jobs_test.go
@@ -29,3 +29,27 @@ func TestJobsService_UnblockJob(t *testing.T) {
 		t.Errorf("UnblockJob returned %+v, want %+v", job, want)
 	}
 }
+
+func TestJobsService_GetJobLog(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/log", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+  "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sub-keith/builds/awesome-build/jobs/awesome-job-id/log",
+  "content": "This is the job's log output",
+	"size": 28
+}`)
+	})
+
+	job, _, err := client.Jobs.GetJobLog("my-great-org", "sup-keith", "awesome-build", "awesome-job-id")
+	if err != nil {
+		t.Errorf("GetJobLog returned error: %v", err)
+	}
+
+	want := &JobLog{URL: String("https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sub-keith/builds/awesome-build/jobs/awesome-job-id/log"), Content: String("This is the job's log output"), Size: Int(28)}
+	if !reflect.DeepEqual(job, want) {
+		t.Errorf("GetJobLog returned %+v, want %+v", job, want)
+	}
+}


### PR DESCRIPTION
This implements https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-log-output to `JobsService`.