### PR TITLE
pipelines: add env struct

### DIFF
--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -53,7 +53,8 @@ type Pipeline struct {
 	Provider *Provider `json:"provider,omitempty" yaml:"provider,omitempty"`
 
 	// build steps
-	Steps []*Step `json:"steps,omitempty" yaml:"steps,omitempty"`
+	Steps []*Step                `json:"steps,omitempty" yaml:"steps,omitempty"`
+	Env   map[string]interface{} `json:"env,omitempty" yaml:"env,omitempty"`
 }
 
 // Step represents a build step in buildkites build pipeline


### PR DESCRIPTION
The rest API sends env back, but the go struct does not expose it.

https://buildkite.com/docs/apis/rest-api/pipelines