### PR TITLE
Support for Arching/Unarchiving pipelines

### DIFF
--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -47,6 +47,7 @@ type Pipeline struct {
 	BuildsURL                       *string    `json:"builds_url,omitempty" yaml:"builds_url,omitempty"`
 	BadgeURL                        *string    `json:"badge_url,omitempty" yaml:"badge_url,omitempty"`
 	CreatedAt                       *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ArchivedAt                      *Timestamp `json:"archived_at,omitempty" yaml:"archived_at,omitempty"`
 	DefaultBranch                   *string    `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
 	Description                     *string    `json:"description,omitempty" yaml:"description,omitempty"`
 	BranchConfiguration             *string    `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -209,3 +209,18 @@ func (ps *PipelinesService) AddWebhook(org string, slug string) (*Response, erro
 
 	return ps.client.Do(req, nil)
 }
+
+// Archive - Archives a pipeline.
+//
+// buildkite API docs: PENDING
+func (ps *PipelinesService) Archive(org string, slug string) (*Response, error) {
+
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/archive", org, slug)
+
+	req, err := ps.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps.client.Do(req, nil)
+}

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -213,10 +213,25 @@ func (ps *PipelinesService) AddWebhook(org string, slug string) (*Response, erro
 
 // Archive - Archives a pipeline.
 //
-// buildkite API docs: PENDING
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipelines#archive-a-pipeline
 func (ps *PipelinesService) Archive(org string, slug string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/archive", org, slug)
+
+	req, err := ps.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps.client.Do(req, nil)
+}
+
+// Unarchive - Unarchive a pipeline.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipelines#unarchive-a-pipeline
+func (ps *PipelinesService) Unarchive(org string, slug string) (*Response, error) {
+
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/unarchive", org, slug)
 
 	req, err := ps.client.NewRequest("POST", u, nil)
 	if err != nil {

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -279,3 +279,17 @@ func TestPipelinesService_Archive(t *testing.T) {
 		t.Errorf("Pipelines.Archive returned error: %v", err)
 	}
 }
+
+func TestPipelinesService_Unarchive(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/unarchive", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	_, err := client.Pipelines.Unarchive("my-great-org", "my-great-pipeline-slug")
+	if err != nil {
+		t.Errorf("Pipelines.UnArchive returned error: %v", err)
+	}
+}

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -37,7 +37,7 @@ func TestPipelinesService_Create(t *testing.T) {
 		Steps: []Step{Step{Type: String("script"),
 			Name:    String("Build :package"),
 			Command: String("script/release.sh")}},
-		DefaultBranch: *String("main"),
+		        DefaultBranch: *String("main"),
 	}
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -37,7 +37,7 @@ func TestPipelinesService_Create(t *testing.T) {
 		Steps: []Step{Step{Type: String("script"),
 			Name:    String("Build :package"),
 			Command: String("script/release.sh")}},
-			DefaultBranch: *String("main"),
+		DefaultBranch: *String("main"),
 	}
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +87,7 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 	defer teardown()
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
-		Repository: *String("my-great-repo"),
+		Repository:    *String("my-great-repo"),
 		Configuration: *String("steps:\n  - command: \"script/release.sh\"\n    label: \"Build :package:\""),
 	}
 
@@ -262,6 +262,20 @@ func TestPipelinesService_AddWebhook(t *testing.T) {
 
 	_, err := client.Pipelines.AddWebhook("my-great-org", "my-great-pipeline-slug")
 	if err != nil {
-		t.Errorf("Pipelines.Delete returned error: %v", err)
+		t.Errorf("Pipelines.AddWebhook returned error: %v", err)
+	}
+}
+
+func TestPipelinesService_Archive(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/archive", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+	})
+
+	_, err := client.Pipelines.Archive("my-great-org", "my-great-pipeline-slug")
+	if err != nil {
+		t.Errorf("Pipelines.Archive returned error: %v", err)
 	}
 }


### PR DESCRIPTION
# Descriptions

Thanks to @shevaun for creating the REST API endpoints for us. We have already started using the `archive` and `unarchive` endpoints Shevaun created via a forked `go-buildkite` and want to contribute these changes back upstream.

### Changes
* Added `Archive` method for `PipelinesService`.
* Added `Unarchive` method for `PipelinesService`.
* Exposing `ArchivedAt` field for `Pipeline` struct.

### Testing 
* Unit test for `Archive` and `Unarchive`
* Have tested this and was able to successfully archive, unarchive pipelines within our buildkite org. Also tested retrieving `ArchivedAt` field.