### PR TITLE
Expose additional webhook fields on builds and jobs

### DIFF
--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -60,6 +60,12 @@ type PullRequest struct {
 	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
 }
 
+type TriggeredFrom struct {
+	BuildID           *string `json:"build_id,omitempty" yaml:"build_id,omitempty"`
+	BuildNumber       *int    `json:"build_number,omitempty" yaml:"build_number,omitempty"`
+	BuildPipelineSlug *string `json:"build_pipeline_slug,omitempty" yaml:"build_pipeline_slug,omitempty"`
+}
+
 // Build represents a build which has run in buildkite
 type Build struct {
 	ID          *string                `json:"id,omitempty" yaml:"id,omitempty"`
@@ -93,6 +99,10 @@ type Build struct {
 
 	// the pull request this build is associated with
 	PullRequest *PullRequest `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
+
+	// the build that this build is triggered from
+	// https://buildkite.com/docs/pipelines/trigger-step
+	TriggeredFrom *TriggeredFrom `json:"triggered_from,omitempty" yaml:"triggered_from,omitempty"`
 }
 
 type MetaDataFilters struct {

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -50,6 +50,7 @@ type Job struct {
 	ParallelGroupTotal *int            `json:"parallel_group_total,omitempty" yaml:"parallel_group_total,omitempty"`
 	ClusterID          *string         `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
 	ClusterQueueID     *string         `json:"cluster_queue_id,omitempty" yaml:"cluster_queue_id,omitempty"`
+	TriggeredBuild     *TriggeredBuild `json:"triggered_build,omitempty" yaml:"triggered_build,omitempty"`
 }
 
 // JobRetrySource represents what triggered this retry.
@@ -83,6 +84,13 @@ type JobLog struct {
 // JobEnvs represent job environments output
 type JobEnvs struct {
 	EnvironmentVariables *map[string]string `json:"env,string" yaml:"env,string"`
+}
+
+type TriggeredBuild struct {
+	ID     *string `json:"id,omitempty" yaml:"id,omitempty"`
+	Number *int    `json:"number,omitempty" yaml:"number,omitempty"`
+	URL    *string `json:"url,omitempty" yaml:"url,omitempty"`
+	WebURL *string `json:"web_url,omitempty" yaml:"web_url,omitempty"`
 }
 
 // UnblockJob - unblock a job


### PR DESCRIPTION
This is useful when deserializing json webhooks that have this data.