### PR TITLE
Fix tests: compile error, segfault.

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -113,7 +113,7 @@ type BuildsListOptions struct {
 	ListOptions
 }
 
-// Cancel - Trigger a cancel for the target build 
+// Cancel - Trigger a cancel for the target build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/builds#cancel-a-build
 func (bs *BuildsService) Cancel(org, pipeline, build string) (*Build, error) {
@@ -160,7 +160,6 @@ func (bs *BuildsService) Get(org string, pipeline string, id string, opt *Builds
 	if err != nil {
 		return nil, nil, err
 	}
-	fmt.Println(u)
 
 	req, err := bs.client.NewRequest("GET", u, nil)
 	if err != nil {

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -61,7 +61,7 @@ func TestBuildsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id":"123"}`)
 	})
 
-	build, _, err := client.Builds.Get("my-great-org", "sup-keith", "123")
+	build, _, err := client.Builds.Get("my-great-org", "sup-keith", "123", nil)
 	if err != nil {
 		t.Errorf("Builds.Get returned error: %v", err)
 	}

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -170,10 +170,12 @@ func (ps *PipelinesService) Update(org string, p *Pipeline) (*Response, error) {
 	// There is quite a lot of properties that are not represented by the Client-side
 	// Pipeline abstraction hence only a subset can be updated.
 	cp := &CreatePipeline{
-		Name:             *p.Name,
-		Repository:       *p.Repository,
-		Steps:            make([]Step, len(p.Steps)),
-		ProviderSettings: p.Provider.Settings,
+		Name:       *p.Name,
+		Repository: *p.Repository,
+		Steps:      make([]Step, len(p.Steps)),
+	}
+	if p.Provider != nil {
+		cp.ProviderSettings = p.Provider.Settings
 	}
 
 	for i := range p.Steps {


### PR DESCRIPTION
(Depends on #56 to easily build/test)

Looks like the test suite was feeling a bit neglected; one test had a compile error, and another hit a segfault which real code could pretty easily encounter too, and one had some debug output. This PR gives it a bit of love.

---

builds_test fixed: `BuildsService.Get()` expects `opt`. The additional argument was added in aa2d94e. Presumably this test has failed to compile since then. This patch passes `nil` which is explicitly supported by `addOptions()`.

---

pipelines: `Pipeline.Provider` is optional, avoid segfault. This was segfaulting in the existing test suite:

```
--- FAIL: TestPipelinesService_Update (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x6e0614]
```

---

builds.go: remove fmt.Println of URL from development/debug. This was showing up in TestBuildsService_Get:

        $ go test -v ./... -run TestBuildsService_Get
        === RUN   TestBuildsService_Get
        v2/organizations/my-great-org/pipelines/sup-keith/builds/123
        --- PASS: TestBuildsService_Get (0.00s)
        PASS
        ok      github.com/buildkite/go-buildkite/buildkite     0.003s
        ?       github.com/buildkite/go-buildkite/examples/artifacts    [no test files]
        ?       github.com/buildkite/go-buildkite/examples/projects     [no test files]


---

The full test suite it passing now:

```
$ go test -v -count=1 ./...

=== RUN   TestAgentsService_List
--- PASS: TestAgentsService_List (0.00s)
=== RUN   TestAgentsService_Get
--- PASS: TestAgentsService_Get (0.00s)
=== RUN   TestAgentsService_Create
--- PASS: TestAgentsService_Create (0.00s)
=== RUN   TestAgentsService_Delete
--- PASS: TestAgentsService_Delete (0.00s)
=== RUN   TestNewClient
--- PASS: TestNewClient (0.00s)
=== RUN   TestNewRequest
--- PASS: TestNewRequest (0.00s)
=== RUN   TestResponse_populatePageValues
--- PASS: TestResponse_populatePageValues (0.00s)
=== RUN   TestBuildsService_Cancel
--- PASS: TestBuildsService_Cancel (0.00s)
=== RUN   TestBuildsService_List
--- PASS: TestBuildsService_List (0.00s)
=== RUN   TestBuildsService_Get
--- PASS: TestBuildsService_Get (0.00s)
=== RUN   TestBuildsService_List_by_status
--- PASS: TestBuildsService_List_by_status (0.00s)
=== RUN   TestBuildsService_List_by_multiple_status
--- PASS: TestBuildsService_List_by_multiple_status (0.00s)
=== RUN   TestBuildsService_List_by_created_date
--- PASS: TestBuildsService_List_by_created_date (0.00s)
=== RUN   TestBuildsService_ListByOrg
--- PASS: TestBuildsService_ListByOrg (0.00s)
=== RUN   TestBuildsService_ListByOrg_branch_commit
--- PASS: TestBuildsService_ListByOrg_branch_commit (0.00s)
=== RUN   TestBuildsService_ListByPipeline
--- PASS: TestBuildsService_ListByPipeline (0.00s)
=== RUN   TestBuildsUnmarshalWebhook
--- PASS: TestBuildsUnmarshalWebhook (0.00s)
=== RUN   TestJobsService_UnblockJob
--- PASS: TestJobsService_UnblockJob (0.00s)
=== RUN   TestJobsService_GetJobLog
--- PASS: TestJobsService_GetJobLog (0.00s)
=== RUN   TestListEmojis
--- PASS: TestListEmojis (0.00s)
=== RUN   TestOrganizationsService_List
--- PASS: TestOrganizationsService_List (0.00s)
=== RUN   TestOrganizationsService_Get
--- PASS: TestOrganizationsService_Get (0.00s)
=== RUN   TestPipelinesService_List
--- PASS: TestPipelinesService_List (0.00s)
=== RUN   TestPipelinesService_Create
--- PASS: TestPipelinesService_Create (0.00s)
=== RUN   TestPipelinesService_Get
--- PASS: TestPipelinesService_Get (0.00s)
=== RUN   TestPipelinesService_Delete
--- PASS: TestPipelinesService_Delete (0.00s)
=== RUN   TestPipelinesService_Update
--- PASS: TestPipelinesService_Update (0.00s)
=== RUN   TestUnmarshalBitbucketProvider
--- PASS: TestUnmarshalBitbucketProvider (0.00s)
=== RUN   TestUnmarshalGitHubProvider
--- PASS: TestUnmarshalGitHubProvider (0.00s)
=== RUN   TestUnmarshalGitLabProvider
--- PASS: TestUnmarshalGitLabProvider (0.00s)
=== RUN   TestUnmarshalUnknownProvider
--- PASS: TestUnmarshalUnknownProvider (0.00s)
=== RUN   TestTeamsService_List
--- PASS: TestTeamsService_List (0.00s)
=== RUN   TestTimestamp_Marshal
--- PASS: TestTimestamp_Marshal (0.00s)
=== RUN   TestTimestamp_Unmarshal
--- PASS: TestTimestamp_Unmarshal (0.00s)
=== RUN   TestUserService_Get
--- PASS: TestUserService_Get (0.00s)
PASS
ok  	github.com/buildkite/go-buildkite/buildkite	0.010s
?   	github.com/buildkite/go-buildkite/examples/artifacts	[no test files]
?   	github.com/buildkite/go-buildkite/examples/projects	[no test files]
```