### PR TITLE
Update docs to reference pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# buildkite-go [![GoDoc](https://img.shields.io/badge/godoc-Reference-brightgreen.svg?style=flat)](http://godoc.org/github.com/buildkite/go-buildkite) [![Build status](https://badge.buildkite.com/b16a0d730b8732a1cfba06068f8450aa7cc4b2cf40eb6e6717.svg?branch=master)](https://buildkite.com/buildkite/go-buildkite)
+# buildkite-go [![Go Reference](https://pkg.go.dev/badge/github.com/buildkite/go-buildkite.svg)](https://pkg.go.dev/github.com/buildkite/go-buildkite/v2) [![Build status](https://badge.buildkite.com/b16a0d730b8732a1cfba06068f8450aa7cc4b2cf40eb6e6717.svg?branch=master)](https://buildkite.com/buildkite/go-buildkite)
 
 A [Go](http://golang.org) library and client for the [Buildkite API](https://buildkite.com/docs/api). This project draws a lot of it's structure and testing methods from [go-github](https://github.com/google/go-github).
 


### PR DESCRIPTION
`godoc.org` is still alive. But requests redirect to pkg.go.dev.
This fixed to point to pkg.go.dev direct to reduce unneeded redirect.
Ref: https://blog.golang.org/godoc.org-redirect

Also, specify a version to a link for showing the latest doc.