### PR TITLE
Addition of issue/new feature/release templates, Codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@jradtilbrook @mcncl @james2791 @lizrabuya

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+(Or any other appropriate list of steps that reproduces your issue)
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/NEW_FEATURE/new_feature.md
+++ b/.github/NEW_FEATURE/new_feature.md
@@ -1,0 +1,24 @@
+<type: fix | feat | build | chore | ci | docs | style | refactor | perf | test >(scope)[!]: [description]
+
+## PR checklist:
+- [ ] tests added
+- [ ] examples of each function added to the relevant `examples/` folder (create if new)
+- [ ] `CHANGELOG.md` updated with pending release information
+
+### Example
+feat(pipeline service): Add extra parameter to CreatePipeline struct
+
+## PR checklist:
+- [ ] tests added
+- [x] examples of each function added to the relevant `examples/` folder (create if new)
+- [x] `CHANGELOG.md` updated with pending release information
+
+#### To ! or not to !
+`!` denotes a breaking change, in this example the test does **not** cause a breaking change and so `!` is not required.
+
+A `BREAKING CHANGE` footer may also be used:
+
+```
+feat: strip non-ASCII chars from pipeline name
+BREAKING CHANGE: no longer replaces non-ASCII with "blank symbols"
+```

--- a/.github/NEW_FEATURE/new_feature.md
+++ b/.github/NEW_FEATURE/new_feature.md
@@ -2,7 +2,7 @@
 
 ## PR checklist:
 - [ ] tests added
-- [ ] examples of each function added to the relevant `examples/` folder (create if new)
+- [ ] examples of each service action (List, Get etc) added to the relevant `examples/` folder (create if new)
 - [ ] `CHANGELOG.md` updated with pending release information
 
 ### Example
@@ -10,7 +10,7 @@ feat(pipeline service): Add extra parameter to CreatePipeline struct
 
 ## PR checklist:
 - [ ] tests added
-- [x] examples of each function added to the relevant `examples/` folder (create if new)
+- [x] examples of each service action (List, Get etc) added to the relevant `examples/` folder (create if new)
 - [x] `CHANGELOG.md` updated with pending release information
 
 #### To ! or not to !

--- a/.github/NEW_FEATURE/release.md
+++ b/.github/NEW_FEATURE/release.md
@@ -1,0 +1,3 @@
+## Release checklist:
+- [ ] `CHANGELOG.md` updated 
+- [ ] `buildkite/version.go` update with release version number 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* Addition of issue/new feature/release templates, Codeowners [#148](https://github.com/buildkite/go-buildkite/pull/148) ([james2791](https://github.com/james2791))
 
 ## [v3.4.0](https://github.com/buildkite/go-buildkite/compare/v3.3.1...v3.4.0) (2023-08-10)
 * Support build.failing events [#141](https://github.com/buildkite/go-buildkite/pull/141) ([mcncl](https://github.com/mcncl))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## Unreleased
+
 ## [v3.4.0](https://github.com/buildkite/go-buildkite/compare/v3.3.1...v3.4.0) (2023-08-10)
 * Support build.failing events [#141](https://github.com/buildkite/go-buildkite/pull/141) ([mcncl](https://github.com/mcncl))
 * SUP-1314: Test Analytics Integration [#142](https://github.com/buildkite/go-buildkite/pull/142) ([james2791](https://github.com/james2791))


### PR DESCRIPTION
feat (GitHub): Addition of new feature/release/issue templates, Codeowners 

Each to look something like this (new feature):

## PR checklist:
- [x] tests added 
- [x] examples of each service action (List, Get etc) added to the relevant `examples/` folder (create if new)
- [x] `CHANGELOG.md` updated with pending release information
