### PR TITLE
[SUP-1074] Request body cannot be nil

### DIFF
--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -82,11 +82,6 @@ func (js *JobsService) UnblockJob(org string, pipeline string, buildNumber strin
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/unblock", org, pipeline, buildNumber, jobID)
 
-	u, err := addOptions(u, opt)
-	if err != nil {
-		return nil, nil, err
-	}
-
 	if opt == nil {
 		opt = &JobUnblockOptions{}
 	}

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -82,6 +82,11 @@ func (js *JobsService) UnblockJob(org string, pipeline string, buildNumber strin
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/unblock", org, pipeline, buildNumber, jobID)
 
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	if opt == nil {
 		opt = &JobUnblockOptions{}
 	}

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -87,6 +87,10 @@ func (js *JobsService) UnblockJob(org string, pipeline string, buildNumber strin
 		return nil, nil, err
 	}
 
+	if opt == nil {
+		opt = &JobUnblockOptions{}
+	}
+
 	req, err := js.client.NewRequest("PUT", u, opt)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
If no unblock parameters are passed, a 500 error is returned from go-buildkite. The reason is that an null request body was passed. The expected behavior is a 400 bad request returned when no unblock parameters are passed.

This will resolve #136 