### PR TITLE
Add GraphQLID to more api objects

### DIFF
--- a/buildkite/agents.go
+++ b/buildkite/agents.go
@@ -15,6 +15,7 @@ type AgentsService struct {
 // Agent represents a buildkite build agent.
 type Agent struct {
 	ID                *string    `json:"id,omitempty" yaml:"id,omitempty"`
+	GraphQLID         *string    `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
 	URL               *string    `json:"url,omitempty" yaml:"url,omitempty"`
 	WebURL            *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
 	Name              *string    `json:"name,omitempty" yaml:"name,omitempty"`

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -54,6 +54,7 @@ type PullRequest struct {
 // Build represents a build which has run in buildkite
 type Build struct {
 	ID          *string                `json:"id,omitempty" yaml:"id,omitempty"`
+	GraphQLID   *string                `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
 	URL         *string                `json:"url,omitempty" yaml:"url,omitempty"`
 	WebURL      *string                `json:"web_url,omitempty" yaml:"web_url,omitempty"`
 	Number      *int                   `json:"number,omitempty" yaml:"number,omitempty"`

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -15,6 +15,7 @@ type JobsService struct {
 // Job represents a job run during a build in buildkite
 type Job struct {
 	ID              *string      `json:"id,omitempty" yaml:"id,omitempty"`
+	GraphQLID       *string      `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
 	Type            *string      `json:"type,omitempty" yaml:"type,omitempty"`
 	Name            *string      `json:"name,omitempty" yaml:"name,omitempty"`
 	Label           *string      `json:"label,omitempty" yaml:"label,omitempty"`

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -40,6 +40,7 @@ type CreatePipeline struct {
 // Pipeline represents a buildkite pipeline.
 type Pipeline struct {
 	ID                              *string    `json:"id,omitempty" yaml:"id,omitempty"`
+	GraphQLID                       *string    `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
 	URL                             *string    `json:"url,omitempty" yaml:"url,omitempty"`
 	WebURL                          *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
 	Name                            *string    `json:"name,omitempty" yaml:"name,omitempty"`


### PR DESCRIPTION
I need it on pipelines specifically, but I figured I'd add it to a couple more objects just for the sake of future users