### PR TITLE
Add `rebuilt_from` field to Build struct

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -27,7 +27,7 @@ type CreateBuild struct {
 
 	// Optional fields
 	Author                      Author            `json:"author,omitempty" yaml:"author,omitempty"`
-	CleanCheckout 				bool 			  `json:"clean_checkout,omitempty" yaml:"clean_checkout,omitempty"`
+	CleanCheckout               bool              `json:"clean_checkout,omitempty" yaml:"clean_checkout,omitempty"`
 	Env                         map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	MetaData                    map[string]string `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
 	IgnorePipelineBranchFilters bool              `json:"ignore_pipeline_branch_filters,omitempty" yaml:"ignore_pipeline_branch_filters,omitempty"`
@@ -43,6 +43,13 @@ type Creator struct {
 	Email     string     `json:"email" yaml:"email"`
 	ID        string     `json:"id" yaml:"id"`
 	Name      string     `json:"name" yaml:"name"`
+}
+
+// RebuiltFrom references a previous build
+type RebuiltFrom struct {
+	ID     string `json:"id" yaml:"id"`
+	Number int    `json:"number" yaml:"number"`
+	URL    string `json:"url" yaml:"url"`
 }
 
 // PullRequest represents a Github PR
@@ -79,6 +86,9 @@ type Build struct {
 
 	// the pipeline this build is associated with
 	Pipeline *Pipeline `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
+
+	// the build this build is a rebuild of
+	RebuiltFrom *RebuiltFrom `json:"rebuilt_from,omitempty" yaml:"rebuilt_from,omitempty"`
 
 	// the pull request this build is associated with
 	PullRequest *PullRequest `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`


### PR DESCRIPTION
These are present in the API, but currently undocumented, see buildkite/docs#2032. As per the community Slack, the field is stable and can be relied upon.

See also: #79