### PR TITLE
Support filtering list builds call by multiple branches

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -102,8 +102,8 @@ type BuildsListOptions struct {
 	// failed, canceled, skipped and not_run. Default is "".
 	State []string `url:"state,brackets,omitempty"`
 
-	// Branch filter by the name of the branch. Default is "".
-	Branch string `url:"branch,omitempty"`
+	// Filters the results by branch name(s)
+	Branch []string `url:"branch,brackets,omitempty"`
 
 	// Filters the results by builds for the specific commit SHA (full, not shortened). Default is "".
 	Commit string `url:"commit,omitempty"`


### PR DESCRIPTION
Per [docs](https://buildkite.com/docs/apis/rest-api/builds#list-builds-for-a-pipeline), we should be able to filter by more than one branch.