### PR TITLE
run tests on go 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,0 @@
-FROM golang:1.7.3
-
-RUN mkdir -p /go/src/github.com/buildkite/go-buildkite
-ADD . /go/src/github.com/buildkite/go-buildkite
-
-WORKDIR /go/src/github.com/buildkite/go-buildkite

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,6 @@
-GOPATH := $(shell pwd)/.gopath
-STAGING_PATH = $(shell pwd)/.gopath/src/github.com/buildkite
-DEPS = $(go list -f '{{range .TestImports}}{{.}} {{end}}' ./...)
+all: test
 
-all: deps test
-
-deps:
-	mkdir -p ${STAGING_PATH}
-	go get -d -v ./...
-
-test: deps
-	cd ${STAGING_PATH}/go-buildkite
+test:
 	go test -timeout=3s -v ./...
 
-clean:
-	rm -rf $(shell pwd)/.gopath || true
-
-.PHONY: all deps test clean
+.PHONY: all test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
-version: '2'
+version: '3.5'
+
 services:
   app:
-    build: .
+    image: golang:1.13.6
+    volumes:
+      - .:/work
+    working_dir: /work


### PR DESCRIPTION
They were running on go 1.7, which is kinda old now.

The setup is much easier now that we're using go modules, so I was able to drop a few lines from the makefile. We can ignore gopath, and go will download the dependencies for us if required.