### PR TITLE
Stricter type for build metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * SUP-1353: Clusters integration [#154](https://github.com/buildkite/go-buildkite/pull/154) ([james2791](https://github.com/james2791))
 * SUP-1354: Cluster Queues integration [#156](https://github.com/buildkite/go-buildkite/pull/156) ([james2791](https://github.com/james2791))
 * SUP-1355: Cluster Tokens integration [#157](https://github.com/buildkite/go-buildkite/pull/157) ([james2791](https://github.com/james2791))
+* Stricter type for build meta_data [#155](https://github.com/buildkite/go-buildkite/pull/155) ([erichiggins0](https://github.com/erichiggins0))
 
 ## [v3.5.0](https://github.com/buildkite/go-buildkite/compare/v3.4.0...v3.5.0) (2023-09-01)
 * Addition of issue/new feature/release templates, Codeowners [#148](https://github.com/buildkite/go-buildkite/pull/148) ([james2791](https://github.com/james2791))

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -78,7 +78,7 @@ type Build struct {
 	ScheduledAt *Timestamp             `json:"scheduled_at,omitempty" yaml:"scheduled_at,omitempty"`
 	StartedAt   *Timestamp             `json:"started_at,omitempty" yaml:"started_at,omitempty"`
 	FinishedAt  *Timestamp             `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
-	MetaData    interface{}            `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
+	MetaData    map[string]string      `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
 	Creator     *Creator               `json:"creator,omitempty" yaml:"creator,omitempty"`
 	Source      *string                `json:"source,omitempty" yaml:"source,omitempty"`
 


### PR DESCRIPTION
As far as I can tell, build metadata is always a map with string keys and values.