### PR TITLE
Upgrade to latest go

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   app:
-    image: golang:1.13.6
+    image: golang:1.20
     volumes:
       - .:/work
     working_dir: /work

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/go-buildkite/v3
 
-go 1.16
+go 1.20
 
 require (
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect


### PR DESCRIPTION
Go is currently on `1.20`. It makes sense to use this version rather than upgrading to a version that'll also be outdated soon.