### PR TITLE
SUP-1681: Webhook event type definition for struct literal creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 * Expose retry_source and retry_type on jobs [#171](https://github.com/buildkite/go-buildkite/pull/171) ([drcapulet](https://github.com/drcapulet))
+* Expose additional webhook fields on builds and jobs [#173](https://github.com/buildkite/go-buildkite/pull/173) ([mstifflin](https://github.com/mstifflin))
+* SUP-1697 Add username to Author struct [#174](https://github.com/buildkite/go-buildkite/pull/174) ([lizrabuya](https://github.com/lizrabuya))
+* SUP-1681: Webhook event type definition for struct literal creation [#175](https://github.com/buildkite/go-buildkite/pull/175) ([james2791](https://github.com/james2791))
 
 ## [v3.10.0](https://github.com/buildkite/go-buildkite/compare/v3.9.0...v3.10.0) (2023-11-15)
 * cluster_tokens: expose token string [#168](https://github.com/buildkite/go-buildkite/pull/168) ([gmichelo](https://github.com/gmichelo))

--- a/buildkite/webhook_events.go
+++ b/buildkite/webhook_events.go
@@ -3,130 +3,103 @@ package buildkite
 // agentEvent is a wrapper for an agent event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentEvent struct {
-    Event  *string `json:"event"`
-    Agent  *Agent  `json:"agent"`
-    Sender *User   `json:"sender"`
+type agentEvent struct {
+	Event  *string `json:"event"`
+	Agent  *Agent  `json:"agent"`
+	Sender *User   `json:"sender"`
 }
 
 // AgentConnectedEvent is triggered when an agent has connected to the API
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentConnectedEvent struct {
-    AgentEvent *AgentEvent
-}
+type AgentConnectedEvent agentEvent
 
 // AgentDisconnectedEvent is triggered when an agent has disconnected.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentDisconnectedEvent struct {
-    AgentEvent *AgentEvent
-}
+type AgentDisconnectedEvent agentEvent
 
 // AgentLostEvent is triggered when an agent has been marked as lost.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentLostEvent struct {
-    AgentEvent *AgentEvent
-}
+type AgentLostEvent agentEvent
 
 // AgentStoppedEvent is triggered when an agent has stopped.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentStoppedEvent struct {
-    AgentEvent *AgentEvent
-}
+type AgentStoppedEvent agentEvent
 
 // AgentStoppingEvent is triggered when an agent is stopping.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentStoppingEvent struct {
-    AgentEvent *AgentEvent
-}
+type AgentStoppingEvent agentEvent
 
 // buildEvent is a wrapper for a build event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildEvent struct {
-    Event    *string   `json:"event"`
-    Build    *Build    `json:"build"`
-    Pipeline *Pipeline `json:"pipeline"`
-    Sender   *User     `json:"sender"`
+type buildEvent struct {
+	Event    *string   `json:"event"`
+	Build    *Build    `json:"build"`
+	Pipeline *Pipeline `json:"pipeline"`
+	Sender   *User     `json:"sender"`
 }
 
 // BuildFailingEvent is triggered when a build enters a failing state
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildFailingEvent struct {
-    BuildEvent *BuildEvent
-}
+type BuildFailingEvent buildEvent
 
 // BuildFinishedEvent is triggered when a build finishes
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildFinishedEvent struct {
-    BuildEvent *BuildEvent
-}
+type BuildFinishedEvent buildEvent
 
 // BuildRunningEvent is triggered when a build starts running
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildRunningEvent struct {
-    BuildEvent *BuildEvent
-}
+type BuildRunningEvent buildEvent
 
 // BuildScheduledEvent is triggered when a build is scheduled
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildScheduledEvent struct {
-    BuildEvent *BuildEvent
-}
+type BuildScheduledEvent buildEvent
 
 // jobEvent is a wrapper for a job event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobEvent struct {
-    Event    *string   `json:"event"`
-    Build    *Build    `json:"build"`
-    Job      *Job      `json:"job"`
-    Pipeline *Pipeline `json:"pipeline"`
-    Sender   *User     `json:"sender"`
+type jobEvent struct {
+	Event    *string   `json:"event"`
+	Build    *Build    `json:"build"`
+	Job      *Job      `json:"job"`
+	Pipeline *Pipeline `json:"pipeline"`
+	Sender   *User     `json:"sender"`
 }
 
 // JobActivatedEvent is triggered when a job is activated
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobActivatedEvent struct {
-    JobEvent *JobEvent
-}
+type JobActivatedEvent jobEvent
 
 // JobFinishedEvent is triggered when a job is finished
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobFinishedEvent struct {
-    JobEvent *JobEvent
-}
+type JobFinishedEvent jobEvent
 
 // JobScheduledEvent is triggered when a job is scheduled
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobScheduledEvent struct {
-    JobEvent *JobEvent
-}
+type JobScheduledEvent jobEvent
 
 // JobStartedEvent is triggered when a job is started
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobStartedEvent struct {
-    JobEvent *JobEvent
-}
+type JobStartedEvent jobEvent
 
 // PingEvent is triggered when a webhook notification setting is changed
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/ping-events
 type PingEvent struct {
-    Event        *string       `json:"event"`
-    Organization *Organization `json:"organization"`
-    Sender       *User         `json:"sender"`
+	Event        *string       `json:"event"`
+	Organization *Organization `json:"organization"`
+	Sender       *User         `json:"sender"`
 }
-

--- a/buildkite/webhook_events.go
+++ b/buildkite/webhook_events.go
@@ -3,7 +3,7 @@ package buildkite
 // agentEvent is a wrapper for an agent event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type agentEvent struct {
+type AgentEvent struct {
 	Event  *string `json:"event"`
 	Agent  *Agent  `json:"agent"`
 	Sender *User   `json:"sender"`
@@ -12,32 +12,42 @@ type agentEvent struct {
 // AgentConnectedEvent is triggered when an agent has connected to the API
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentConnectedEvent agentEvent
+type AgentConnectedEvent struct {
+	AgentEvent
+}
 
 // AgentDisconnectedEvent is triggered when an agent has disconnected.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentDisconnectedEvent agentEvent
+type AgentDisconnectedEvent struct {
+	AgentEvent
+}
 
 // AgentLostEvent is triggered when an agent has been marked as lost.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentLostEvent agentEvent
+type AgentLostEvent struct {
+	AgentEvent
+}
 
 // AgentStoppedEvent is triggered when an agent has stopped.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentStoppedEvent agentEvent
+type AgentStoppedEvent struct {
+	AgentEvent
+}
 
 // AgentStoppingEvent is triggered when an agent is stopping.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type AgentStoppingEvent agentEvent
+type AgentStoppingEvent struct {
+	AgentEvent
+}
 
 // buildEvent is a wrapper for a build event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type buildEvent struct {
+type BuildEvent struct {
 	Event    *string   `json:"event"`
 	Build    *Build    `json:"build"`
 	Pipeline *Pipeline `json:"pipeline"`
@@ -47,27 +57,35 @@ type buildEvent struct {
 // BuildFailingEvent is triggered when a build enters a failing state
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildFailingEvent buildEvent
+type BuildFailingEvent struct {
+	BuildEvent
+}
 
 // BuildFinishedEvent is triggered when a build finishes
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildFinishedEvent buildEvent
+type BuildFinishedEvent struct {
+	BuildEvent
+}
 
 // BuildRunningEvent is triggered when a build starts running
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildRunningEvent buildEvent
+type BuildRunningEvent struct {
+	BuildEvent
+}
 
 // BuildScheduledEvent is triggered when a build is scheduled
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type BuildScheduledEvent buildEvent
+type BuildScheduledEvent struct {
+	BuildEvent
+}
 
 // jobEvent is a wrapper for a job event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type jobEvent struct {
+type JobEvent struct {
 	Event    *string   `json:"event"`
 	Build    *Build    `json:"build"`
 	Job      *Job      `json:"job"`
@@ -78,22 +96,30 @@ type jobEvent struct {
 // JobActivatedEvent is triggered when a job is activated
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobActivatedEvent jobEvent
+type JobActivatedEvent struct {
+	JobEvent
+}
 
 // JobFinishedEvent is triggered when a job is finished
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobFinishedEvent jobEvent
+type JobFinishedEvent struct {
+	JobEvent
+}
 
 // JobScheduledEvent is triggered when a job is scheduled
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobScheduledEvent jobEvent
+type JobScheduledEvent struct {
+	JobEvent
+}
 
 // JobStartedEvent is triggered when a job is started
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type JobStartedEvent jobEvent
+type JobStartedEvent struct {
+	JobEvent
+}
 
 // PingEvent is triggered when a webhook notification setting is changed
 //

--- a/buildkite/webhook_events.go
+++ b/buildkite/webhook_events.go
@@ -3,129 +3,130 @@ package buildkite
 // agentEvent is a wrapper for an agent event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
-type agentEvent struct {
-	Event  *string `json:"event"`
-	Agent  *Agent  `json:"agent"`
-	Sender *User   `json:"sender"`
+type AgentEvent struct {
+    Event  *string `json:"event"`
+    Agent  *Agent  `json:"agent"`
+    Sender *User   `json:"sender"`
 }
 
 // AgentConnectedEvent is triggered when an agent has connected to the API
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
 type AgentConnectedEvent struct {
-	agentEvent
+    AgentEvent *AgentEvent
 }
 
 // AgentDisconnectedEvent is triggered when an agent has disconnected.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
 type AgentDisconnectedEvent struct {
-	agentEvent
+    AgentEvent *AgentEvent
 }
 
 // AgentLostEvent is triggered when an agent has been marked as lost.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
 type AgentLostEvent struct {
-	agentEvent
+    AgentEvent *AgentEvent
 }
 
 // AgentStoppedEvent is triggered when an agent has stopped.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
 type AgentStoppedEvent struct {
-	agentEvent
+    AgentEvent *AgentEvent
 }
 
 // AgentStoppingEvent is triggered when an agent is stopping.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
 type AgentStoppingEvent struct {
-	agentEvent
+    AgentEvent *AgentEvent
 }
 
 // buildEvent is a wrapper for a build event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
-type buildEvent struct {
-	Event    *string   `json:"event"`
-	Build    *Build    `json:"build"`
-	Pipeline *Pipeline `json:"pipeline"`
-	Sender   *User     `json:"sender"`
+type BuildEvent struct {
+    Event    *string   `json:"event"`
+    Build    *Build    `json:"build"`
+    Pipeline *Pipeline `json:"pipeline"`
+    Sender   *User     `json:"sender"`
 }
 
 // BuildFailingEvent is triggered when a build enters a failing state
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
 type BuildFailingEvent struct {
-	buildEvent
+    BuildEvent *BuildEvent
 }
 
 // BuildFinishedEvent is triggered when a build finishes
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
 type BuildFinishedEvent struct {
-	buildEvent
+    BuildEvent *BuildEvent
 }
 
 // BuildRunningEvent is triggered when a build starts running
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
 type BuildRunningEvent struct {
-	buildEvent
+    BuildEvent *BuildEvent
 }
 
 // BuildScheduledEvent is triggered when a build is scheduled
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
 type BuildScheduledEvent struct {
-	buildEvent
+    BuildEvent *BuildEvent
 }
 
 // jobEvent is a wrapper for a job event notification
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
-type jobEvent struct {
-	Event    *string   `json:"event"`
-	Build    *Build    `json:"build"`
-	Job      *Job      `json:"job"`
-	Pipeline *Pipeline `json:"pipeline"`
-	Sender   *User     `json:"sender"`
+type JobEvent struct {
+    Event    *string   `json:"event"`
+    Build    *Build    `json:"build"`
+    Job      *Job      `json:"job"`
+    Pipeline *Pipeline `json:"pipeline"`
+    Sender   *User     `json:"sender"`
 }
 
 // JobActivatedEvent is triggered when a job is activated
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
 type JobActivatedEvent struct {
-	jobEvent
+    JobEvent *JobEvent
 }
 
 // JobFinishedEvent is triggered when a job is finished
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
 type JobFinishedEvent struct {
-	jobEvent
+    JobEvent *JobEvent
 }
 
 // JobScheduledEvent is triggered when a job is scheduled
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
 type JobScheduledEvent struct {
-	jobEvent
+    JobEvent *JobEvent
 }
 
 // JobStartedEvent is triggered when a job is started
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
 type JobStartedEvent struct {
-	jobEvent
+    JobEvent *JobEvent
 }
 
 // PingEvent is triggered when a webhook notification setting is changed
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/ping-events
 type PingEvent struct {
-	Event        *string       `json:"event"`
-	Organization *Organization `json:"organization"`
-	Sender       *User         `json:"sender"`
+    Event        *string       `json:"event"`
+    Organization *Organization `json:"organization"`
+    Sender       *User         `json:"sender"`
 }
+


### PR DESCRIPTION
Feat (Webhook event types): Webhook event type definitions for allowing creation via struct literals

PR checklist:
- [ ] tests added -> (All pipeline template interaction with the REST API) -> *Tests consistent*
- [ ] examples of each service action (List, Get etc) added to the relevant `examples/` folder -> **No services altered**
- [x] `CHANGELOG.md` updated with pending release information

In previous version of Go-Buildkite; the `type`s of agent, build, job webhook events were created as structs without inner field exporting; meaning that instances of these types couldn't be created in a struct literal manner. A instance of the base type was required _first_ before adding its sub-fields:

```
jobFinishedEvent := buildkite.JobFinishedEvent{}
jobFinishedEvent.Pipeline = &buildkite.Pipeline{
	Name: buildkite.String("Android App"),
	... additional fields ...
}
```

This PR exports the inner types so that instances can be struct literal created while also keeping the above consuming model above in place - for example:

```
jobFinishedEvent := buildkite.JobFinishedEvent{
	JobEvent: buildkite.JobEvent{
		Pipeline: &buildkite.Pipeline{
			Name: buildkite.String("Android App"),
		},
		Build: ...
		Job: ...
	},
}
```

Addresses #170 