### PR TITLE
add group_key to job struct if available

### DIFF
--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -20,6 +20,7 @@ type Job struct {
 	Name               *string      `json:"name,omitempty" yaml:"name,omitempty"`
 	Label              *string      `json:"label,omitempty" yaml:"label,omitempty"`
 	StepKey            *string      `json:"step_key,omitempty" yaml:"step_key,omitempty"`
+	GroupKey           *string      `json:"group_key,omitempty" yaml:"group_key,omitempty"`
 	State              *string      `json:"state,omitempty" yaml:"state,omitempty"`
 	LogsURL            *string      `json:"logs_url,omitempty" yaml:"logs_url,omitempty"`
 	RawLogsURL         *string      `json:"raw_log_url,omitempty" yaml:"raw_log_url,omitempty"`


### PR DESCRIPTION
This is a follow up of my previous PR #104 which should fix the merge conflicts with `main` that are still in #131. Thanks @lizrabuya / @james2791 for attempting to get this merged, sorry the rebase is late. :)
(Happy to close this in favour of #131 if we fix the conflict there instead, just wasn't sure if you were still waiting on me to do it)

### Background
The [Get Build](https://buildkite.com/docs/apis/rest-api/builds#get-a-build) rest api now returns a `group_key` property on jobs if they are part of a [group step](https://buildkite.com/docs/pipelines/group-step). However, the Get Job itself doesn't yet include this property (confirmed via support email).

go-buildkite's `Job` struct doesn't yet include this property and it would be useful to include this to allow SDK usecases that look up jobs belonging to a specific group.

### What's changed
* add `GroupKey` to `Job` struct and omit if missing like other properties
* update `Get` Build test to handle multiple scenarios and add one that includes a job with `group_key` in return payload

### How has this been tested?

- Confirmed unit tests still pass
- Tested working by consuming fork changes and confirming the `group_key` property is parsed properly from the Get Build REST API response.
- @james2791 's testing in #131 

Happy to make any changes required before merging, thanks in advance!