### PR TITLE
SUP-1053: Ability to set `trigger_mode` for Pipelines with GitHub Enterprise ProviderSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 * Addition of issue/new feature/release templates, Codeowners [#148](https://github.com/buildkite/go-buildkite/pull/148) ([james2791](https://github.com/james2791))
 * Add tag fields to pipeline object [#147](https://github.com/buildkite/go-buildkite/pull/147) ([DeanBruntThirdfort](https://github.com/DeanBruntThirdfort))
+* SUP-1053: Ability to set `trigger_mode` for Pipelines with GitHub Enterprise ProviderSettings [#149](https://github.com/buildkite/go-buildkite/pull/149) ([james2791](https://github.com/james2791))
 
 ## [v3.4.0](https://github.com/buildkite/go-buildkite/compare/v3.3.1...v3.4.0) (2023-08-10)
 * Support build.failing events [#141](https://github.com/buildkite/go-buildkite/pull/141) ([mcncl](https://github.com/mcncl))

--- a/buildkite/providers.go
+++ b/buildkite/providers.go
@@ -94,6 +94,7 @@ func (s *GitHubSettings) isProviderSettings() {}
 
 // GitHubEnterpriseSettings are settings for pipelines building from GitHub Enterprise repositories.
 type GitHubEnterpriseSettings struct {
+	TriggerMode                             *string `json:"trigger_mode,omitempty" yaml:"trigger_mode,omitempty"`
 	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty" yaml:"build_pull_requests,omitempty"`
 	BuildBranches                           *bool   `json:"build_branches,omitempty" yaml:"build_branches,omitempty"`
 	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty" yaml:"pull_request_branch_filter_enabled,omitempty"`

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	debug    = kingpin.Flag("debug", "Enable debugging").Bool()
+)
+
+func main() {
+	kingpin.Parse()
+
+	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
+
+	if err != nil {
+		log.Fatalf("client config failed: %s", err)
+	}
+
+	client := buildkite.NewClient(config.Client())
+
+	createPipeline := buildkite.CreatePipeline{
+		Name: *buildkite.String("my-great-pipeline"),
+		Repository: *buildkite.String("git@github.com:my_great_org/my_great_repo2.git"),	
+		Configuration: *buildkite.String("env:\n \"FOO\": \"bar\"\nsteps:\n - command: \"script/release.sh\"\n   \"name\": \"Build 📦\""),
+		Tags: []string{"great", "pipeline"},
+		Description: *buildkite.String("This ia a great pipeline!"),
+		ProviderSettings: &buildkite.GitHubSettings{
+			TriggerMode:       buildkite.String("code"),
+		},
+	}
+
+	pipeline, _, err := client.Pipelines.Create(*org, &createPipeline)
+
+	if err != nil {
+		log.Fatalf("Updating pipeline failed: %s", err)
+	}
+
+	data, err := json.MarshalIndent(pipeline, "", "\t")
+
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -29,13 +29,13 @@ func main() {
 	client := buildkite.NewClient(config.Client())
 
 	createPipeline := buildkite.CreatePipeline{
-		Name: *buildkite.String("my-great-pipeline"),
-		Repository: *buildkite.String("git@github.com:my_great_org/my_great_repo2.git"),	
+		Name:          *buildkite.String("my-great-pipeline"),
+		Repository:    *buildkite.String("git@github.com:my_great_org/my_great_repo2.git"),
 		Configuration: *buildkite.String("env:\n \"FOO\": \"bar\"\nsteps:\n - command: \"script/release.sh\"\n   \"name\": \"Build 📦\""),
-		Tags: []string{"great", "pipeline"},
-		Description: *buildkite.String("This ia a great pipeline!"),
+		Tags:          []string{"great", "pipeline"},
+		Description:   *buildkite.String("This ia a great pipeline!"),
 		ProviderSettings: &buildkite.GitHubSettings{
-			TriggerMode:       buildkite.String("code"),
+			TriggerMode: buildkite.String("code"),
 		},
 	}
 


### PR DESCRIPTION
feat(Provider Settings): [Ability to set `trigger_mode` for pipelines using a repo on GHE]

## PR checklist:
- [x] tests added
- [x] examples of each service action (List, Get etc) added to the relevant `examples/` folder (create if new)
- [x] `CHANGELOG.md` updated with pending release information
