### PR TITLE
consistently use Go 1.16

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   app:
-    image: golang:1.13.6
+    image: golang:1.16
     volumes:
       - .:/work
     working_dir: /work


### PR DESCRIPTION
This ensures Go 1.16 is used in CI (rather than Go 1.13), given that the `go.mod` cites Go 1.16.

This seeks to fix issue #113 