### PR TITLE
Webhook support

### DIFF
--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -155,7 +155,7 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 	want := &Pipeline{Name: String("my-great-pipeline"),
 		Repository: String("my-great-repo"),
 		Steps: []*Step{
-			&Step{
+			{
 				Type:    String("script"),
 				Name:    String("Build :package:"),
 				Command: String("script/release.sh"),
@@ -320,8 +320,8 @@ func TestPipelinesService_Update(t *testing.T) {
 				},
 			},
 		},
-		Slug: String("my-great-repo"),
-                Visibility: String("public"),
+		Slug:       String("my-great-repo"),
+		Visibility: String("public"),
 	}
 
 	if !reflect.DeepEqual(pipeline, want) {

--- a/buildkite/webhook.go
+++ b/buildkite/webhook.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"hash"
 	"io/ioutil"
@@ -92,7 +91,7 @@ func validateSignature(signature string, payload, secretKey []byte) error {
 	macPayload := fmt.Sprintf("%s.%s", timestamp, payload)
 
 	if !checkMAC([]byte(macPayload), sig, secretKey, sha256.New) {
-		return errors.New("payload signature check failed")
+		return fmt.Errorf("payload signature check failed")
 	}
 
 	return nil

--- a/buildkite/webhook.go
+++ b/buildkite/webhook.go
@@ -14,12 +14,10 @@ import (
 )
 
 const (
-	// eventTypeHeader is the Buildkite header key used to pass the event type
-	eventTypeHeader = "X-Buildkite-Event"
-	// signatureHeader is the Buildkite header key used to pass the HMAC hexdigest.
-	signatureHeader = "X-Buildkite-Signature"
-	// tokenHeader is the Buildkite header key used to pass the Buildkite webhook token.
-	tokenHeader = "X-Buildkite-Signature"
+	// EventTypeHeader is the Buildkite header key used to pass the event type
+	EventTypeHeader = "X-Buildkite-Event"
+	// SignatureHeader is the Buildkite header key used to pass the HMAC hexdigest.
+	SignatureHeader = "X-Buildkite-Signature"
 )
 
 var (
@@ -40,7 +38,7 @@ var (
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks
 func WebHookType(r *http.Request) string {
-	return r.Header.Get(eventTypeHeader)
+	return r.Header.Get(EventTypeHeader)
 }
 
 // ParseWebHook parses the event payload. For recognized event types, a
@@ -128,7 +126,11 @@ func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err err
 		return nil, err
 	}
 
-	sig := r.Header.Get(signatureHeader)
+	sig := r.Header.Get(SignatureHeader)
+	if sig == "" {
+		return nil, fmt.Errorf("No %s header present on request", SignatureHeader)
+	}
+
 	if err = validateSignature(sig, payload, secretKey); err != nil {
 		return nil, err
 	}

--- a/buildkite/webhook.go
+++ b/buildkite/webhook.go
@@ -1,0 +1,160 @@
+package buildkite
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+const (
+	// eventTypeHeader is the Buildkite header key used to pass the event type
+	eventTypeHeader = "X-Buildkite-Event"
+	// signatureHeader is the Buildkite header key used to pass the HMAC hexdigest.
+	signatureHeader = "X-Buildkite-Signature"
+	// tokenHeader is the Buildkite header key used to pass the Buildkite webhook token.
+	tokenHeader = "X-Buildkite-Signature"
+)
+
+var (
+	// eventTypeMapping maps webhook types to their corresponding Buildkite structs
+	eventTypeMapping = map[string]string{
+		"job.scheduled": "JobScheduledEvent",
+		"ping":          "PingEvent",
+	}
+)
+
+// WebHookType returns the event type of webhook request r.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks
+func WebHookType(r *http.Request) string {
+	return r.Header.Get(eventTypeHeader)
+}
+
+// ParseWebHook parses the event payload. For recognized event types, a
+// value of the corresponding struct type will be returned (as returned
+// by Event.ParsePayload()). An error will be returned for unrecognized event
+// types.
+func ParseWebHook(messageType string, payload []byte) (interface{}, error) {
+	eventType, ok := eventTypeMapping[messageType]
+	if !ok {
+		return nil, fmt.Errorf("unknown X-Buildkite-Event in message: %v", messageType)
+	}
+
+	event := Event{
+		Type:       &eventType,
+		RawPayload: (*json.RawMessage)(&payload),
+	}
+	return event.ParsePayload()
+}
+
+// genMAC generates the HMAC signature for a message provided the secret key
+// and hashFunc.
+func genMAC(message, key []byte, hashFunc func() hash.Hash) []byte {
+	mac := hmac.New(hashFunc, key)
+	mac.Write(message)
+	return mac.Sum(nil)
+}
+
+// checkMAC reports whether messageMAC is a valid HMAC tag for message.
+func checkMAC(message, messageMAC, key []byte, hashFunc func() hash.Hash) bool {
+	expectedMAC := genMAC(message, key, hashFunc)
+	return hmac.Equal(messageMAC, expectedMAC)
+}
+
+// validateSignature validates the signature for the given payload.
+// signature is the Buildkite hash signature delivered in the X-Buildkite-Signature header.
+// payload is the JSON payload sent by Buildkite Webhook.
+// secretKey is the Buildkite Webhook token.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks#webhook-signature
+func validateSignature(signature string, payload, secretKey []byte) error {
+	timestamp, sig, err := getTimestampAndSignature(signature)
+	if err != nil {
+		return err
+	}
+
+	macPayload := fmt.Sprintf("%s.%s", timestamp, payload)
+
+	if !checkMAC([]byte(macPayload), sig, secretKey, sha256.New) {
+		return errors.New("payload signature check failed")
+	}
+
+	return nil
+}
+
+// getTimestampAndSignature splits the signature header into the timestamp and signature
+// components.
+// sig is the Buildkite hash signature value
+func getTimestampAndSignature(sig string) (timestamp string, signature []byte, err error) {
+	sigParts := strings.Split(sig, ",")
+	if len(sigParts) != 2 {
+		return "", nil, fmt.Errorf("X-Buildkite-Signature format is incorrect.")
+	}
+
+	ts, sg := sigParts[0], sigParts[1]
+
+	timestamp = strings.Split(ts, "=")[1]
+	sigStr := strings.Split(sg, "=")[1]
+	signature, err = hex.DecodeString(sigStr)
+	if err != nil {
+		return "", nil, fmt.Errorf("error decoding signature %q: %v", sigStr, err)
+	}
+
+	return timestamp, signature, nil
+}
+
+// ValidatePayload validates an incoming Buildkite Webhook event request
+// and returns the (JSON) payload.
+// secretKey is the Buildkite Webhook token.
+//
+// Example usage:
+//
+//
+func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err error) {
+	if payload, err = ioutil.ReadAll(r.Body); err != nil {
+		return nil, err
+	}
+
+	sig := r.Header.Get(signatureHeader)
+	if err = validateSignature(sig, payload, secretKey); err != nil {
+		return nil, err
+	}
+
+	return payload, nil
+}
+
+// Event represents a Buildkite webhook event
+type Event struct {
+	Type       *string          `json:"type"`
+	RawPayload *json.RawMessage `json:"payload,omitempty"`
+}
+
+// func (e Event) String() string {
+// 	return Stringify(e)
+// }
+
+// ParsePayload parses the event payload. For recognized event types,
+// a value of the corresponding struct type will be returned.
+// An error will be returned for unrecognized event types.
+//
+// Example usage:
+//
+//
+//
+func (e *Event) ParsePayload() (payload interface{}, err error) {
+	switch *e.Type {
+	case "JobScheduledEvent":
+		payload = &JobScheduledEvent{}
+	case "PingEvent":
+		payload = &PingEvent{}
+	}
+	err = json.Unmarshal(*e.RawPayload, &payload)
+	return payload, err
+}

--- a/buildkite/webhook.go
+++ b/buildkite/webhook.go
@@ -25,8 +25,14 @@ const (
 var (
 	// eventTypeMapping maps webhook types to their corresponding Buildkite structs
 	eventTypeMapping = map[string]string{
-		"job.scheduled": "JobScheduledEvent",
-		"ping":          "PingEvent",
+		"build.finished":  "BuildFinishedEvent",
+		"build.running":   "BuildRunningEvent",
+		"build.scheduled": "BuildScheduledEvent",
+		"job.activated":   "JobActivatedEvent",
+		"job.finished":    "JobFinishedEvent",
+		"job.scheduled":   "JobScheduledEvent",
+		"job.started":     "JobStartedEvent",
+		"ping":            "PingEvent",
 	}
 )
 
@@ -150,8 +156,20 @@ type Event struct {
 //
 func (e *Event) ParsePayload() (payload interface{}, err error) {
 	switch *e.Type {
+	case "BuildFinishedEvent":
+		payload = &BuildFinishedEvent{}
+	case "BuildRunningEvent":
+		payload = &BuildRunningEvent{}
+	case "BuildScheduledEvent":
+		payload = &BuildScheduledEvent{}
+	case "JobActivatedEvent":
+		payload = &JobActivatedEvent{}
+	case "JobFinishedEvent":
+		payload = &JobFinishedEvent{}
 	case "JobScheduledEvent":
 		payload = &JobScheduledEvent{}
+	case "JobStartedEvent":
+		payload = &JobStartedEvent{}
 	case "PingEvent":
 		payload = &PingEvent{}
 	}

--- a/buildkite/webhook.go
+++ b/buildkite/webhook.go
@@ -23,14 +23,19 @@ const (
 var (
 	// eventTypeMapping maps webhook types to their corresponding Buildkite structs
 	eventTypeMapping = map[string]string{
-		"build.finished":  "BuildFinishedEvent",
-		"build.running":   "BuildRunningEvent",
-		"build.scheduled": "BuildScheduledEvent",
-		"job.activated":   "JobActivatedEvent",
-		"job.finished":    "JobFinishedEvent",
-		"job.scheduled":   "JobScheduledEvent",
-		"job.started":     "JobStartedEvent",
-		"ping":            "PingEvent",
+		"agent.connected":    "AgentConnectedEvent",
+		"agent.disconnected": "AgentDisconnectedEvent",
+		"agent.lost":         "AgentLostEvent",
+		"agent.stopped":      "AgentStoppedEvent",
+		"agent.stopping":     "AgentStoppingEvent",
+		"build.finished":     "BuildFinishedEvent",
+		"build.running":      "BuildRunningEvent",
+		"build.scheduled":    "BuildScheduledEvent",
+		"job.activated":      "JobActivatedEvent",
+		"job.finished":       "JobFinishedEvent",
+		"job.scheduled":      "JobScheduledEvent",
+		"job.started":        "JobStartedEvent",
+		"ping":               "PingEvent",
 	}
 )
 
@@ -158,6 +163,16 @@ type Event struct {
 //
 func (e *Event) ParsePayload() (payload interface{}, err error) {
 	switch *e.Type {
+	case "AgentConnectedEvent":
+		payload = &AgentConnectedEvent{}
+	case "AgentDisconnectedEvent":
+		payload = &AgentDisconnectedEvent{}
+	case "AgentLostEvent":
+		payload = &AgentLostEvent{}
+	case "AgentStoppedEvent":
+		payload = &AgentStoppedEvent{}
+	case "AgentStoppingEvent":
+		payload = &AgentStoppingEvent{}
 	case "BuildFinishedEvent":
 		payload = &BuildFinishedEvent{}
 	case "BuildRunningEvent":

--- a/buildkite/webhook_events.go
+++ b/buildkite/webhook_events.go
@@ -1,15 +1,73 @@
 package buildkite
 
-// JobScheduled is triggered when a command step job has been scheduled
-// to run on an agent
+// buildEvent is a wrapper for a build event notification
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
+type buildEvent struct {
+	Event    *string   `json:"event"`
+	Build    *Build    `json:"build"`
+	Pipeline *Pipeline `json:"pipeline"`
+	Sender   *User     `json:"sender"`
+}
+
+// BuildFinishedEvent is triggered when a build finishes
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
+type BuildFinishedEvent struct {
+	buildEvent
+}
+
+// BuildRunningEvent is triggered when a build starts running
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
+type BuildRunningEvent struct {
+	buildEvent
+}
+
+// BuildScheduledEvent is triggered when a build is scheduled
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
+type BuildScheduledEvent struct {
+	buildEvent
+}
+
+// jobEvent is a wrapper for a job event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobScheduledEvent struct {
+type jobEvent struct {
 	Event    *string   `json:"event"`
 	Build    *Build    `json:"build"`
 	Job      *Job      `json:"job"`
 	Pipeline *Pipeline `json:"pipeline"`
 	Sender   *User     `json:"sender"`
+}
+
+// JobActivatedEvent is triggered when a job is activated
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
+type JobActivatedEvent struct {
+	jobEvent
+}
+
+// JobFinishedEvent is triggered when a job is finished
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
+type JobFinishedEvent struct {
+	jobEvent
+}
+
+// JobScheduledEvent is triggered when a job is scheduled
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
+type JobScheduledEvent struct {
+	jobEvent
+}
+
+// JobStartedEvent is triggered when a job is started
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
+type JobStartedEvent struct {
+	jobEvent
 }
 
 // PingEvent is triggered when a webhook notification setting is changed

--- a/buildkite/webhook_events.go
+++ b/buildkite/webhook_events.go
@@ -1,0 +1,22 @@
+package buildkite
+
+// JobScheduled is triggered when a command step job has been scheduled
+// to run on an agent
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
+type JobScheduledEvent struct {
+	Event    *string   `json:"event"`
+	Build    *Build    `json:"build"`
+	Job      *Job      `json:"job"`
+	Pipeline *Pipeline `json:"pipeline"`
+	Sender   *User     `json:"sender"`
+}
+
+// PingEvent is triggered when a webhook notification setting is changed
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/ping-events
+type PingEvent struct {
+	Event        *string       `json:"event"`
+	Organization *Organization `json:"organization"`
+	Sender       *User         `json:"sender"`
+}

--- a/buildkite/webhook_events.go
+++ b/buildkite/webhook_events.go
@@ -1,5 +1,49 @@
 package buildkite
 
+// agentEvent is a wrapper for an agent event notification
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
+type agentEvent struct {
+	Event  *string `json:"event"`
+	Agent  *Agent  `json:"agent"`
+	Sender *User   `json:"sender"`
+}
+
+// AgentConnectedEvent is triggered when an agent has connected to the API
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
+type AgentConnectedEvent struct {
+	agentEvent
+}
+
+// AgentDisconnectedEvent is triggered when an agent has disconnected.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
+type AgentDisconnectedEvent struct {
+	agentEvent
+}
+
+// AgentLostEvent is triggered when an agent has been marked as lost.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
+type AgentLostEvent struct {
+	agentEvent
+}
+
+// AgentStoppedEvent is triggered when an agent has stopped.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
+type AgentStoppedEvent struct {
+	agentEvent
+}
+
+// AgentStoppingEvent is triggered when an agent is stopping.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
+type AgentStoppingEvent struct {
+	agentEvent
+}
+
 // buildEvent is a wrapper for a build event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events

--- a/buildkite/webhook_test.go
+++ b/buildkite/webhook_test.go
@@ -1,0 +1,122 @@
+package buildkite
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestParseWebHook(t *testing.T) {
+	tests := []struct {
+		payload      interface{}
+		messageType  string
+		errorMessage string
+	}{
+		{
+			payload:     &JobScheduledEvent{},
+			messageType: "job.scheduled",
+		},
+		{
+			payload:     &PingEvent{},
+			messageType: "ping",
+		},
+		{
+			payload:      &PingEvent{},
+			messageType:  "invalid",
+			errorMessage: "unknown X-Buildkite-Event in message: invalid",
+		},
+	}
+
+	for _, test := range tests {
+		p, err := json.Marshal(test.payload)
+		if err != nil {
+			t.Fatalf("Marshal(%#v): %v", test.payload, err)
+		}
+
+		got, err := ParseWebHook(test.messageType, p)
+		if err != nil {
+			if test.errorMessage != "" {
+				if err.Error() != test.errorMessage {
+					t.Errorf("ParseWebHook(%#v, %#v) expected error, got %#v", test.messageType, test.payload, err.Error())
+				}
+				continue
+			}
+			t.Fatalf("ParseWebHook: %v", err)
+		}
+
+		if want := test.payload; !reflect.DeepEqual(got, want) {
+			t.Errorf("ParseWebHook(%#v, %#v) = %#v, want %#v", test.messageType, p, got, want)
+		}
+	}
+}
+
+func TestValidatePayload(t *testing.T) {
+	const defaultBody = `{"event":"ping","service":{"id":"c9f8372d-c0cd-43dc-9274-768a875cf6ca","provider":"webhook","settings":{"url":"https://server.com/webhooks"}},"organization":{"id":"49801950-1df0-474f-bb56-ad6a930c5cb9","graphql_id":"T3JnYW5pemF0aW9uLS0tZTBmMzk3MgsTksGkxOWYtZTZjNzczZTJiYjEy","url":"https://api.buildkite.com/v2/organizations/acme-inc","web_url":"https://buildkite.com/acme-inc","name":"ACME Inc","slug":"acme-inc","agents_url":"https://api.buildkite.com/v2/organizations/acme-inc/agents","emojis_url":"https://api.buildkite.com/v2/organizations/acme-inc/emojis","created_at":"2021-02-03T20:34:10.486Z","pipelines_url":"https://api.buildkite.com/v2/organizations/acme-inc/pipelines"},"sender":{"id":"c9f8372d-c0cd-43dc-9269-bcbb7f308e3f","name":"ACME Man"}}`
+	const defaultSignature = "timestamp=1642080837,signature=582d496ac2d869dd97a3101c4cda346288c49a742592daf582ec64c86449f79c"
+	const payloadSignatureError = "payload signature check failed"
+	secretKey := []byte("29b1ff5779c76bd48ba6705eb99ff970")
+
+	tests := []struct {
+		signature   string
+		event       string
+		wantEvent   string
+		wantPayload string
+	}{
+		// The following tests generate expected errors:
+		{},                     // Missing signature
+		{signature: "invalid"}, // Invalid signature format
+		{signature: "timestamp=1642080837,signature=yo"}, // Signature not hex string
+		// The following tests expect err=nil:
+		{
+			signature:   defaultSignature,
+			event:       "ping",
+			wantEvent:   "ping",
+			wantPayload: defaultBody,
+		},
+	}
+
+	for _, test := range tests {
+		buf := bytes.NewBufferString(defaultBody)
+		req, err := http.NewRequest("POST", "http://localhost/webhook", buf)
+		if err != nil {
+			t.Fatalf("NewRequest: %v", err)
+		}
+
+		if test.signature != "" {
+			req.Header.Set(signatureHeader, test.signature)
+		}
+
+		req.Header.Set("Content-Type", "application/json")
+
+		got, err := ValidatePayload(req, secretKey)
+		if err != nil {
+			if test.wantPayload != "" {
+				t.Errorf("ValidatePayload(%#v): err = %v, want nil", test, err)
+			}
+
+			continue
+		}
+
+		if string(got) != test.wantPayload {
+			t.Errorf("ValidatePayload = %q, want %q", got, test.wantPayload)
+		}
+	}
+}
+
+func TestWebHookType(t *testing.T) {
+	eventType := "ping"
+
+	req, err := http.NewRequest("POST", "http://localhost", nil)
+	if err != nil {
+		t.Fatalf("Error building requet: %v", err)
+	}
+
+	req.Header.Set(eventTypeHeader, eventType)
+
+	got := WebHookType(req)
+	if got != eventType {
+		t.Errorf("WebHookType(%#v) = %q, want %q", req, got, eventType)
+	}
+}

--- a/buildkite/webhook_test.go
+++ b/buildkite/webhook_test.go
@@ -15,8 +15,32 @@ func TestParseWebHook(t *testing.T) {
 		errorMessage string
 	}{
 		{
+			payload:     &BuildFinishedEvent{},
+			messageType: "build.finished",
+		},
+		{
+			payload:     &BuildRunningEvent{},
+			messageType: "build.running",
+		},
+		{
+			payload:     &BuildScheduledEvent{},
+			messageType: "build.scheduled",
+		},
+		{
+			payload:     &JobActivatedEvent{},
+			messageType: "job.activated",
+		},
+		{
+			payload:     &JobFinishedEvent{},
+			messageType: "job.finished",
+		},
+		{
 			payload:     &JobScheduledEvent{},
 			messageType: "job.scheduled",
+		},
+		{
+			payload:     &JobStartedEvent{},
+			messageType: "job.started",
 		},
 		{
 			payload:     &PingEvent{},

--- a/buildkite/webhook_test.go
+++ b/buildkite/webhook_test.go
@@ -102,6 +102,7 @@ func TestValidatePayload(t *testing.T) {
 	const defaultSignature = "timestamp=1642080837,signature=582d496ac2d869dd97a3101c4cda346288c49a742592daf582ec64c86449f79c"
 	const errorDecodingSignature = "error decoding signature"
 	const invalidSignatureHeader = "X-Buildkite-Signature format is incorrect."
+	const missingSignatureHeader = "No X-Buildkite-Signature header present on request"
 	const payloadSignatureError = "payload signature check failed"
 	secretKey := []byte("29b1ff5779c76bd48ba6705eb99ff970")
 
@@ -113,7 +114,11 @@ func TestValidatePayload(t *testing.T) {
 		wantPayload string
 	}{
 		// The following tests generate expected errors:
-		{}, // Missing signature
+		// Missing signature
+		{
+			signature: "",
+			wantError: missingSignatureHeader,
+		},
 		// Invalid signature format
 		{
 			signature: "invalid",

--- a/buildkite/webhook_test.go
+++ b/buildkite/webhook_test.go
@@ -15,6 +15,26 @@ func TestParseWebHook(t *testing.T) {
 		errorMessage string
 	}{
 		{
+			payload:     &AgentConnectedEvent{},
+			messageType: "agent.connected",
+		},
+		{
+			payload:     &AgentDisconnectedEvent{},
+			messageType: "agent.disconnected",
+		},
+		{
+			payload:     &AgentLostEvent{},
+			messageType: "agent.lost",
+		},
+		{
+			payload:     &AgentStoppedEvent{},
+			messageType: "agent.stopped",
+		},
+		{
+			payload:     &AgentStoppingEvent{},
+			messageType: "agent.stopping",
+		},
+		{
 			payload:     &BuildFinishedEvent{},
 			messageType: "build.finished",
 		},

--- a/buildkite/webhook_test.go
+++ b/buildkite/webhook_test.go
@@ -109,7 +109,7 @@ func TestValidatePayload(t *testing.T) {
 		}
 
 		if test.signature != "" {
-			req.Header.Set(signatureHeader, test.signature)
+			req.Header.Set(SignatureHeader, test.signature)
 		}
 
 		req.Header.Set("Content-Type", "application/json")
@@ -137,7 +137,7 @@ func TestWebHookType(t *testing.T) {
 		t.Fatalf("Error building requet: %v", err)
 	}
 
-	req.Header.Set(eventTypeHeader, eventType)
+	req.Header.Set(EventTypeHeader, eventType)
 
 	got := WebHookType(req)
 	if got != eventType {


### PR DESCRIPTION
This enables support for parsing and verifying Buildkite Webhook events.

Added support for `ping`, `build.*` and `job.*` events.
Also added several helper functions to parse and validate the incoming webhook, including HMAC verification.

Code is closely modelled on `go-github` package.