### PR TITLE
fix "more than one error-wrapping directive %w"

### DIFF
--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -99,7 +99,7 @@ func (p *Plugins) UnmarshalJSON(bs []byte) error {
 
 	asArray := []map[string]Plugin{}
 	if err2 := json.Unmarshal(bs, &asArray); err2 != nil {
-		return fmt.Errorf("plugins are neither a map or an array: %w, %w", err, err2)
+		return fmt.Errorf("plugins are neither a map or an array: %s, %s", err.Error(), err2.Error())
 	}
 	for _, plugin := range asArray {
 		if len(plugin) != 1 {


### PR DESCRIPTION
This seeks to offer a relatively low tech fix for the following build error and fixes issue #114 :

```
$ make
go test -timeout=3s -v ./...
buildkite/pipelines.go:102:10: fmt.Errorf call has more than one
error-wrapping directive %w
FAIL    github.com/buildkite/go-buildkite/v3/buildkite [build failed]
?       github.com/buildkite/go-buildkite/v3/examples/artifacts[no test
files]
?       github.com/buildkite/go-buildkite/v3/examples/projects[no test
files]
FAIL
make: *** [test] Error 2
```

...which occurs because `fmt.Errorf` does not support multiple `%w` directives, if I understand correctly:

> It is invalid to include more than one %w verb

As explained at https://pkg.go.dev/fmt#Errorf

Is this reasonable? Thanks!