### PR TITLE
SUP-1537: Annotations create endpoint interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+* SUP-1537: Annotations create endpoint interaction [#163](https://github.com/buildkite/go-buildkite/pull/163) ([james2791](https://github.com/james2791))
 
 ## [v3.7.0](https://github.com/buildkite/go-buildkite/compare/v3.6.0...v3.7.0) (2023-10-31)
 * Add support for `user_id` query string parameter when loading teams [#159](https://github.com/buildkite/go-buildkite/pull/159) ([mwgamble](https://github.com/mwgamble))

--- a/buildkite/annotations.go
+++ b/buildkite/annotations.go
@@ -60,9 +60,9 @@ func (as *AnnotationsService) ListByBuild(org string, pipeline string, build str
 	return *annotations, resp, err
 }
 
-func (as *AnnotationsService) Create(org, build string, ac *AnnotationCreate) (*Annotation, *Response, error) {
+func (as *AnnotationsService) Create(org, buildID string, ac *AnnotationCreate) (*Annotation, *Response, error) {
 
-	u := fmt.Sprintf("v2/organizations/%s/builds/%s/annotations", org, build)
+	u := fmt.Sprintf("v2/organizations/%s/builds/%s/annotations", org, buildID)
 
 	req, err := as.client.NewRequest("POST", u, ac)
 

--- a/buildkite/annotations.go
+++ b/buildkite/annotations.go
@@ -60,9 +60,9 @@ func (as *AnnotationsService) ListByBuild(org string, pipeline string, build str
 	return *annotations, resp, err
 }
 
-func (as *AnnotationsService) Create(org, buildID string, ac *AnnotationCreate) (*Annotation, *Response, error) {
+func (as *AnnotationsService) Create(org, pipeline, build string, ac *AnnotationCreate) (*Annotation, *Response, error) {
 
-	u := fmt.Sprintf("v2/organizations/%s/builds/%s/annotations", org, buildID)
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/annotations", org, pipeline, build)
 
 	req, err := as.client.NewRequest("POST", u, ac)
 

--- a/buildkite/annotations.go
+++ b/buildkite/annotations.go
@@ -23,10 +23,10 @@ type Annotation struct {
 }
 
 type AnnotationCreate struct {
-	Body	  *string	 `json:"body,omitempty" yaml:"body,omitempty"`
-	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
-	Style     *string    `json:"style,omitempty" yaml:"style,omitempty"`
-	Append	  *bool		 `json:"append,omitempty" yaml:"append,omitempty"`
+	Body    *string `json:"body,omitempty" yaml:"body,omitempty"`
+	Context *string `json:"context,omitempty" yaml:"context,omitempty"`
+	Style   *string `json:"style,omitempty" yaml:"style,omitempty"`
+	Append  *bool   `json:"append,omitempty" yaml:"append,omitempty"`
 }
 
 // AnnotationListOptions specifies the optional parameters to the

--- a/buildkite/annotations.go
+++ b/buildkite/annotations.go
@@ -22,6 +22,13 @@ type Annotation struct {
 	UpdatedAt *Timestamp `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 }
 
+type AnnotationCreate struct {
+	Body	  *string	 `json:"body,omitempty" yaml:"body,omitempty"`
+	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
+	Style     *string    `json:"style,omitempty" yaml:"style,omitempty"`
+	Append	  *bool		 `json:"append,omitempty" yaml:"append,omitempty"`
+}
+
 // AnnotationListOptions specifies the optional parameters to the
 // AnnoationsService.List method.
 type AnnotationListOptions struct {
@@ -51,4 +58,25 @@ func (as *AnnotationsService) ListByBuild(org string, pipeline string, build str
 		return nil, resp, err
 	}
 	return *annotations, resp, err
+}
+
+func (as *AnnotationsService) Create(org, build string, ac *AnnotationCreate) (*Annotation, *Response, error) {
+
+	u := fmt.Sprintf("v2/organizations/%s/builds/%s/annotations", org, build)
+
+	req, err := as.client.NewRequest("POST", u, ac)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	annotation := new(Annotation)
+
+	resp, err := as.client.Do(req, annotation)
+
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return annotation, resp, err
 }

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -72,7 +72,7 @@ func TestAnnotationsService_Create(t *testing.T) {
 		Append: 	 Bool(false),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/builds/1/annotations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/organizations/my-great-org/builds/4d8189ea-10eb-478d-8353-64d36a73f8fb/annotations", func(w http.ResponseWriter, r *http.Request) {
 		v := new(AnnotationCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -72,7 +72,7 @@ func TestAnnotationsService_Create(t *testing.T) {
 		Append: 	 Bool(false),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/builds/4d8189ea-10eb-478d-8353-64d36a73f8fb/annotations", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline/builds/10/annotations", func(w http.ResponseWriter, r *http.Request) {
 		v := new(AnnotationCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -94,7 +94,7 @@ func TestAnnotationsService_Create(t *testing.T) {
 			}`)
 	})
 
-	annotation, _, err := client.Annotations.Create("my-great-org", "4d8189ea-10eb-478d-8353-64d36a73f8fb", input)
+	annotation, _, err := client.Annotations.Create("my-great-org", "my-great-pipeline", "10", input)
 
 	if err != nil {
 		t.Errorf("TestAnnotations.Create returned error: %v", err)

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -66,10 +66,10 @@ func TestAnnotationsService_Create(t *testing.T) {
 	defer teardown()
 
 	input := &AnnotationCreate{
-		Style:       String("info"),
-		Context:   	 String("default"),
-		Body:        String("<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>"),
-		Append: 	 Bool(false),
+		Style:   String("info"),
+		Context: String("default"),
+		Body:    String("<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>"),
+		Append:  Bool(false),
 	}
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline/builds/10/annotations", func(w http.ResponseWriter, r *http.Request) {
@@ -116,6 +116,3 @@ func TestAnnotationsService_Create(t *testing.T) {
 		t.Errorf("TestAnnotations.Create returned %+v, want %+v", annotation, want)
 	}
 }
-
-
-

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -86,15 +86,15 @@ func TestAnnotationsService_Create(t *testing.T) {
 			`
 			{
 				"id": "68aef727-f754-48e1-aad8-5f5da8a9960c",
-				"context": "coverage",
+				"context": "default",
 				"style": "info",
-				"body_html": "Read the <a href=\"artifact://coverage/index.html\">uploaded coverage report</a>",
+				"body_html": "<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>",
 				"created_at": "2023-08-21T08:50:05.824Z",
-				"created_at": "2023-08-21T08:50:05.824Z",
+				"updated_at": "2023-08-21T08:50:05.824Z"
 			}`)
 	})
 
-	annotation, _, err := client.Annotations.Create("my-great-org", "1", input)
+	annotation, _, err := client.Annotations.Create("my-great-org", "4d8189ea-10eb-478d-8353-64d36a73f8fb", input)
 
 	if err != nil {
 		t.Errorf("TestAnnotations.Create returned error: %v", err)

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -59,3 +60,62 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 		t.Errorf("ListByBuild returned %+v, want %+v", annotations, want)
 	}
 }
+
+func TestAnnotationsService_Create(t *testing.T) {
+	setup()
+	defer teardown()
+
+	input := &AnnotationCreate{
+		Style:       String("info"),
+		Context:   	 String("default"),
+		Body:        String("<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>"),
+		Append: 	 Bool(false),
+	}
+
+	mux.HandleFunc("/v2/organizations/my-great-org/builds/1/annotations", func(w http.ResponseWriter, r *http.Request) {
+		v := new(AnnotationCreate)
+		json.NewDecoder(r.Body).Decode(&v)
+
+		testMethod(t, r, "POST")
+
+		if !reflect.DeepEqual(v, input) {
+			t.Errorf("Request body = %+v, want %+v", v, input)
+		}
+
+		fmt.Fprint(w,
+			`
+			{
+				"id": "68aef727-f754-48e1-aad8-5f5da8a9960c",
+				"context": "coverage",
+				"style": "info",
+				"body_html": "Read the <a href=\"artifact://coverage/index.html\">uploaded coverage report</a>",
+				"created_at": "2023-08-21T08:50:05.824Z",
+				"created_at": "2023-08-21T08:50:05.824Z",
+			}`)
+	})
+
+	annotation, _, err := client.Annotations.Create("my-great-org", "1", input)
+
+	if err != nil {
+		t.Errorf("TestAnnotations.Create returned error: %v", err)
+	}
+
+	annotationCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-21T08:50:05.824Z")
+	annotationUpatedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-21T08:50:05.824Z")
+
+	want := &Annotation{
+		ID:        String("68aef727-f754-48e1-aad8-5f5da8a9960c"),
+		Context:   String("default"),
+		Style:     String("info"),
+		BodyHTML:  String("<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>"),
+		CreatedAt: NewTimestamp(annotationCreatedAt),
+		UpdatedAt: NewTimestamp(annotationUpatedAt),
+	}
+
+	if !reflect.DeepEqual(annotation, want) {
+		t.Errorf("TestAnnotations.Create returned %+v, want %+v", annotation, want)
+	}
+}
+
+
+

--- a/buildkite/teams_test.go
+++ b/buildkite/teams_test.go
@@ -46,7 +46,7 @@ func TestTeamsService_ListForUser(t *testing.T) {
 	}
 
 	want := []Team{{ID: String("123")}}
-	if ! reflect.DeepEqual(teams, want) {
+	if !reflect.DeepEqual(teams, want) {
 		t.Errorf("Teams.List returned %+v, want %+v", teams, want)
 	}
 }

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -14,7 +14,8 @@ import (
 var (
 	apiToken  = kingpin.Flag("token", "API token").Required().String()
 	org       = kingpin.Flag("org", "Orginization slug").Required().String()
-	buildID   = kingpin.Flag("buildID", "Build UUID").Required().String()
+	slug      = kingpin.Flag("slug", "Pipeline slug").Required().String()
+	number    = kingpin.Flag("number", "Build number").Required().String()
 	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
@@ -36,10 +37,10 @@ func main() {
 		Append: 	 buildkite.Bool(false),
 	}
 
-	annotation, _, err := client.Annotations.Create(*org, *buildID, &annotationCreate)
+	annotation, _, err := client.Annotations.Create(*org, *slug, *number, &annotationCreate)
 
 	if err != nil {
-		log.Fatalf("Creating annotation failed: %s", err)
+		log.Fatalf("Listing annotations for build %s in pipeline %s failed: %s", *number, *slug, err)
 	}
 
 	data, err := json.MarshalIndent(annotation, "", "\t")

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -12,11 +12,11 @@ import (
 )
 
 var (
-	apiToken  = kingpin.Flag("token", "API token").Required().String()
-	org       = kingpin.Flag("org", "Orginization slug").Required().String()
-	slug      = kingpin.Flag("slug", "Pipeline slug").Required().String()
-	number    = kingpin.Flag("number", "Build number").Required().String()
-	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	slug     = kingpin.Flag("slug", "Pipeline slug").Required().String()
+	number   = kingpin.Flag("number", "Build number").Required().String()
+	debug    = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
 func main() {
@@ -31,10 +31,10 @@ func main() {
 	client := buildkite.NewClient(config.Client())
 
 	annotationCreate := buildkite.AnnotationCreate{
-		Style:       buildkite.String("info"),
-		Context:   	 buildkite.String("default"),
-		Body:        buildkite.String("An example annotation!"),
-		Append: 	 buildkite.Bool(false),
+		Style:   buildkite.String("info"),
+		Context: buildkite.String("default"),
+		Body:    buildkite.String("An example annotation!"),
+		Append:  buildkite.Bool(false),
 	}
 
 	annotation, _, err := client.Annotations.Create(*org, *slug, *number, &annotationCreate)

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	apiToken  = kingpin.Flag("token", "API token").Required().String()
+	org       = kingpin.Flag("org", "Orginization slug").Required().String()
+	buildID   = kingpin.Flag("buildID", "Build UUID").Required().String()
+	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
+)
+
+func main() {
+	kingpin.Parse()
+
+	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
+
+	if err != nil {
+		log.Fatalf("client config failed: %s", err)
+	}
+
+	client := buildkite.NewClient(config.Client())
+
+	annotationCreate := buildkite.AnnotationCreate{
+		Style:       buildkite.String("info"),
+		Context:   	 buildkite.String("default"),
+		Body:        buildkite.String("An example annotation!"),
+		Append: 	 buildkite.Bool(false),
+	}
+
+	annotation, _, err := client.Annotations.Create(*org, *buildID, &annotationCreate)
+
+	if err != nil {
+		log.Fatalf("Creating annotation failed: %s", err)
+	}
+
+	data, err := json.MarshalIndent(annotation, "", "\t")
+
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -15,7 +15,7 @@ var (
 	apiToken  = kingpin.Flag("token", "API token").Required().String()
 	org       = kingpin.Flag("org", "Orginization slug").Required().String()
 	slug      = kingpin.Flag("slug", "Pipeline slug").Required().String()
-	buildID   = kingpin.Flag("buildID", "Build UUID").Required().String()
+	number    = kingpin.Flag("number", "Build number").Required().String()
 	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
@@ -30,10 +30,10 @@ func main() {
 
 	client := buildkite.NewClient(config.Client())
 
-	annotations, _, err := client.Annotations.ListByBuild(*org, *slug, *buildID, nil)
+	annotations, _, err := client.Annotations.ListByBuild(*org, *slug, *number, nil)
 
 	if err != nil {
-		log.Fatalf("Listing annotations for build %s failed: %s", *buildID, err)
+		log.Fatalf("Listing annotations for build %s in pipeline %s failed: %s", *number, *slug, err)
 	}
 
 	data, err := json.MarshalIndent(annotations, "", "\t")

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v3/buildkite"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	apiToken  = kingpin.Flag("token", "API token").Required().String()
+	org       = kingpin.Flag("org", "Orginization slug").Required().String()
+	slug      = kingpin.Flag("slug", "Pipeline slug").Required().String()
+	buildID   = kingpin.Flag("buildID", "Build UUID").Required().String()
+	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
+)
+
+func main() {
+	kingpin.Parse()
+
+	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
+
+	if err != nil {
+		log.Fatalf("client config failed: %s", err)
+	}
+
+	client := buildkite.NewClient(config.Client())
+
+	annotations, _, err := client.Annotations.ListByBuild(*org, *slug, *buildID, nil)
+
+	if err != nil {
+		log.Fatalf("Listing annotations for build %s failed: %s", *buildID, err)
+	}
+
+	data, err := json.MarshalIndent(annotations, "", "\t")
+
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -12,11 +12,11 @@ import (
 )
 
 var (
-	apiToken  = kingpin.Flag("token", "API token").Required().String()
-	org       = kingpin.Flag("org", "Orginization slug").Required().String()
-	slug      = kingpin.Flag("slug", "Pipeline slug").Required().String()
-	number    = kingpin.Flag("number", "Build number").Required().String()
-	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	slug     = kingpin.Flag("slug", "Pipeline slug").Required().String()
+	number   = kingpin.Flag("number", "Build number").Required().String()
+	debug    = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
 func main() {


### PR DESCRIPTION
feat(Annotations): Adds support for interacting with Annotations `POST`/create REST API functionality

## PR checklist:
- [x] tests added
- [x] examples of each service action (List, Get etc) added to the relevant `examples/` folder (create if new)
- [x] `CHANGELOG.md` updated with pending release information

I also added `ListByBuild`/`create` examples to this PR, as we didnt have any annotation context examples (given now its two endpoints)
