### PR TITLE
Version bump to V3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [v3.0.0](https://github.com/buildkite/go-buildkite/compare/v2.9.0...v3.0.0) (2021-08-20)
+
+- Add block-job label [#90](https://github.com/buildkite/go-buildkite/pull/90) ([BEvgeniyS](https://github.com/BEvgeniyS))
+- Fix pagination for teams [#89](https://github.com/buildkite/go-buildkite/pull/89) ([atishpatel](https://github.com/atishpatel))
+- Add support for plugins to Pipeline steps [#82](https://github.com/buildkite/go-buildkite/pull/82) ([luma](https://github.com/luma))
+
 ## [v2.9.0](https://github.com/buildkite/go-buildkite/compare/v2.8.1...v2.9.0) (2021-08-03)
 
 - Implement Access Tokens API [#87](https://github.com/buildkite/go-buildkite/pull/87) ([alam0rt](https://github.com/alam0rt))

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ A [Go](http://golang.org) library and client for the [Buildkite API](https://bui
 To get the package, execute:
 
 ```
-go get github.com/buildkite/go-buildkite/v2/buildkite
+go get github.com/buildkite/go-buildkite/v3/buildkite
 ```
 
 Simple shortened example for listing all pipelines is provided below, see examples for more.
 
 ```go
 import (
-    "github.com/buildkite/go-buildkite/v2/buildkite"
+    "github.com/buildkite/go-buildkite/v3/buildkite"
 )
 ...
 

--- a/buildkite/version.go
+++ b/buildkite/version.go
@@ -1,4 +1,4 @@
 package buildkite
 
 // Version the library version number
-const Version = "2.9.0"
+const Version = "3.0.0"

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v2/buildkite"
+	"github.com/buildkite/go-buildkite/v3/buildkite"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/examples/projects/main.go
+++ b/examples/projects/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v2/buildkite"
+	"github.com/buildkite/go-buildkite/v3/buildkite"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/buildkite/go-buildkite/v2
+module github.com/buildkite/go-buildkite/v3
 
-go 1.15
+go 1.16
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,7 +10,6 @@ github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASu
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -21,7 +20,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
There was a breaking change in https://github.com/buildkite/go-buildkite/pull/89 so I have done the things needed for a major version bump.

- [x] update import paths
- [x] update version
- [x] update changelog
- [x] go version minor bump
- [x] go mod tidy