### PR TITLE
Added group_key to Job struct, Builds test updates

### DIFF
--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -20,6 +20,7 @@ type Job struct {
 	Name               *string      `json:"name,omitempty" yaml:"name,omitempty"`
 	Label              *string      `json:"label,omitempty" yaml:"label,omitempty"`
 	StepKey            *string      `json:"step_key,omitempty" yaml:"step_key,omitempty"`
+	GroupKey           *string      `json:"group_key,omitempty" yaml:"group_key,omitempty"`
 	State              *string      `json:"state,omitempty" yaml:"state,omitempty"`
 	LogsURL            *string      `json:"logs_url,omitempty" yaml:"logs_url,omitempty"`
 	RawLogsURL         *string      `json:"raw_log_url,omitempty" yaml:"raw_log_url,omitempty"`


### PR DESCRIPTION
Reraise and adjustment of original contributor [PR](https://github.com/buildkite/go-buildkite/pull/104), edited with previous master [PR](https://github.com/buildkite/go-buildkite/pull/126) here.

Added the `GroupKey` parameter to the Job struct (`group_key` in output) - which states the Job's group if they are such defined in one as part of a [group step](https://buildkite.com/docs/pipelines/group-step).

Tested locally associating with a Build that has a group defined, notably with the following steps (sequential group command echoes):

```
steps:
  - group: ":lock_with_ink_pen: Say hello with groups"
    key: "echoes"
    steps:
      - label: ":wave: 1"
        key: wave_1
        command: "echo 'Hello 1'"
        agents:
          local: true
      - label: ":wave: 2"
        key: wave_2
        command: "echo 'Hello 2'"
        depends_on:
        - wave_1
        agents:
          local: true
      - label: ":wave: 3"
        key: wave_3
        command: "echo 'Hello 3'"
        depends_on:
        - wave_2
        agents:
          local: true
      - label: ":wave: 4"
        key: wave_4
        command: "echo 'Hello 4'"
        depends_on:
        - wave_3
        agents:
          local: true
```
The corresponding run of the `ListByPipeline` [function](https://github.com/buildkite/go-buildkite/blob/main/buildkite/builds.go#L248) gives all such builds of this pipeline: and notably each `job` inside the results shows such key as expected:

![image](https://user-images.githubusercontent.com/70425486/232665952-1685dab5-7c0e-43ff-a1e8-ee124b55c9d5.png)

Also, the rewritten `TestBuildsService_Get` function with the two seperate functions pass as expected - one with a expected ID (123) and the other with a `group_key` of `job_group`

![image](https://user-images.githubusercontent.com/70425486/232666378-d768b833-0d28-4651-b810-a51221882b4c.png)

