### PR TITLE
SUP-1321: Pipeline updates utilising dedicated PipelineUpdate struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 ## Unreleased
 * Support build.failing events [#141](https://github.com/buildkite/go-buildkite/pull/141) ([mcncl](https://github.com/mcncl))
 * SUP-1314: Test Analytics Integration [#142](https://github.com/buildkite/go-buildkite/pull/142) ([james2791](https://github.com/james2791))
-* SUP-1321: Pipeline updates with PATCH friendly struct input [#143](https://github.com/buildkite/go-buildkite/pull/143) ([james2791](https://github.com/james2791))
-
-### Notice
-As part of this release, the properties that can be set when updating a pipeline using the [PipelinesService](https://github.com/buildkite/go-buildkite/blob/main/buildkite/pipelines.go) have changed to reflect the permitted request body properties in the pipeline update [REST API endpoint](https://buildkite.com/docs/apis/rest-api/pipelines#update-a-pipeline).
+* SUP-1321: Pipeline updates utilising dedicated PipelineUpdate struct [#144](https://github.com/buildkite/go-buildkite/pull/144) ([james2791](https://github.com/james2791))
 
 ## [v3.3.1](https://github.com/buildkite/go-buildkite/compare/v3.3.0...v3.3.1) (2023-06-08)
 * Resolved issue on 500 error when request body is null [#137](https://github.com/buildkite/go-buildkite/pull/137) ([lizrabuya](ttps://github.com/lizrabuya))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * SUP-1314: Test Analytics Integration [#142](https://github.com/buildkite/go-buildkite/pull/142) ([james2791](https://github.com/james2791))
 * SUP-1321: Pipeline updates utilising dedicated PipelineUpdate struct [#145](https://github.com/buildkite/go-buildkite/pull/145) ([james2791](https://github.com/james2791))
 
+### Notice
+As part of this release, the properties that can be set when updating a pipeline using the [PipelinesService](https://github.com/buildkite/go-buildkite/blob/main/buildkite/pipelines.go) have changed to reflect the permitted request body properties in the pipeline update [REST API endpoint](https://buildkite.com/docs/apis/rest-api/pipelines#update-a-pipeline).
+
 ## [v3.3.1](https://github.com/buildkite/go-buildkite/compare/v3.3.0...v3.3.1) (2023-06-08)
 * Resolved issue on 500 error when request body is null [#137](https://github.com/buildkite/go-buildkite/pull/137) ([lizrabuya](ttps://github.com/lizrabuya))
 * Bump to v3.3.1 [#138](https://github.com/buildkite/go-buildkite/pull/138) ([lizrabuya](ttps://github.com/lizrabuya))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 * Support build.failing events [#141](https://github.com/buildkite/go-buildkite/pull/141) ([mcncl](https://github.com/mcncl))
 * SUP-1314: Test Analytics Integration [#142](https://github.com/buildkite/go-buildkite/pull/142) ([james2791](https://github.com/james2791))
-* SUP-1321: Pipeline updates utilising dedicated PipelineUpdate struct [#144](https://github.com/buildkite/go-buildkite/pull/144) ([james2791](https://github.com/james2791))
+* SUP-1321: Pipeline updates utilising dedicated PipelineUpdate struct [#145](https://github.com/buildkite/go-buildkite/pull/145) ([james2791](https://github.com/james2791))
 
 ## [v3.3.1](https://github.com/buildkite/go-buildkite/compare/v3.3.0...v3.3.1) (2023-06-08)
 * Resolved issue on 500 error when request body is null [#137](https://github.com/buildkite/go-buildkite/pull/137) ([lizrabuya](ttps://github.com/lizrabuya))

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -350,3 +350,9 @@ func String(v string) *string {
 	*p = v
 	return p
 }
+
+func Bool(v bool) *bool {
+	p := new(bool)
+	*p = v
+	return p
+}

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -232,20 +232,19 @@ func (ps *PipelinesService) Delete(org string, slug string) (*Response, error) {
 // Update - Updates a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#update-a-pipeline
-func (ps *PipelinesService) Update(org, slug string, p *UpdatePipeline) (*Pipeline, *Response, error) {
+func (ps *PipelinesService) Update(org string, p *UpdatePipeline) (*Response, error) {
+	if p == nil {
+		return nil, errors.New("Pipeline must not be nil")
+	}
 
-	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, p.Slug)
 
 	req, err := ps.client.NewRequest("PATCH", u, p)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	pipeline := new(Pipeline)
-
-	resp, err := ps.client.Do(req, pipeline)
-
+	resp, err := ps.client.Do(req, p)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -240,7 +240,7 @@ func (ps *PipelinesService) Update(org string, p *Pipeline) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, *p.Slug)
 
-	pu := generatePipelineUpdate(*p)
+	pu := generateUpdatePipelineStruct(*p)
 
 	req, err := ps.client.NewRequest("PATCH", u, pu)
 
@@ -301,7 +301,7 @@ func (ps *PipelinesService) Unarchive(org string, slug string) (*Response, error
 	return ps.client.Do(req, nil)
 }
 
-func generatePipelineUpdate(p Pipeline) UpdatePipeline {
+func generateUpdatePipelineStruct(p Pipeline) UpdatePipeline {
 
 	// Create a UpdatePipeline struct to use for updating
 	updatePipeline := UpdatePipeline{

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -240,7 +240,7 @@ func (ps *PipelinesService) Update(org string, p *Pipeline) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, *p.Slug)
 
-	pu := generateUpdatePipelineStruct(*p)
+	pu := generateUpdatePipelineInstance(*p)
 
 	req, err := ps.client.NewRequest("PATCH", u, pu)
 
@@ -301,7 +301,7 @@ func (ps *PipelinesService) Unarchive(org string, slug string) (*Response, error
 	return ps.client.Do(req, nil)
 }
 
-func generateUpdatePipelineStruct(p Pipeline) UpdatePipeline {
+func generateUpdatePipelineInstance(p Pipeline) UpdatePipeline {
 
 	// Create a UpdatePipeline struct to use for updating
 	updatePipeline := UpdatePipeline{

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -38,6 +39,9 @@ type CreatePipeline struct {
 }
 
 type UpdatePipeline struct {
+	// Slug required for determining the pipeline to update
+	Slug string `json:"slug" yaml:"slug"`
+
 	// Either configuration needs to be specified as a yaml string or steps (based on what the pipeline uses)
 	Configuration string `json:"configuration,omitempty" yaml:"configuration,omitempty"`
 	Steps         []Step `json:"steps,omitempty" yaml:"steps,omitempty"`
@@ -241,15 +245,15 @@ func (ps *PipelinesService) Update(org string, p *UpdatePipeline) (*Response, er
 
 	req, err := ps.client.NewRequest("PATCH", u, p)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	resp, err := ps.client.Do(req, p)
 	if err != nil {
-		return nil, resp, err
+		return resp, err
 	}
 
-	return pipeline, resp, err
+	return resp, err
 }
 
 // AddWebhook - Adds webhook in github for pipeline.

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -275,6 +275,7 @@ func TestPipelinesService_Update(t *testing.T) {
 
 	// Update pipeline
 	update := &UpdatePipeline{
+		Slug:          *String("my-great-repo"),
 		DefaultBranch: *String("develop"),
 	}
 
@@ -287,10 +288,15 @@ func TestPipelinesService_Update(t *testing.T) {
 		fmt.Fprint(w,
 			`
 			{
-	updatedPipeline, _, err := client.Pipelines.Update("my-great-org", "my-great-repo", update)
+				"slug": "my-great-repo",
+				"default_branch": "develop"
+			}`)
+	})
+
+	_, err = client.Pipelines.Update("my-great-org", update)
 
 	// Update pipeline with the patched default branch
-	pipeline.DefaultBranch = updatedPipeline.DefaultBranch
+	pipeline.DefaultBranch = &update.DefaultBranch
 
 	if err != nil {
 		t.Errorf("Pipelines.Update returned error: %v", err)

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -287,10 +287,6 @@ func TestPipelinesService_Update(t *testing.T) {
 		fmt.Fprint(w,
 			`
 			{
-				"default_branch": "develop"
-			}`)
-	})
-
 	updatedPipeline, _, err := client.Pipelines.Update("my-great-org", "my-great-repo", update)
 
 	// Update pipeline with the patched default branch

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
 

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -12,7 +12,6 @@ import (
 var (
 	apiToken = kingpin.Flag("token", "API token").Required().String()
 	org      = kingpin.Flag("org", "Orginization slug").Required().String()
-	slug     = kingpin.Flag("slug", "Pipeline slug").Required().String()
 	debug    = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
@@ -28,20 +27,15 @@ func main() {
 	client := buildkite.NewClient(config.Client())
 
 	updatePipeline := buildkite.UpdatePipeline{
-		Description: *buildkite.String("This ia a deployment pipeline"),
+		Slug:        *buildkite.String("my-great-repo"),
+		Description: *buildkite.String("This ia a great pipeline!"),
 	}
 
-	pipeline, _, err := client.Pipelines.Update(*org, *slug, &updatePipeline)
+	resp, err := client.Pipelines.Update(*org, &updatePipeline)
 
 	if err != nil {
 		log.Fatalf("Updating pipeline failed: %s", err)
 	}
 
-	data, err := json.MarshalIndent(pipeline, "", "\t")
-
-	if err != nil {
-		log.Fatalf("json encode failed: %s", err)
-	}
-
-	fmt.Fprintf(os.Stdout, "%s", string(data))
+	fmt.Println(resp.StatusCode)
 }

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -31,7 +31,7 @@ func main() {
 		Description: buildkite.String("This ia a great pipeline!"),
 		Provider: &buildkite.Provider{
 			Settings: &buildkite.GitHubSettings{
-				TriggerMode:       buildkite.String("Code"),
+				TriggerMode:       buildkite.String("fork"),
 				BuildPullRequests: buildkite.Bool(false),
 			},
 		},

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -26,12 +26,18 @@ func main() {
 
 	client := buildkite.NewClient(config.Client())
 
-	updatePipeline := buildkite.UpdatePipeline{
-		Slug:        *buildkite.String("my-great-repo"),
-		Description: *buildkite.String("This ia a great pipeline!"),
+	pipeline := buildkite.Pipeline{
+		Slug:        buildkite.String("my-great-repo"),
+		Description: buildkite.String("This ia a great pipeline!"),
+		Provider: &buildkite.Provider{
+			Settings: &buildkite.GitHubSettings{
+				TriggerMode:       buildkite.String("Code"),
+				BuildPullRequests: buildkite.Bool(false),
+			},
+		},
 	}
 
-	resp, err := client.Pipelines.Update(*org, &updatePipeline)
+	resp, err := client.Pipelines.Update(*org, &pipeline)
 
 	if err != nil {
 		log.Fatalf("Updating pipeline failed: %s", err)


### PR DESCRIPTION
- [x] tests added
- [x] examples of each service action (List, Get etc) added to the relevant `examples/` folder (create if new)
- [x] `CHANGELOG.md` updated with pending release information

This PR reverts [#143](https://github.com/buildkite/go-buildkite/pull/143) while introducing the main change of allowing only-permitted properties as part of updating a pipeline via the `UpdatePipeline` struct. From the `Update` function, the passed in `Pipeline` (p) instance is used to create said `UpdatePipeline` instance with via p's values in `generateUpdatePipelineInstance`

The `Update` function's signature is also reverted to the existing implementation from `3.3.1`.