### PR TITLE
Deprecate authenticating roundtrippers, replace with new client constructor

### DIFF
--- a/buildkite/access_tokens_test.go
+++ b/buildkite/access_tokens_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAccessTokensService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +31,7 @@ func TestAccessTokensService_Get(t *testing.T) {
 }
 
 func TestAccessTokensService_Revoke(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/agents_test.go
+++ b/buildkite/agents_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAgentsService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +31,7 @@ func TestAgentsService_List(t *testing.T) {
 }
 
 func TestAgentsService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +51,7 @@ func TestAgentsService_Get(t *testing.T) {
 }
 
 func TestAgentsService_Create(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &Agent{Name: String("new_agent_bob")}
@@ -82,7 +82,7 @@ func TestAgentsService_Create(t *testing.T) {
 }
 
 func TestAgentsService_Delete(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
@@ -96,7 +96,7 @@ func TestAgentsService_Delete(t *testing.T) {
 }
 
 func TestAgentsService_Stop(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123/stop", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/agents_test.go
+++ b/buildkite/agents_test.go
@@ -3,7 +3,7 @@ package buildkite
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"reflect"
 	"strings"
@@ -101,7 +101,7 @@ func TestAgentsService_Stop(t *testing.T) {
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123/stop", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Errorf("could not read request body: %v", err)
 		}

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAnnotationsService_ListByBuild(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/annotations", func(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +62,7 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 }
 
 func TestAnnotationsService_Create(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &AnnotationCreate{

--- a/buildkite/auth.go
+++ b/buildkite/auth.go
@@ -7,6 +7,8 @@ import (
 )
 
 // TokenAuthTransport manages injection of the API token for each request
+//
+// Deprecated: Use NewOpts with the WithToken option instead.
 type TokenAuthTransport struct {
 	APIToken  string
 	APIHost   string
@@ -14,6 +16,8 @@ type TokenAuthTransport struct {
 }
 
 // RoundTrip invoked each time a request is made
+//
+// Deprecated: Use NewOpts with the WithToken option instead.
 func (t TokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.URL.Host == t.APIHost || t.APIHost == "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", t.APIToken))
@@ -22,6 +26,8 @@ func (t TokenAuthTransport) RoundTrip(req *http.Request) (*http.Response, error)
 }
 
 // Client builds a new http client.
+//
+// Deprecated: Use NewOpts with the WithToken option instead.
 func (t *TokenAuthTransport) Client() *http.Client {
 	return &http.Client{Transport: t}
 }
@@ -37,6 +43,8 @@ func (t *TokenAuthTransport) transport() http.RoundTripper {
 
 // NewTokenConfig configure authentication using an API token
 // NOTE: the debug flag is not used anymore.
+//
+// Deprecated: Use NewOpts with the WithToken option instead.
 func NewTokenConfig(apiToken string, debug bool) (*TokenAuthTransport, error) {
 	if apiToken == "" {
 		return nil, fmt.Errorf("Invalid token, empty string supplied")
@@ -45,6 +53,8 @@ func NewTokenConfig(apiToken string, debug bool) (*TokenAuthTransport, error) {
 }
 
 // BasicAuthTransport manages injection of the authorization header
+//
+// Deprecated: Use NewOpts with the WithBasicAuth option instead.
 type BasicAuthTransport struct {
 	APIHost  string
 	Username string
@@ -52,6 +62,8 @@ type BasicAuthTransport struct {
 }
 
 // RoundTrip invoked each time a request is made
+//
+// Deprecated: Use NewOpts with the WithBasicAuth option instead.
 func (bat BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.URL.Host == bat.APIHost || bat.APIHost == "" {
 		req.Header.Set("Authorization", fmt.Sprintf("Basic %s",
@@ -62,11 +74,15 @@ func (bat BasicAuthTransport) RoundTrip(req *http.Request) (*http.Response, erro
 }
 
 // Client builds a new http client.
+//
+// Deprecated: Use NewOpts with the WithBasicAuth option instead.
 func (bat *BasicAuthTransport) Client() *http.Client {
 	return &http.Client{Transport: bat}
 }
 
 // NewBasicConfig configure authentication using the supplied credentials
+//
+// Deprecated: Use NewOpts with the WithBasicAuth option instead.
 func NewBasicConfig(username string, password string) (*BasicAuthTransport, error) {
 	if username == "" {
 		return nil, fmt.Errorf("Invalid username, empty string supplied")

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -272,7 +271,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	resp := <-respCh
 
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body)
+	defer io.Copy(io.Discard, resp.Body)
 
 	response := newResponse(resp)
 
@@ -312,7 +311,7 @@ func checkResponse(r *http.Response) error {
 	if c := r.StatusCode; 200 <= c && c <= 299 {
 		return nil
 	}
-	data, err := ioutil.ReadAll(r.Body)
+	data, err := io.ReadAll(r.Body)
 	errorResponse := &ErrorResponse{Response: r, RawBody: data}
 	if err == nil && data != nil {
 		json.Unmarshal(data, errorResponse)

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -132,6 +132,8 @@ func NewOpts(opts ...clientOpt) (*Client, error) {
 
 // NewClient returns a new buildkite API client. As API calls require authentication
 // you MUST supply a client which provides the required API key.
+//
+// Deprecated: Use NewOpts instead.
 func NewClient(httpClient *http.Client) *Client {
 	baseURL, _ := url.Parse(defaultBaseURL)
 

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -58,16 +59,75 @@ type Client struct {
 	Tests             *TestsService
 	TestRuns          *TestRunsService
 	TestSuites        *TestSuitesService
+
+	authHeader string
 }
 
-// ListOptions specifies the optional parameters to various List methods that
-// support pagination.
-type ListOptions struct {
-	// For paginated result sets, page of results to retrieve.
-	Page int `url:"page,omitempty"`
+type clientOpt func(*Client) error
 
-	// For paginated result sets, the number of results to include per page.
-	PerPage int `url:"per_page,omitempty"`
+func WithHTTPClient(client *http.Client) clientOpt {
+	return func(c *Client) error {
+		c.client = client
+		return nil
+	}
+}
+
+func WithBaseURL(baseURL string) clientOpt {
+	return func(c *Client) error {
+		var err error
+		c.BaseURL, err = url.Parse(baseURL)
+		if err != nil {
+			return fmt.Errorf("failed to parse baseURL: %w", err)
+		}
+
+		return nil
+	}
+}
+
+func WithUserAgent(userAgent string) clientOpt {
+	return func(c *Client) error {
+		c.UserAgent = userAgent
+		return nil
+	}
+}
+
+func WithTokenAuth(token string) clientOpt {
+	return func(c *Client) error {
+		c.authHeader = fmt.Sprintf("Bearer %s", token)
+		return nil
+	}
+}
+
+func WithBasicAuth(username, password string) clientOpt {
+	return func(c *Client) error {
+		auth := fmt.Sprintf("%s:%s", username, password)
+		c.authHeader = "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
+		return nil
+	}
+}
+
+// NewOpts returns a new buildkite API client with the provided options.
+// Note that at least one of [WithTokenAuth] or [WithBasicAuth] must be provided.
+// Otherwise, sensible defaults are used.
+func NewOpts(opts ...clientOpt) (*Client, error) {
+	baseURL, _ := url.Parse(defaultBaseURL)
+
+	c := &Client{
+		client:    http.DefaultClient,
+		BaseURL:   baseURL,
+		UserAgent: userAgent,
+	}
+
+	for _, opt := range opts {
+		err := opt(c)
+		if err != nil {
+			return nil, fmt.Errorf("failed to apply client option: %w", err)
+		}
+	}
+
+	c.populateDefaultServices()
+
+	return c, nil
 }
 
 // NewClient returns a new buildkite API client. As API calls require authentication
@@ -80,6 +140,22 @@ func NewClient(httpClient *http.Client) *Client {
 		BaseURL:   baseURL,
 		UserAgent: userAgent,
 	}
+
+	c.populateDefaultServices()
+
+	if c.client != nil {
+		if tokenAuth, ok := c.client.Transport.(*TokenAuthTransport); ok {
+			tokenAuth.APIHost = baseURL.Host
+		}
+
+		if basicAuth, ok := c.client.Transport.(*BasicAuthTransport); ok {
+			basicAuth.APIHost = baseURL.Host
+		}
+	}
+	return c
+}
+
+func (c *Client) populateDefaultServices() {
 	c.AccessTokens = &AccessTokensService{c}
 	c.Agents = &AgentsService{c}
 	c.Annotations = &AnnotationsService{c}
@@ -98,17 +174,6 @@ func NewClient(httpClient *http.Client) *Client {
 	c.Tests = &TestsService{c}
 	c.TestRuns = &TestRunsService{c}
 	c.TestSuites = &TestSuitesService{c}
-
-	if c.client != nil {
-		if tokenAuth, ok := c.client.Transport.(*TokenAuthTransport); ok {
-			tokenAuth.APIHost = baseURL.Host
-		}
-
-		if basicAuth, ok := c.client.Transport.(*BasicAuthTransport); ok {
-			basicAuth.APIHost = baseURL.Host
-		}
-	}
-	return c
 }
 
 // SetHttpDebug this enables global http request/response dumping for this API
@@ -143,6 +208,10 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+
+	if c.authHeader != "" {
+		req.Header.Set("Authorization", c.authHeader)
+	}
 
 	if c.UserAgent != "" {
 		req.Header.Add("User-Agent", c.UserAgent)
@@ -362,4 +431,14 @@ func Bool(v bool) *bool {
 	p := new(bool)
 	*p = v
 	return p
+}
+
+// ListOptions specifies the optional parameters to various List methods that
+// support pagination.
+type ListOptions struct {
+	// For paginated result sets, page of results to retrieve.
+	Page int `url:"page,omitempty"`
+
+	// For paginated result sets, the number of results to include per page.
+	PerPage int `url:"per_page,omitempty"`
 }

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -24,15 +24,16 @@ var (
 // setup sets up a test HTTP server along with a buildkite.Client that is
 // configured to talk to that test server.  Tests should register handlers on
 // mux which provide mock responses for the API method being tested.
-func setup() {
+func setup(t *testing.T) {
 	// test server
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
-	// github client configured to use test server
-	client = NewClient(http.DefaultClient)
-	url, _ := url.Parse(server.URL)
-	client.BaseURL = url
+	var err error
+	client, err = NewOpts(WithBaseURL(server.URL))
+	if err != nil {
+		t.Fatalf("unexpected NewOpts() error: %v", err)
+	}
 }
 
 // teardown closes the test HTTP server.

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestBuildsService_Cancel(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/1/cancel", func(w http.ResponseWriter, r *http.Request) {
@@ -33,7 +33,7 @@ func TestBuildsService_Cancel(t *testing.T) {
 }
 
 func TestBuildsService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -59,7 +59,7 @@ func TestBuildsService_Get(t *testing.T) {
 	requestSlug := fmt.Sprintf("/v2/organizations/%s/pipelines/%s/builds/%s",
 		orgName, pipelineName, buildNumber)
 	t.Run("returns a build struct with expected id", func(t *testing.T) {
-		setup()
+		setup(t)
 		defer teardown()
 
 		mux.HandleFunc(requestSlug,
@@ -80,7 +80,7 @@ func TestBuildsService_Get(t *testing.T) {
 	})
 
 	t.Run("returns a build struct with expected job containing a group key", func(t *testing.T) {
-		setup()
+		setup(t)
 		defer teardown()
 
 		expectedGroup := "job_group"
@@ -105,7 +105,7 @@ func TestBuildsService_Get(t *testing.T) {
 	})
 
 	t.Run("returns a build struct with expected manual job values", func(t *testing.T) {
-		setup()
+		setup(t)
 		defer teardown()
 
 		jobType := "manual"
@@ -135,7 +135,7 @@ func TestBuildsService_Get(t *testing.T) {
 }
 
 func TestBuildsService_List_by_status(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -163,7 +163,7 @@ func TestBuildsService_List_by_status(t *testing.T) {
 }
 
 func TestBuildsService_List_by_multiple_status(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -192,7 +192,7 @@ func TestBuildsService_List_by_multiple_status(t *testing.T) {
 }
 
 func TestBuildsService_List_by_created_date(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	ts, err := time.Parse(BuildKiteDateFormat, "2016-03-24T01:00:00Z")
@@ -225,7 +225,7 @@ func TestBuildsService_List_by_created_date(t *testing.T) {
 }
 
 func TestBuildsService_ListByOrg(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -245,7 +245,7 @@ func TestBuildsService_ListByOrg(t *testing.T) {
 }
 
 func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -274,7 +274,7 @@ func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
 }
 
 func TestBuildsService_List_by_multiple_branches(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -301,7 +301,7 @@ func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 }
 
 func TestBuildsService_ListByPipeline(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -340,7 +340,7 @@ func TestBuildsUnmarshalWebhook(t *testing.T) {
 		"username": "foojim",
 		"name": "Uhh, Jim",
 		"email": "slam@space.jam"
-	  },	
+	  },
     "creator": {
       "id": "foo",
       "name": "Uhh, Jim",

--- a/buildkite/cluster_queues_test.go
+++ b/buildkite/cluster_queues_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestClusterQueuesService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
@@ -125,7 +125,7 @@ func TestClusterQueuesService_List(t *testing.T) {
 }
 
 func TestClusterQueuesService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140", func(w http.ResponseWriter, r *http.Request) {
@@ -204,7 +204,7 @@ func TestClusterQueuesService_Get(t *testing.T) {
 }
 
 func TestClusterQueuesService_Create(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &ClusterQueueCreate{
@@ -247,7 +247,7 @@ func TestClusterQueuesService_Create(t *testing.T) {
 }
 
 func TestClusterQueuesService_Update(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &ClusterQueueCreate{
@@ -320,7 +320,7 @@ func TestClusterQueuesService_Update(t *testing.T) {
 }
 
 func TestClusterQueuesService_Delete(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
@@ -335,7 +335,7 @@ func TestClusterQueuesService_Delete(t *testing.T) {
 }
 
 func TestClusterQueuesService_Pause(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &ClusterQueueCreate{
@@ -410,7 +410,7 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 }
 
 func TestClusterQueuesService_Resume(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/5cadac07-51dd-4e12-bea3-d91be4655c2f/resume_dispatch", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestClusterTokensService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
@@ -101,13 +101,13 @@ func TestClusterTokensService_List(t *testing.T) {
 }
 
 func TestClusterTokensService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
-			`	
+			`
 			{
 				"id": "38e8fdb0-52bf-4e73-ad82-ce93cfbaa724",
 				"graphql_id": "Q2x1c3RlclRva2VuLS0tMzhlOGZkYjAtNTJiZi00ZTczLWFkODItY2U5M2NmYmFhNzI0",
@@ -162,7 +162,7 @@ func TestClusterTokensService_Get(t *testing.T) {
 }
 
 func TestClusterTokensService_Create(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &ClusterTokenCreateUpdate{
@@ -202,7 +202,7 @@ func TestClusterTokensService_Create(t *testing.T) {
 }
 
 func TestClusterTokensService_Update(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &ClusterTokenCreateUpdate{
@@ -271,7 +271,7 @@ func TestClusterTokensService_Update(t *testing.T) {
 }
 
 func TestClusterTokensService_Delete(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestClustersService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
@@ -115,7 +115,7 @@ func TestClustersService_List(t *testing.T) {
 }
 
 func TestClustersService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0", func(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +182,7 @@ func TestClustersService_Get(t *testing.T) {
 }
 
 func TestClustersService_Create(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &ClusterCreate{
@@ -231,7 +231,7 @@ func TestClustersService_Create(t *testing.T) {
 }
 
 func TestClustersService_Update(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &ClusterCreate{
@@ -313,7 +313,7 @@ func TestClustersService_Update(t *testing.T) {
 }
 
 func TestClustersService_Delete(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/7d2aa9b5-bf2a-4ce0-b9d7-90d3d9b8942c", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/flaky_tests_test.go
+++ b/buildkite/flaky_tests_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestFlakyTestsService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/flaky-tests", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/jobs_test.go
+++ b/buildkite/jobs_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestJobsService_UnblockJob(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/unblock", func(w http.ResponseWriter, r *http.Request) {
@@ -32,7 +32,7 @@ func TestJobsService_UnblockJob(t *testing.T) {
 }
 
 func TestJobsService_RetryJob(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/retry", func(w http.ResponseWriter, r *http.Request) {
@@ -57,7 +57,7 @@ func TestJobsService_RetryJob(t *testing.T) {
 }
 
 func TestJobsService_GetJobLog(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/log", func(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +87,7 @@ func TestJobsService_GetJobLog(t *testing.T) {
 }
 
 func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	envVars := map[string]string{

--- a/buildkite/misc_test.go
+++ b/buildkite/misc_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestListEmojis(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/emojis", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/organizations_test.go
+++ b/buildkite/organizations_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestOrganizationsService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations", func(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +28,7 @@ func TestOrganizationsService_List(t *testing.T) {
 }
 
 func TestOrganizationsService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/babelstoemp", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/pipeline_templates_test.go
+++ b/buildkite/pipeline_templates_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPipelineTemplatesService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
@@ -133,7 +133,7 @@ func TestPipelineTemplatesService_List(t *testing.T) {
 }
 
 func TestPipelineTemplatesService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e", func(w http.ResponseWriter, r *http.Request) {
@@ -209,7 +209,7 @@ func TestPipelineTemplatesService_Get(t *testing.T) {
 }
 
 func TestPipelineTemplatesService_Create(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &PipelineTemplateCreateUpdate{
@@ -262,7 +262,7 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 }
 
 func TestPipelineTemplatesService_Update(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &PipelineTemplateCreateUpdate{
@@ -346,7 +346,7 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 }
 
 func TestPipelineTemplatesService_Delete(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/19dbd05a-96d7-430f-bac0-14b791558562", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestPipelinesService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +29,7 @@ func TestPipelinesService_List(t *testing.T) {
 }
 
 func TestPipelinesService_Create(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -121,7 +121,7 @@ func TestPipelinesService_Create(t *testing.T) {
 }
 
 func TestPipelinesService_CreateByConfiguration(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -188,7 +188,7 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 }
 
 func TestPipelinesService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
@@ -214,7 +214,7 @@ func TestPipelinesService_Get(t *testing.T) {
 }
 
 func TestPipelinesService_Delete(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
@@ -228,7 +228,7 @@ func TestPipelinesService_Delete(t *testing.T) {
 }
 
 func TestPipelinesService_Update(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -346,7 +346,7 @@ func TestPipelinesService_Update(t *testing.T) {
 }
 
 func TestPipelinesService_AddWebhook(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/webhook", func(w http.ResponseWriter, r *http.Request) {
@@ -360,7 +360,7 @@ func TestPipelinesService_AddWebhook(t *testing.T) {
 }
 
 func TestPipelinesService_Archive(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/archive", func(w http.ResponseWriter, r *http.Request) {
@@ -374,7 +374,7 @@ func TestPipelinesService_Archive(t *testing.T) {
 }
 
 func TestPipelinesService_Unarchive(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/unarchive", func(w http.ResponseWriter, r *http.Request) {
@@ -388,7 +388,7 @@ func TestPipelinesService_Unarchive(t *testing.T) {
 }
 
 func TestPluginsUnmarshal(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	for _, tc := range []struct {

--- a/buildkite/teams_test.go
+++ b/buildkite/teams_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTeamsService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +28,7 @@ func TestTeamsService_List(t *testing.T) {
 }
 
 func TestTeamsService_ListForUser(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/test_runs_test.go
+++ b/buildkite/test_runs_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTestRunsService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs", func(w http.ResponseWriter, r *http.Request) {
@@ -75,7 +75,7 @@ func TestTestRunsService_List(t *testing.T) {
 }
 
 func TestTestRunsService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/test_suites_test.go
+++ b/buildkite/test_suites_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestTestSuitesService_List(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +70,7 @@ func TestTestSuitesService_List(t *testing.T) {
 }
 
 func TestTestSuitesService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-1", func(w http.ResponseWriter, r *http.Request) {
@@ -110,7 +110,7 @@ func TestTestSuitesService_Get(t *testing.T) {
 }
 
 func TestTestSuitesService_Create(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &TestSuiteCreate{
@@ -155,7 +155,7 @@ func TestTestSuitesService_Create(t *testing.T) {
 }
 
 func TestTestSuitesService_Update(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	input := &TestSuiteCreate{
@@ -227,7 +227,7 @@ func TestTestSuitesService_Update(t *testing.T) {
 }
 
 func TestTestSuitesService_Delete(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-5", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/tests_test.go
+++ b/buildkite/tests_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestTestsService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/user_test.go
+++ b/buildkite/user_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestUserService_Get(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/v2/user", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/webhook.go
+++ b/buildkite/webhook.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -125,7 +125,7 @@ func getTimestampAndSignature(sig string) (timestamp string, signature []byte, e
 //
 // Example usage:
 func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err error) {
-	if payload, err = ioutil.ReadAll(r.Body); err != nil {
+	if payload, err = io.ReadAll(r.Body); err != nil {
 		return nil, err
 	}
 

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -22,13 +22,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	annotationCreate := buildkite.AnnotationCreate{
 		Style:   buildkite.String("info"),

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -22,13 +22,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	annotations, _, err := client.Annotations.ListByBuild(*org, *slug, *number, nil)
 

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -22,13 +22,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	artifacts, _, err := client.Artifacts.ListByBuild(*org, *pipeline, *build, nil)
 

--- a/examples/builds/get/main.go
+++ b/examples/builds/get/main.go
@@ -22,13 +22,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	build, _, err := client.Builds.Get(*org, *slug, *number, nil)
 

--- a/examples/cluster_queues/create/main.go
+++ b/examples/cluster_queues/create/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	clusterQueueCreate := buildkite.ClusterQueueCreate{
 		Key:         buildkite.String("dev1"),

--- a/examples/cluster_queues/delete/main.go
+++ b/examples/cluster_queues/delete/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	resp, err := client.ClusterQueues.Delete(*org, *clusterID, *queueID)
 

--- a/examples/cluster_queues/get/main.go
+++ b/examples/cluster_queues/get/main.go
@@ -22,13 +22,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	queue, _, err := client.ClusterQueues.Get(*org, *clusterID, *queueID)
 

--- a/examples/cluster_queues/list/main.go
+++ b/examples/cluster_queues/list/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	queues, _, err := client.ClusterQueues.List(*org, *clusterID, nil)
 

--- a/examples/cluster_queues/pause/main.go
+++ b/examples/cluster_queues/pause/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	clusterQueuePause := buildkite.ClusterQueuePause{
 		Note: buildkite.String("Pausing dispatch over the weekend"),

--- a/examples/cluster_queues/resume/main.go
+++ b/examples/cluster_queues/resume/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	resp, err := client.ClusterQueues.Resume(*org, *clusterID, *queueID)
 

--- a/examples/cluster_queues/update/main.go
+++ b/examples/cluster_queues/update/main.go
@@ -19,13 +19,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	clusterQueueUpdate := buildkite.ClusterQueueUpdate{
 		Description: buildkite.String("Development team cluster queue"),

--- a/examples/cluster_tokens/create/main.go
+++ b/examples/cluster_tokens/create/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	clusterTokenCreate := buildkite.ClusterTokenCreateUpdate{
 		Description: buildkite.String("Dev squad agent fleet token"),

--- a/examples/cluster_tokens/delete/main.go
+++ b/examples/cluster_tokens/delete/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	resp, err := client.ClusterTokens.Delete(*org, *clusterID, *tokenID)
 

--- a/examples/cluster_tokens/get/main.go
+++ b/examples/cluster_tokens/get/main.go
@@ -22,13 +22,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	token, _, err := client.ClusterTokens.Get(*org, *clusterID, *tokenID)
 

--- a/examples/cluster_tokens/list/main.go
+++ b/examples/cluster_tokens/list/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	tokens, _, err := client.ClusterTokens.List(*org, *clusterID, nil)
 

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	clusterTokenUpdate := buildkite.ClusterTokenCreateUpdate{
 		Description: buildkite.String("Dev squad agent token"),

--- a/examples/clusters/create/main.go
+++ b/examples/clusters/create/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	clusterCreate := buildkite.ClusterCreate{
 		Name:        "Development Cluster",

--- a/examples/clusters/delete/main.go
+++ b/examples/clusters/delete/main.go
@@ -19,13 +19,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	resp, err := client.Clusters.Delete(*org, *clusterID)
 

--- a/examples/clusters/get/main.go
+++ b/examples/clusters/get/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	cluster, _, err := client.Clusters.Get(*org, *clusterID)
 

--- a/examples/clusters/list/main.go
+++ b/examples/clusters/list/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	clusters, _, err := client.Clusters.List(*org, nil)
 

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -19,13 +19,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	clusterUpdate := buildkite.ClusterUpdate{
 		Description: buildkite.String("Development cluster"),

--- a/examples/flaky_tests/list/main.go
+++ b/examples/flaky_tests/list/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	flakyTests, _, err := client.FlakyTests.List(*org, *slug, nil)
 

--- a/examples/pipeline_templates/create/main.go
+++ b/examples/pipeline_templates/create/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	pipelineTemplateCreate := buildkite.PipelineTemplateCreateUpdate{
 		Name:          buildkite.String("Production Pipeline uploader"),

--- a/examples/pipeline_templates/delete/main.go
+++ b/examples/pipeline_templates/delete/main.go
@@ -19,13 +19,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	resp, err := client.PipelineTemplates.Delete(*org, *templateUUID)
 

--- a/examples/pipeline_templates/get/main.go
+++ b/examples/pipeline_templates/get/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	pipelineTemplate, _, err := client.PipelineTemplates.Get(*org, *templateUUID)
 

--- a/examples/pipeline_templates/list/main.go
+++ b/examples/pipeline_templates/list/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	pipelineTemplates, _, err := client.PipelineTemplates.List(*org, nil)
 

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -19,13 +19,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	pipelineTemplateUpdate := buildkite.PipelineTemplateCreateUpdate{
 		Description: buildkite.String("Production pipeline template uploader"),

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	createPipeline := buildkite.CreatePipeline{
 		Name:          *buildkite.String("my-great-pipeline"),

--- a/examples/pipelines/list/main.go
+++ b/examples/pipelines/list/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	pipelines, _, err := client.Pipelines.List(*org, nil)
 

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -18,13 +18,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	pipeline := buildkite.Pipeline{
 		Slug:        buildkite.String("my-great-repo"),

--- a/examples/test_runs/get/main.go
+++ b/examples/test_runs/get/main.go
@@ -22,13 +22,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	testRuns, _, err := client.TestRuns.Get(*org, *slug, *runID)
 

--- a/examples/test_runs/list/main.go
+++ b/examples/test_runs/list/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	testRuns, _, err := client.TestRuns.List(*org, *slug, nil)
 

--- a/examples/test_suites/create/main.go
+++ b/examples/test_suites/create/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	suiteCreate := buildkite.TestSuiteCreate{
 		Name:          "RSpec tests",

--- a/examples/test_suites/delete/main.go
+++ b/examples/test_suites/delete/main.go
@@ -19,13 +19,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	resp, err := client.TestSuites.Delete(*org, *slug)
 

--- a/examples/test_suites/get/main.go
+++ b/examples/test_suites/get/main.go
@@ -21,13 +21,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	suite, _, err := client.TestSuites.Get(*org, *slug)
 

--- a/examples/test_suites/list/main.go
+++ b/examples/test_suites/list/main.go
@@ -20,13 +20,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	suites, _, err := client.TestSuites.List(*org, nil)
 

--- a/examples/test_suites/update/main.go
+++ b/examples/test_suites/update/main.go
@@ -18,13 +18,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	suiteUpdate := buildkite.TestSuite{
 		DefaultBranch: buildkite.String("test"),

--- a/examples/tests/get/main.go
+++ b/examples/tests/get/main.go
@@ -22,13 +22,10 @@ var (
 func main() {
 	kingpin.Parse()
 
-	config, err := buildkite.NewTokenConfig(*apiToken, *debug)
-
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 	if err != nil {
-		log.Fatalf("client config failed: %s", err)
+		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
-
-	client := buildkite.NewClient(config.Client())
 
 	test, _, err := client.Tests.Get(*org, *slug, *testID)
 


### PR DESCRIPTION
Using RoundTrip to modify requests is [discouraged](https://pkg.go.dev/net/http#RoundTripper) by the go authors, and given that we control the full lifecycle of the request anyway, we can create a nicer interface for users of this package.

To wit, this commit deprecates the `buildkite.New` function, as well as the authenticating transports that it's used with - creating a client would usually look like:

```go
	config, err := buildkite.NewTokenConfig(apiToken, debug)
	if err != nil {
		return fmt.Errorf("client config failed: %w", err)
	}

	client := buildkite.NewClient(config.Client())
```

This commit adds a new constructor method for clients, `NewOpts`. It accepts options to configure both of our supported auth schemes:
```go
client := buildkite.NewOpts(buildkite.WithTokenAuth(token))
client = buildkite.NewOpts(buildkite.WithBasicAuth("shirley_dander", "hunter2"))
```

`NewOpts` also accepts options for configuring the http client it uses, the base URL it uses for requests, and the user agent it reports.