### PR TITLE
SUP-1321: Pipeline updates with PATCH friendly struct input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * SUP-1314: Test Analytics Integration [#142](https://github.com/buildkite/go-buildkite/pull/142) ([james2791](https://github.com/james2791))
 * SUP-1321: Pipeline updates with PATCH friendly struct input [#143](https://github.com/buildkite/go-buildkite/pull/143) ([james2791](https://github.com/james2791))
 
+### Notice
+As part of this release, the properties that can be set when updating a pipeline using the [PipelinesService](https://github.com/buildkite/go-buildkite/blob/main/buildkite/pipelines.go) have changed to reflect the permitted request body properties in the pipeline update [REST API endpoint](https://buildkite.com/docs/apis/rest-api/pipelines#update-a-pipeline).
+
 ## [v3.3.1](https://github.com/buildkite/go-buildkite/compare/v3.3.0...v3.3.1) (2023-06-08)
 * Resolved issue on 500 error when request body is null [#137](https://github.com/buildkite/go-buildkite/pull/137) ([lizrabuya](ttps://github.com/lizrabuya))
 * Bump to v3.3.1 [#138](https://github.com/buildkite/go-buildkite/pull/138) ([lizrabuya](ttps://github.com/lizrabuya))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 * Support build.failing events [#141](https://github.com/buildkite/go-buildkite/pull/141) ([mcncl](https://github.com/mcncl))
 * SUP-1314: Test Analytics Integration [#142](https://github.com/buildkite/go-buildkite/pull/142) ([james2791](https://github.com/james2791))
+* SUP-1321: Pipeline updates with PATCH friendly struct input [#143](https://github.com/buildkite/go-buildkite/pull/143) ([james2791](https://github.com/james2791))
 
 ## [v3.3.1](https://github.com/buildkite/go-buildkite/compare/v3.3.0...v3.3.1) (2023-06-08)
 * Resolved issue on 500 error when request body is null [#137](https://github.com/buildkite/go-buildkite/pull/137) ([lizrabuya](ttps://github.com/lizrabuya))

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 all: test
 
+fmt: 
+	gofmt -w .
+
 test:
 	go test -timeout=3s -v ./...
 

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -42,18 +42,18 @@ type UpdatePipeline struct {
 	Configuration string `json:"configuration,omitempty" yaml:"configuration,omitempty"`
 	Steps         []Step `json:"steps,omitempty" yaml:"steps,omitempty"`
 
-	Name                            string            `json:"name,omitempty" yaml:"name,omitempty"`
-	Repository                      string            `json:"repository,omitempty" yaml:"repository,omitempty"`
-	DefaultBranch                   string            `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
-	Description                     string            `json:"description,omitempty" yaml:"description,omitempty"`
-	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty" yaml:"provider_settings,omitempty"`
-	BranchConfiguration             string            `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty" yaml:"skip_queued_branch_builds,omitempty"`
-	SkipQueuedBranchBuildsFilter    string            `json:"skip_queued_branch_builds_filter,omitempty" yaml:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds,omitempty" yaml:"cancel_running_branch_builds,omitempty"`
-	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty" yaml:"cancel_running_branch_builds_filter,omitempty"`
-	ClusterID                       string            `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
-	Visibility                      *string           `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+	Name                            string           `json:"name,omitempty" yaml:"name,omitempty"`
+	Repository                      string           `json:"repository,omitempty" yaml:"repository,omitempty"`
+	DefaultBranch                   string           `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
+	Description                     string           `json:"description,omitempty" yaml:"description,omitempty"`
+	ProviderSettings                ProviderSettings `json:"provider_settings,omitempty" yaml:"provider_settings,omitempty"`
+	BranchConfiguration             string           `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
+	SkipQueuedBranchBuilds          bool             `json:"skip_queued_branch_builds,omitempty" yaml:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuildsFilter    string           `json:"skip_queued_branch_builds_filter,omitempty" yaml:"skip_queued_branch_builds_filter,omitempty"`
+	CancelRunningBranchBuilds       bool             `json:"cancel_running_branch_builds,omitempty" yaml:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuildsFilter string           `json:"cancel_running_branch_builds_filter,omitempty" yaml:"cancel_running_branch_builds_filter,omitempty"`
+	ClusterID                       string           `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
+	Visibility                      *string          `json:"visibility,omitempty" yaml:"visibility,omitempty"`
 }
 
 // Pipeline represents a buildkite pipeline.

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -233,24 +232,25 @@ func (ps *PipelinesService) Delete(org string, slug string) (*Response, error) {
 // Update - Updates a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#update-a-pipeline
-func (ps *PipelinesService) Update(org, slug string, p *UpdatePipeline) (*Response, error) {
-	if p == nil {
-		return nil, errors.New("Pipeline must not be nil")
-	}
+func (ps *PipelinesService) Update(org, slug string, p *UpdatePipeline) (*Pipeline, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
 
 	req, err := ps.client.NewRequest("PATCH", u, p)
+
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	resp, err := ps.client.Do(req, p)
+	pipeline := new(Pipeline)
+
+	resp, err := ps.client.Do(req, pipeline)
+
 	if err != nil {
-		return resp, err
+		return nil, resp, err
 	}
 
-	return resp, err
+	return pipeline, resp, err
 }
 
 // AddWebhook - Adds webhook in github for pipeline.

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -38,6 +38,27 @@ type CreatePipeline struct {
 	Visibility                      *string           `json:"visibility,omitempty" yaml:"visibility,omitempty"`
 }
 
+type UpdatePipeline struct {
+	Name       string `json:"name" yaml:"name"`
+	Repository string `json:"repository" yaml:"repository"`
+
+	// Either configuration needs to be specified as a yaml string or steps.
+	Configuration string `json:"configuration,omitempty" yaml:"configuration,omitempty"`
+	Steps         []Step `json:"steps,omitempty" yaml:"steps,omitempty"`
+
+	DefaultBranch                   string            `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
+	Description                     string            `json:"description,omitempty" yaml:"description,omitempty"`
+	Env                             map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
+	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty" yaml:"provider_settings,omitempty"`
+	BranchConfiguration             string            `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
+	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty" yaml:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuildsFilter    string            `json:"skip_queued_branch_builds_filter,omitempty" yaml:"skip_queued_branch_builds_filter,omitempty"`
+	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds,omitempty" yaml:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty" yaml:"cancel_running_branch_builds_filter,omitempty"`
+	ClusterID                       string            `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
+	Visibility                      *string           `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+}
+
 // Pipeline represents a buildkite pipeline.
 type Pipeline struct {
 	ID                              *string    `json:"id,omitempty" yaml:"id,omitempty"`

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -39,16 +39,17 @@ type CreatePipeline struct {
 }
 
 type UpdatePipeline struct {
-	Name       string `json:"name" yaml:"name"`
-	Repository string `json:"repository" yaml:"repository"`
+	// Slug required for determining the pipeline to update
+	Slug string `json:"slug" yaml:"slug"`
 
-	// Either configuration needs to be specified as a yaml string or steps.
+	// Either configuration needs to be specified as a yaml string or steps (based on what the pipeline uses)
 	Configuration string `json:"configuration,omitempty" yaml:"configuration,omitempty"`
 	Steps         []Step `json:"steps,omitempty" yaml:"steps,omitempty"`
 
+	Name                            string            `json:"name,omitempty" yaml:"name,omitempty"`
+	Repository                      string            `json:"repository,omitempty" yaml:"repository,omitempty"`
 	DefaultBranch                   string            `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
 	Description                     string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Env                             map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
 	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty" yaml:"provider_settings,omitempty"`
 	BranchConfiguration             string            `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
 	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty" yaml:"skip_queued_branch_builds,omitempty"`
@@ -235,19 +236,19 @@ func (ps *PipelinesService) Delete(org string, slug string) (*Response, error) {
 // Update - Updates a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#update-a-pipeline
-func (ps *PipelinesService) Update(org string, p *Pipeline) (*Response, error) {
-	if p == nil {
-		return nil, errors.New("pipeline must not be nil")
+func (ps *PipelinesService) Update(org string, pu *UpdatePipeline) (*Response, error) {
+	if pu == nil {
+		return nil, errors.New("Pipeline must not be nil")
 	}
 
-	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, *p.Slug)
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, pu.Slug)
 
-	req, err := ps.client.NewRequest("PATCH", u, p)
+	req, err := ps.client.NewRequest("PATCH", u, pu)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := ps.client.Do(req, p)
+	resp, err := ps.client.Do(req, pu)
 	if err != nil {
 		return resp, err
 	}

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -39,9 +39,6 @@ type CreatePipeline struct {
 }
 
 type UpdatePipeline struct {
-	// Slug required for determining the pipeline to update
-	Slug string `json:"slug" yaml:"slug"`
-
 	// Either configuration needs to be specified as a yaml string or steps (based on what the pipeline uses)
 	Configuration string `json:"configuration,omitempty" yaml:"configuration,omitempty"`
 	Steps         []Step `json:"steps,omitempty" yaml:"steps,omitempty"`
@@ -236,19 +233,19 @@ func (ps *PipelinesService) Delete(org string, slug string) (*Response, error) {
 // Update - Updates a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#update-a-pipeline
-func (ps *PipelinesService) Update(org string, pu *UpdatePipeline) (*Response, error) {
-	if pu == nil {
+func (ps *PipelinesService) Update(org, slug string, p *UpdatePipeline) (*Response, error) {
+	if p == nil {
 		return nil, errors.New("Pipeline must not be nil")
 	}
 
-	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, pu.Slug)
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
 
-	req, err := ps.client.NewRequest("PATCH", u, pu)
+	req, err := ps.client.NewRequest("PATCH", u, p)
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := ps.client.Do(req, pu)
+	resp, err := ps.client.Do(req, p)
 	if err != nil {
 		return resp, err
 	}

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -284,7 +284,7 @@ func TestPipelinesService_Update(t *testing.T) {
 
 		testMethod(t, r, "PATCH")
 
-		fmt.Fprint(w, 
+		fmt.Fprint(w,
 			`
 			{
 				"default_branch": "develop"

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -234,6 +234,7 @@ func TestPipelinesService_Update(t *testing.T) {
 				},
 			},
 		},
+		DefaultBranch: *String("main"),
 	}
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
@@ -262,16 +263,20 @@ func TestPipelinesService_Update(t *testing.T) {
 								}
 							}
 						],
-						"slug": "my-great-repo"
+						"default_branch":"main"
 					}`)
 	})
 
 	pipeline, _, err := client.Pipelines.Create("my-great-org", input)
+
 	if err != nil {
 		t.Errorf("Pipelines.Create returned error: %v", err)
 	}
 
-	pipeline.Name = String("derp")
+	// Update pipeline
+	update := &UpdatePipeline{
+		DefaultBranch: *String("develop"),
+	}
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-repo", func(w http.ResponseWriter, r *http.Request) {
 		v := new(CreatePipeline)
@@ -279,33 +284,23 @@ func TestPipelinesService_Update(t *testing.T) {
 
 		testMethod(t, r, "PATCH")
 
-		fmt.Fprint(w, `{
-						"name":"derp",
-						"repository":"my-great-repo",
-						"steps": [
-							{
-								"type": "script",
-								"name": "Build :package:",
-								"command": "script/release.sh",
-								"plugins": {
-									"my-org/docker#v3.3.0": {
-										"image":   "node",
-										"workdir": "/app"
-									}
-								}
-							}
-						],
-						"slug": "my-great-repo",
-                                                "visibility": "public"
-					}`)
+		fmt.Fprint(w, 
+			`
+			{
+				"default_branch": "develop"
+			}`)
 	})
 
-	_, err = client.Pipelines.Update("my-great-org", pipeline)
+	updatedPipeline, _, err := client.Pipelines.Update("my-great-org", "my-great-repo", update)
+
+	// Update pipeline with the patched default branch
+	pipeline.DefaultBranch = updatedPipeline.DefaultBranch
+
 	if err != nil {
 		t.Errorf("Pipelines.Update returned error: %v", err)
 	}
 
-	want := &Pipeline{Name: String("derp"),
+	want := &Pipeline{Name: String("my-great-pipeline"),
 		Repository: String("my-great-repo"),
 		Steps: []*Step{
 			{
@@ -320,8 +315,7 @@ func TestPipelinesService_Update(t *testing.T) {
 				},
 			},
 		},
-		Slug:       String("my-great-repo"),
-		Visibility: String("public"),
+		DefaultBranch: String("develop"),
 	}
 
 	if !reflect.DeepEqual(pipeline, want) {

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -30,7 +30,7 @@ func main() {
 	client := buildkite.NewClient(config.Client())
 
 	updatePipeline := buildkite.UpdatePipeline{
-		Description:   *buildkite.String("This ia a deployment pipeline"),
+		Description: *buildkite.String("This ia a deployment pipeline"),
 	}
 
 	pipeline, _, err := client.Pipelines.Update(*org, *slug, &updatePipeline)

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	slug     = kingpin.Flag("slug", "Pipeline slug").Required().String()
+	debug    = kingpin.Flag("debug", "Enable debugging").Bool()
+)
+
+func main() {
+	kingpin.Parse()
+
+	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
+
+	if err != nil {
+		log.Fatalf("client config failed: %s", err)
+	}
+
+	client := buildkite.NewClient(config.Client())
+
+	updatePipeline := buildkite.UpdatePipeline{
+		Description:   *buildkite.String("This ia a deployment pipeline"),
+	}
+
+	pipeline, _, err := client.Pipelines.Update(*org, *slug, &updatePipeline)
+
+	if err != nil {
+		log.Fatalf("Updating pipeline failed: %s", err)
+	}
+
+	data, err := json.MarshalIndent(pipeline, "", "\t")
+
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "%s", string(data))
+}


### PR DESCRIPTION
- [x] tests added
- [x] examples of each service action (List, Get etc) added to the relevant `examples/` folder (create if new)
- [x] `CHANGELOG.md` updated with pending release information

Altered the `Update` function of `PipelinesService` to only use a new struct in generating the request body for its `PATCH` request. The new struct only contains validated properties expected by the API. Notably, the `slug` has been moved out of the request and into the function's arguments for constructing the URL (and not resulting it to be fed in along with other unpermitted parameters)