### PR TITLE
Add soft_failed attribute for job

### DIFF
--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -36,6 +36,7 @@ type Job struct {
 	Retried         bool       `json:"retried,omitempty" yaml:"retried,omitempty"`
 	RetriedInJobID  string     `json:"retried_in_job_id,omitempty" yaml:"retried_in_job_id,omitempty"`
 	RetriesCount    int        `json:"retries_count,omitempty" yaml:"retries_count,omitempty"`
+	SoftFailed      bool       `json:"soft_failed,omitempty" yaml:"soft_failed,omitempty"`
 }
 
 // JobUnblockOptions specifies the optional parameters to UnblockJob


### PR DESCRIPTION
This is part of the Jobs API model, and having it would be useful for people to know whether a job in the [build](https://buildkite.com/docs/apis/rest-api/builds#get-a-build) is `soft_failed` or not.