### PR TITLE
License/Copyright tidy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015-2019, Mark Wolfe, Buildkite Pty Ltd
+Copyright (c) 2015-2020, Mark Wolfe, Buildkite Pty Ltd
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/buildkite/agents.go
+++ b/buildkite/agents.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import "fmt"

--- a/buildkite/artifacts.go
+++ b/buildkite/artifacts.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import (

--- a/buildkite/auth.go
+++ b/buildkite/auth.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import (

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import (

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import (

--- a/buildkite/misc.go
+++ b/buildkite/misc.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import "fmt"

--- a/buildkite/organizations.go
+++ b/buildkite/organizations.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import "fmt"

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import (

--- a/buildkite/timestamp.go
+++ b/buildkite/timestamp.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import "time"

--- a/buildkite/user.go
+++ b/buildkite/user.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 import "fmt"

--- a/buildkite/version.go
+++ b/buildkite/version.go
@@ -1,8 +1,3 @@
-// Copyright 2014 Mark Wolfe. All rights reserved.
-//
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package buildkite
 
 // Version the library version number


### PR DESCRIPTION
Remove per-source-file copyright message; it's redundant with the `LICENSE` file. Most source files have contributions from many authors. At least one file (`artifacts.go`) had no contributions from the listed copyright holder; presumably copy/paste/modify/commit. This is likely to keep happening and get confusing (e.g. #54). I don't think we gain anything by stating/tracking copyright separately in each file. It's in the project-level LICENSE file.

Also, updating the Copyright range in LICENSE from 2019 to 2020.

(Ping @wolfeidau - let me know if you had any strong reasons/opinions for per-file notices)