### PR TITLE
Add clean_checkout to CreateBuild struct

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -27,6 +27,7 @@ type CreateBuild struct {
 
 	// Optional fields
 	Author                      Author            `json:"author,omitempty" yaml:"author,omitempty"`
+	CleanCheckout 				bool 			  `json:"clean_checkout,omitempty" yaml:"clean_checkout,omitempty"`
 	Env                         map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	MetaData                    map[string]string `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
 	IgnorePipelineBranchFilters bool              `json:"ignore_pipeline_branch_filters,omitempty" yaml:"ignore_pipeline_branch_filters,omitempty"`


### PR DESCRIPTION
This adds the `clean_checkout` field to the `CreateBuild` struct so that clients can create builds with a clean checkout. API documentation available at https://buildkite.com/docs/apis/rest-api/builds#create-a-build