### PR TITLE
Format slug correctly for Pipeline GET

### DIFF
--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -3,6 +3,7 @@ package buildkite
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // PipelinesService handles communication with the pipeline related
@@ -99,6 +100,8 @@ func (ps *PipelinesService) Create(org string, p *CreatePipeline) (*Pipeline, *R
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#get-a-pipeline
 func (ps *PipelinesService) Get(org string, slug string) (*Pipeline, *Response, error) {
+	// slug may not contain /
+	slug = strings.ReplaceAll(slug, "/", "-")
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
 
@@ -147,6 +150,8 @@ func (ps *PipelinesService) List(org string, opt *PipelineListOptions) ([]Pipeli
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#delete-a-pipeline
 func (ps *PipelinesService) Delete(org string, slug string) (*Response, error) {
+	// slug may not contain /
+	slug = strings.ReplaceAll(slug, "/", "-")
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
 

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -99,6 +99,11 @@ func TestPipelinesService_Get(t *testing.T) {
 		t.Errorf("Pipelines.Get returned error: %v", err)
 	}
 
+	pipeline, _, err = client.Pipelines.Get("my-great-org", "my-great/pipeline-slug")
+	if err != nil {
+		t.Errorf("Pipelines.Get returned error: %v", err)
+	}
+
 	want := &Pipeline{ID: String("123"), Slug: String("my-great-pipeline-slug")}
 	if !reflect.DeepEqual(pipeline, want) {
 		t.Errorf("Pipelines.Get returned %+v, want %+v", pipeline, want)
@@ -114,6 +119,11 @@ func TestPipelinesService_Delete(t *testing.T) {
 	})
 
 	_, err := client.Pipelines.Delete("my-great-org", "my-great-pipeline-slug")
+	if err != nil {
+		t.Errorf("Pipelines.Delete returned error: %v", err)
+	}
+
+	_, err = client.Pipelines.Delete("my-great-org", "my-great/pipeline-slug")
 	if err != nil {
 		t.Errorf("Pipelines.Delete returned error: %v", err)
 	}


### PR DESCRIPTION
The Buildkite API will replace "/" with "-" to create a slug, when the
name of a pipeline contains a "/". We should do that here as well to
prevent usage errors :)