### PR TITLE
First cut of fetch test plan endpoint.

### DIFF
--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -57,7 +57,7 @@ type Client struct {
 	User              *UserService
 	Teams             *TeamsService
 	Tests             *TestsService
-	TestPlans					*TestPlansService
+	TestPlans         *TestPlansService
 	TestRuns          *TestRunsService
 	TestSuites        *TestSuitesService
 }

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -57,6 +57,7 @@ type Client struct {
 	User              *UserService
 	Teams             *TeamsService
 	Tests             *TestsService
+	TestPlans					*TestPlansService
 	TestRuns          *TestRunsService
 	TestSuites        *TestSuitesService
 }
@@ -97,6 +98,7 @@ func NewClient(httpClient *http.Client) *Client {
 	c.User = &UserService{c}
 	c.Teams = &TeamsService{c}
 	c.Tests = &TestsService{c}
+	c.TestPlans = &TestPlansService{c}
 	c.TestRuns = &TestRunsService{c}
 	c.TestSuites = &TestSuitesService{c}
 

--- a/buildkite/test_plans.go
+++ b/buildkite/test_plans.go
@@ -19,7 +19,6 @@ type Tests struct {
 type Task struct {
 	NodeNumber *int   `json:"node_number,omitempty" yaml:"node_number,omitempty"`
 	Tests      *Tests `json:"tests,omitempty" yaml:"tests,omitempty"`
-
 }
 
 type TestPlan struct {

--- a/buildkite/test_plans.go
+++ b/buildkite/test_plans.go
@@ -29,7 +29,6 @@ type TestPlan struct {
 
 func (tps *TestPlansService) Get(org, slug string, identifier string) (*TestPlan, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s", org, slug, identifier)
-	fmt.Printf(u)
 
 	req, err := tps.client.NewRequest("GET", u, nil)
 

--- a/buildkite/test_plans.go
+++ b/buildkite/test_plans.go
@@ -1,0 +1,50 @@
+package buildkite
+
+import "fmt"
+
+type TestPlansService struct {
+	client *Client
+}
+
+type Case struct {
+	Path              *string `json:"path,omitempty" yaml:"path,omitempty"`
+	EstimatedDuration *int `json:"estimated_duration,omitempty" yaml:"estimated_duration,omitempty"`
+}
+
+type Tests struct {
+	Format *string `json:"format,omitempty" yaml:"format,omitempty"`
+	Cases  []Case  `json:"cases,omitempty" yaml:"cases,omitempty"`
+}
+
+type Task struct {
+	NodeNumber *int   `json:"node_number,omitempty" yaml:"node_number,omitempty"`
+	Tests      *Tests `json:"tests,omitempty" yaml:"tests,omitempty"`
+
+}
+
+type TestPlan struct {
+	Identifier  *string `json:"identifier,omitempty" yaml:"identifier,omitempty"`
+	Parallelism *int    `json:"parallelism,omitempty" yaml:"paralellism,omitempty"`
+	Tasks       []Task  `json:"tasks,omitempty" yaml:"tasks,omitempty"`
+}
+
+func (tps *TestPlansService) Get(org, slug string, identifier string) (*TestPlan, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/test_plan?identifier=%s", org, slug, identifier)
+	fmt.Printf(u)
+
+	req, err := tps.client.NewRequest("GET", u, nil)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	testPlan := new(TestPlan)
+
+	resp, err := tps.client.Do(req, testPlan)
+
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return testPlan, resp, err
+}

--- a/buildkite/test_plans_test.go
+++ b/buildkite/test_plans_test.go
@@ -1,0 +1,98 @@
+package buildkite
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestTestPlansService_Get(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-1/test_plan", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w,
+			`
+			{
+				"identifier": "7c202aaa-3165-4811-9813-173c4c285463",
+			  "parallelism": 2,
+        "tasks": [
+          {
+            "node_number": 0,
+            "tests": {
+              "cases": [
+                {
+                  "path": "spec/models/apple_spec.rb",
+                  "estimated_duration": 1
+                },
+                {
+                  "path": "spec/models/pear_spec.rb",
+                  "estimated_duration": 2
+                }
+              ],
+              "format": "files"
+            }
+          },
+          {
+            "node_number": 1,
+            "tests": {
+              "cases": [
+                {
+                  "path": "spec/models/banana_spec.rb",
+                  "estimated_duration": 3
+                }
+              ],
+              "format": "files"
+            }
+          }
+        ]
+			}`)
+	})
+
+	suite, _, err := client.TestPlans.Get("my-great-org", "suite-1", "7c202aaa-3165-4811-9813-173c4c285463")
+
+	if err != nil {
+		t.Errorf("TestPlans.Get returned error: %v", err)
+	}
+
+	want := &TestPlan{
+		Identifier:    String("7c202aaa-3165-4811-9813-173c4c285463"),
+		Parallelism:   Int(2),
+    Tasks:         []Task{
+      {
+        NodeNumber: Int(0),
+        Tests: &Tests{
+          Format: String("files"),
+          Cases: []Case{
+            {
+              Path: String("spec/models/apple_spec.rb"),
+              EstimatedDuration: Int(1),
+            },
+            {
+              Path: String("spec/models/pear_spec.rb"),
+              EstimatedDuration: Int(2),
+            },
+          },
+        },
+      },
+      {
+        NodeNumber: Int(1),
+        Tests: &Tests{
+          Format: String("files"),
+          Cases: []Case{
+            {
+              Path: String("spec/models/banana_spec.rb"),
+              EstimatedDuration: Int(3),
+            },
+          },
+        },
+      },
+    },
+	}
+
+	if !reflect.DeepEqual(suite, want) {
+		t.Errorf("TestPlans.Get returned %+v, want %+v", suite, want)
+	}
+}


### PR DESCRIPTION
Here's a (probably) very rough cut of a new API endpoint for fetching TestPlans for test splitting. This endpoint is currently being hit by the [test-splitter](https://github.com/buildkite/test-splitter) itself, but I think it makes sense for the go bindings to grow support as well.

cc @nprizal and @amybiyuliu 