### PR TITLE
Test cleanups

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,26 @@
 steps:
-  - name: ":golang:"
-    command: make
+  - name: ":go::robot_face: Lint"
+    key: lint
+    command: .buildkite/steps/lint.sh
     plugins:
-      - docker-compose#ab65b07:
-          run: app
+      - docker#v5.9.0:
+          image: "golang:1.22"
+
+  - name: ":go::test_tube: Test"
+    key: test
+    command: ".buildkite/steps/test.sh"
+    artifact_paths: junit-*.xml
+    plugins:
+      - docker#v5.9.0:
+          image: "golang:1.22"
+          propagate-environment: true
+      - artifacts#v1.9.0:
+          upload: "cover.{html,out}"
+
+  - label: ":writing_hand: Annotate with Test Failures"
+    key: annotate
+    depends_on: test
+    allow_dependency_failure: true
+    plugins:
+      - junit-annotate#v1.6.0:
+          artifacts: junit-*.xml

--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -Eeufo pipefail
+
+echo --- :go: Checking go mod tidiness...
+go mod tidy
+if ! git diff --no-ext-diff --exit-code; then
+  echo ^^^ +++
+  echo "The go.mod or go.sum files are out of sync with the source code"
+  echo "Please run \`go mod tidy\` locally, and commit the result."
+
+  exit 1
+fi
+
+echo --- :go: Checking go formatting...
+go fmt ./...
+if ! git diff --no-ext-diff --exit-code; then
+  echo ^^^ +++
+  echo "Files have not been formatted with gofmt."
+  echo "Fix this by running \`go fmt ./...\` locally, and committing the result."
+
+  exit 1
+fi
+
+echo --- :go: Checking go vet...
+go vet ./...
+
+echo --- :go: Checking code generation...
+go generate ./...
+if ! git diff --no-ext-diff --exit-code; then
+  echo ^^^ +++
+  echo "Generated code is out of date."
+  echo "Please run \`go generate ./...\` locally, and commit the result."
+
+  exit 1
+fi
+
+
+echo +++ Everything is clean and tidy! 🎉

--- a/.buildkite/steps/test.sh
+++ b/.buildkite/steps/test.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+go install gotest.tools/gotestsum@v1.8.0
+
+echo '+++ Running tests'
+gotestsum --junitfile "junit-${BUILDKITE_JOB_ID}.xml" -- -count=1 -coverprofile=cover.out -failfast "$@" ./...
+
+echo 'Producing coverage report'
+go tool cover -html cover.out -o cover.html

--- a/buildkite/access_tokens_test.go
+++ b/buildkite/access_tokens_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestAccessTokensService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -32,7 +32,7 @@ func TestAccessTokensService_Get(t *testing.T) {
 
 func TestAccessTokensService_Revoke(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/buildkite/access_tokens_test.go
+++ b/buildkite/access_tokens_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestAccessTokensService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +33,9 @@ func TestAccessTokensService_Get(t *testing.T) {
 }
 
 func TestAccessTokensService_Revoke(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/agents_test.go
+++ b/buildkite/agents_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 func TestAgentsService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
@@ -31,7 +33,9 @@ func TestAgentsService_List(t *testing.T) {
 }
 
 func TestAgentsService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
@@ -51,7 +55,9 @@ func TestAgentsService_Get(t *testing.T) {
 }
 
 func TestAgentsService_Create(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &Agent{Name: String("new_agent_bob")}
@@ -82,7 +88,9 @@ func TestAgentsService_Create(t *testing.T) {
 }
 
 func TestAgentsService_Delete(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
@@ -96,7 +104,9 @@ func TestAgentsService_Delete(t *testing.T) {
 }
 
 func TestAgentsService_Stop(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123/stop", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/agents_test.go
+++ b/buildkite/agents_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestAgentsService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -32,7 +32,7 @@ func TestAgentsService_List(t *testing.T) {
 
 func TestAgentsService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -52,7 +52,7 @@ func TestAgentsService_Get(t *testing.T) {
 
 func TestAgentsService_Create(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &Agent{Name: String("new_agent_bob")}
 
@@ -83,7 +83,7 @@ func TestAgentsService_Create(t *testing.T) {
 
 func TestAgentsService_Delete(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -97,7 +97,7 @@ func TestAgentsService_Delete(t *testing.T) {
 
 func TestAgentsService_Stop(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/agents/123/stop", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestAnnotationsService_ListByBuild(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/annotations", func(w http.ResponseWriter, r *http.Request) {
@@ -62,7 +64,9 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 }
 
 func TestAnnotationsService_Create(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &AnnotationCreate{

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -100,8 +100,8 @@ func TestAnnotationsService_Create(t *testing.T) {
 		t.Errorf("TestAnnotations.Create returned error: %v", err)
 	}
 
-	annotationCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-21T08:50:05.824Z")
-	annotationUpatedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-21T08:50:05.824Z")
+	annotationCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-21T08:50:05.824Z"))
+	annotationUpatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-21T08:50:05.824Z"))
 
 	want := &Annotation{
 		ID:        String("68aef727-f754-48e1-aad8-5f5da8a9960c"),

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAnnotationsService_ListByBuild(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/annotations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -63,7 +63,7 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 
 func TestAnnotationsService_Create(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &AnnotationCreate{
 		Style:   String("info"),

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -27,6 +27,11 @@ var (
 func setup(t *testing.T) {
 	// test server
 	mux = http.NewServeMux()
+	// Fail test if unexpected request is received, "/" matches any request not matched by a more specific handler
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("unexpected %s request for %s", r.Method, r.URL.Path)
+	})
+
 	server = httptest.NewServer(mux)
 
 	var err error

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -10,40 +10,25 @@ import (
 	"testing"
 )
 
-var (
-	// mux is the HTTP request multiplexer used with the test server.
-	mux *http.ServeMux
-
-	// client is the buildkite client being tested.
-	client *Client
-
-	// server is a test HTTP server used to provide mock API responses.
-	server *httptest.Server
-)
-
-// setup sets up a test HTTP server along with a buildkite.Client that is
+// newMockServerAndClient sets up a test HTTP server along with a buildkite.Client that is
 // configured to talk to that test server.  Tests should register handlers on
 // mux which provide mock responses for the API method being tested.
-func setup(t *testing.T) {
+func newMockServerAndClient(t *testing.T) (*http.ServeMux, *Client, func()) {
 	// test server
-	mux = http.NewServeMux()
+	mux := http.NewServeMux()
 	// Fail test if unexpected request is received, "/" matches any request not matched by a more specific handler
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		t.Fatalf("unexpected %s request for %s", r.Method, r.URL.Path)
 	})
 
-	server = httptest.NewServer(mux)
+	server := httptest.NewServer(mux)
 
-	var err error
-	client, err = NewOpts(WithBaseURL(server.URL))
+	client, err := NewOpts(WithBaseURL(server.URL))
 	if err != nil {
 		t.Fatalf("unexpected NewOpts() error: %v", err)
 	}
-}
 
-// teardown closes the test HTTP server.
-func teardown() {
-	server.Close()
+	return mux, client, func() { server.Close() }
 }
 
 func testMethod(t *testing.T, r *http.Request, want string) {

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestBuildsService_Cancel(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/1/cancel", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -34,7 +34,7 @@ func TestBuildsService_Cancel(t *testing.T) {
 
 func TestBuildsService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -60,7 +60,7 @@ func TestBuildsService_Get(t *testing.T) {
 		orgName, pipelineName, buildNumber)
 	t.Run("returns a build struct with expected id", func(t *testing.T) {
 		setup(t)
-		defer teardown()
+		t.Cleanup(teardown)
 
 		mux.HandleFunc(requestSlug,
 			func(w http.ResponseWriter, r *http.Request) {
@@ -81,7 +81,7 @@ func TestBuildsService_Get(t *testing.T) {
 
 	t.Run("returns a build struct with expected job containing a group key", func(t *testing.T) {
 		setup(t)
-		defer teardown()
+		t.Cleanup(teardown)
 
 		expectedGroup := "job_group"
 		mux.HandleFunc(requestSlug,
@@ -106,7 +106,7 @@ func TestBuildsService_Get(t *testing.T) {
 
 	t.Run("returns a build struct with expected manual job values", func(t *testing.T) {
 		setup(t)
-		defer teardown()
+		t.Cleanup(teardown)
 
 		jobType := "manual"
 		unblockedAt := "2023-01-01T15:00:00.00Z"
@@ -136,7 +136,7 @@ func TestBuildsService_Get(t *testing.T) {
 
 func TestBuildsService_List_by_status(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -164,7 +164,7 @@ func TestBuildsService_List_by_status(t *testing.T) {
 
 func TestBuildsService_List_by_multiple_status(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -193,7 +193,7 @@ func TestBuildsService_List_by_multiple_status(t *testing.T) {
 
 func TestBuildsService_List_by_created_date(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	ts, err := time.Parse(BuildKiteDateFormat, "2016-03-24T01:00:00Z")
 	if err != nil {
@@ -226,7 +226,7 @@ func TestBuildsService_List_by_created_date(t *testing.T) {
 
 func TestBuildsService_ListByOrg(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -246,7 +246,7 @@ func TestBuildsService_ListByOrg(t *testing.T) {
 
 func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -275,7 +275,7 @@ func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
 
 func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -302,7 +302,7 @@ func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 
 func TestBuildsService_ListByPipeline(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestBuildsService_Cancel(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/1/cancel", func(w http.ResponseWriter, r *http.Request) {
@@ -33,7 +35,9 @@ func TestBuildsService_Cancel(t *testing.T) {
 }
 
 func TestBuildsService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -53,13 +57,17 @@ func TestBuildsService_List(t *testing.T) {
 }
 
 func TestBuildsService_Get(t *testing.T) {
+	t.Parallel()
+
 	buildNumber := "123"
 	orgName := "my-great-org"
 	pipelineName := "sup-keith"
 	requestSlug := fmt.Sprintf("/v2/organizations/%s/pipelines/%s/builds/%s",
 		orgName, pipelineName, buildNumber)
 	t.Run("returns a build struct with expected id", func(t *testing.T) {
-		setup(t)
+		t.Parallel()
+
+		mux, client, teardown := newMockServerAndClient(t)
 		t.Cleanup(teardown)
 
 		mux.HandleFunc(requestSlug,
@@ -80,7 +88,9 @@ func TestBuildsService_Get(t *testing.T) {
 	})
 
 	t.Run("returns a build struct with expected job containing a group key", func(t *testing.T) {
-		setup(t)
+		t.Parallel()
+
+		mux, client, teardown := newMockServerAndClient(t)
 		t.Cleanup(teardown)
 
 		expectedGroup := "job_group"
@@ -105,7 +115,9 @@ func TestBuildsService_Get(t *testing.T) {
 	})
 
 	t.Run("returns a build struct with expected manual job values", func(t *testing.T) {
-		setup(t)
+		t.Parallel()
+
+		mux, client, teardown := newMockServerAndClient(t)
 		t.Cleanup(teardown)
 
 		jobType := "manual"
@@ -135,7 +147,9 @@ func TestBuildsService_Get(t *testing.T) {
 }
 
 func TestBuildsService_List_by_status(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -163,7 +177,9 @@ func TestBuildsService_List_by_status(t *testing.T) {
 }
 
 func TestBuildsService_List_by_multiple_status(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -192,7 +208,9 @@ func TestBuildsService_List_by_multiple_status(t *testing.T) {
 }
 
 func TestBuildsService_List_by_created_date(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	ts, err := time.Parse(BuildKiteDateFormat, "2016-03-24T01:00:00Z")
@@ -225,7 +243,9 @@ func TestBuildsService_List_by_created_date(t *testing.T) {
 }
 
 func TestBuildsService_ListByOrg(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -245,7 +265,9 @@ func TestBuildsService_ListByOrg(t *testing.T) {
 }
 
 func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -274,7 +296,9 @@ func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
 }
 
 func TestBuildsService_List_by_multiple_branches(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
@@ -301,7 +325,9 @@ func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 }
 
 func TestBuildsService_ListByPipeline(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -110,7 +110,7 @@ func TestBuildsService_Get(t *testing.T) {
 
 		jobType := "manual"
 		unblockedAt := "2023-01-01T15:00:00.00Z"
-		parsedTime, err := time.Parse(BuildKiteDateFormat, unblockedAt)
+		parsedTime := must(time.Parse(BuildKiteDateFormat, unblockedAt))
 
 		mux.HandleFunc(requestSlug,
 			func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/cluster_queues_test.go
+++ b/buildkite/cluster_queues_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestClusterQueuesService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -126,7 +126,7 @@ func TestClusterQueuesService_List(t *testing.T) {
 
 func TestClusterQueuesService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -205,7 +205,7 @@ func TestClusterQueuesService_Get(t *testing.T) {
 
 func TestClusterQueuesService_Create(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
 		Key:         String("development1"),
@@ -248,7 +248,7 @@ func TestClusterQueuesService_Create(t *testing.T) {
 
 func TestClusterQueuesService_Update(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
 		Key:         String("development1"),
@@ -321,7 +321,7 @@ func TestClusterQueuesService_Update(t *testing.T) {
 
 func TestClusterQueuesService_Delete(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -336,7 +336,7 @@ func TestClusterQueuesService_Delete(t *testing.T) {
 
 func TestClusterQueuesService_Pause(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
 		Key:         String("development1"),
@@ -411,7 +411,7 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 
 func TestClusterQueuesService_Resume(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/5cadac07-51dd-4e12-bea3-d91be4655c2f/resume_dispatch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")

--- a/buildkite/cluster_queues_test.go
+++ b/buildkite/cluster_queues_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestClusterQueuesService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
@@ -125,7 +127,9 @@ func TestClusterQueuesService_List(t *testing.T) {
 }
 
 func TestClusterQueuesService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140", func(w http.ResponseWriter, r *http.Request) {
@@ -204,7 +208,9 @@ func TestClusterQueuesService_Get(t *testing.T) {
 }
 
 func TestClusterQueuesService_Create(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
@@ -247,7 +253,9 @@ func TestClusterQueuesService_Create(t *testing.T) {
 }
 
 func TestClusterQueuesService_Update(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
@@ -320,7 +328,9 @@ func TestClusterQueuesService_Update(t *testing.T) {
 }
 
 func TestClusterQueuesService_Delete(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
@@ -335,7 +345,9 @@ func TestClusterQueuesService_Delete(t *testing.T) {
 }
 
 func TestClusterQueuesService_Pause(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
@@ -410,7 +422,9 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 }
 
 func TestClusterQueuesService_Resume(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/5cadac07-51dd-4e12-bea3-d91be4655c2f/resume_dispatch", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/cluster_queues_test.go
+++ b/buildkite/cluster_queues_test.go
@@ -75,10 +75,10 @@ func TestClusterQueuesService_List(t *testing.T) {
 		t.Errorf("TestClusterQueues.List returned error: %v", err)
 	}
 
-	defaultQueueCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-06-06T15:02:08.951Z")
-	devQueueClusterCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-06-07T11:30:17.941Z")
-	devQueuePausedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-25T08:53:05.824Z")
-	userCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z")
+	defaultQueueCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-06-06T15:02:08.951Z"))
+	devQueueClusterCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-06-07T11:30:17.941Z"))
+	devQueuePausedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-25T08:53:05.824Z"))
+	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
 	clusterCreator := &ClusterCreator{
 		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
@@ -169,9 +169,9 @@ func TestClusterQueuesService_Get(t *testing.T) {
 		t.Errorf("TestClusterQueues.Get returned error: %v", err)
 	}
 
-	devQueueClusterCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-06-07T11:30:17.941Z")
-	devQueuePausedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-25T08:53:05.824Z")
-	userCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z")
+	devQueueClusterCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-06-07T11:30:17.941Z"))
+	devQueuePausedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-25T08:53:05.824Z"))
+	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
 	clusterCreator := &ClusterCreator{
 		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -60,9 +60,9 @@ func TestClusterTokensService_List(t *testing.T) {
 		t.Errorf("TestClusterTokens.List returned error: %v", err)
 	}
 
-	developmentTokenCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-06-07T08:01:02.951Z")
-	testTokenCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-06-07T08:05:00.755Z")
-	userCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z")
+	developmentTokenCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-06-07T08:01:02.951Z"))
+	testTokenCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-06-07T08:05:00.755Z"))
+	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
 	clusterCreator := &ClusterCreator{
 		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
@@ -133,8 +133,8 @@ func TestClusterTokensService_Get(t *testing.T) {
 		t.Errorf("TestClusterTokens.Get returned error: %v", err)
 	}
 
-	developmentTokenCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-06-07T08:01:02.951Z")
-	userCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z")
+	developmentTokenCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-06-07T08:01:02.951Z"))
+	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
 	clusterCreator := &ClusterCreator{
 		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestClusterTokensService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
@@ -101,7 +103,9 @@ func TestClusterTokensService_List(t *testing.T) {
 }
 
 func TestClusterTokensService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724", func(w http.ResponseWriter, r *http.Request) {
@@ -162,7 +166,9 @@ func TestClusterTokensService_Get(t *testing.T) {
 }
 
 func TestClusterTokensService_Create(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterTokenCreateUpdate{
@@ -202,7 +208,9 @@ func TestClusterTokensService_Create(t *testing.T) {
 }
 
 func TestClusterTokensService_Update(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterTokenCreateUpdate{
@@ -271,7 +279,9 @@ func TestClusterTokensService_Update(t *testing.T) {
 }
 
 func TestClusterTokensService_Delete(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestClusterTokensService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -102,7 +102,7 @@ func TestClusterTokensService_List(t *testing.T) {
 
 func TestClusterTokensService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -163,7 +163,7 @@ func TestClusterTokensService_Get(t *testing.T) {
 
 func TestClusterTokensService_Create(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &ClusterTokenCreateUpdate{
 		Description: String("Development 2 cluster token"),
@@ -203,7 +203,7 @@ func TestClusterTokensService_Create(t *testing.T) {
 
 func TestClusterTokensService_Update(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &ClusterTokenCreateUpdate{
 		Description: String("Development 1 Fleet Token"),
@@ -272,7 +272,7 @@ func TestClusterTokensService_Update(t *testing.T) {
 
 func TestClusterTokensService_Delete(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestClustersService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
@@ -115,7 +117,9 @@ func TestClustersService_List(t *testing.T) {
 }
 
 func TestClustersService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0", func(w http.ResponseWriter, r *http.Request) {
@@ -182,7 +186,9 @@ func TestClustersService_Get(t *testing.T) {
 }
 
 func TestClustersService_Create(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterCreate{
@@ -231,7 +237,9 @@ func TestClustersService_Create(t *testing.T) {
 }
 
 func TestClustersService_Update(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterCreate{
@@ -313,7 +321,9 @@ func TestClustersService_Update(t *testing.T) {
 }
 
 func TestClustersService_Delete(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/7d2aa9b5-bf2a-4ce0-b9d7-90d3d9b8942c", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestClustersService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -116,7 +116,7 @@ func TestClustersService_List(t *testing.T) {
 
 func TestClustersService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -183,7 +183,7 @@ func TestClustersService_Get(t *testing.T) {
 
 func TestClustersService_Create(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &ClusterCreate{
 		Name:        "Testing Cluster",
@@ -232,7 +232,7 @@ func TestClustersService_Create(t *testing.T) {
 
 func TestClustersService_Update(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &ClusterCreate{
 		Name:        "Testing Cluster",
@@ -314,7 +314,7 @@ func TestClustersService_Update(t *testing.T) {
 
 func TestClustersService_Delete(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/clusters/7d2aa9b5-bf2a-4ce0-b9d7-90d3d9b8942c", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -67,9 +67,9 @@ func TestClustersService_List(t *testing.T) {
 		t.Errorf("TestClusters.List returned error: %v", err)
 	}
 
-	devClusterCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-09-01T04:27:11.392Z")
-	prodClusterCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-09-04T04:25:55.751Z")
-	userCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z")
+	devClusterCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-09-01T04:27:11.392Z"))
+	prodClusterCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-09-04T04:25:55.751Z"))
+	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
 	clusterCreator := &ClusterCreator{
 		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
@@ -150,8 +150,8 @@ func TestClustersService_Get(t *testing.T) {
 		t.Errorf("TestClusters.Get returned error: %v", err)
 	}
 
-	devClusterCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-09-01T04:27:11.392Z")
-	userCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z")
+	devClusterCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-09-01T04:27:11.392Z"))
+	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
 	clusterCreator := &ClusterCreator{
 		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),

--- a/buildkite/flaky_tests.go
+++ b/buildkite/flaky_tests.go
@@ -18,7 +18,7 @@ type FlakyTest struct {
 	Location             *string    `json:"location,omitempty" yaml:"location,omitempty"`
 	FileName             *string    `json:"file_name,omitempty" yaml:"file_name,omitempty"`
 	Instances            *int       `json:"instances,omitempty" yaml:"instances,omitempty"`
-	MostRecentInstanceAt *Timestamp `json:"most_recent_instance_at,omitempty" yaml:"most_recent_instance_at,omitempty`
+	MostRecentInstanceAt *Timestamp `json:"most_recent_instance_at,omitempty" yaml:"most_recent_instance_at,omitempty"`
 }
 
 type FlakyTestsListOptions struct {

--- a/buildkite/flaky_tests_test.go
+++ b/buildkite/flaky_tests_test.go
@@ -47,8 +47,8 @@ func TestFlakyTestsService_List(t *testing.T) {
 	}
 
 	// Create Time instances from strings in BuildKiteDateFormat friendly format
-	parsedTime1, err := time.Parse(BuildKiteDateFormat, "2023-05-19T20:00:02.223Z")
-	parsedTime2, err := time.Parse(BuildKiteDateFormat, "2023-07-10T13:14:03.214Z")
+	parsedTime1 := must(time.Parse(BuildKiteDateFormat, "2023-05-19T20:00:02.223Z"))
+	parsedTime2 := must(time.Parse(BuildKiteDateFormat, "2023-07-10T13:14:03.214Z"))
 
 	if err != nil {
 		t.Errorf("TestSuites.List time.Parse error: %v", err)

--- a/buildkite/flaky_tests_test.go
+++ b/buildkite/flaky_tests_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestFlakyTestsService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/flaky-tests", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/flaky_tests_test.go
+++ b/buildkite/flaky_tests_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestFlakyTestsService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/flaky-tests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/buildkite/jobs_test.go
+++ b/buildkite/jobs_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestJobsService_UnblockJob(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/unblock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -33,7 +33,7 @@ func TestJobsService_UnblockJob(t *testing.T) {
 
 func TestJobsService_RetryJob(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/retry", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
@@ -58,7 +58,7 @@ func TestJobsService_RetryJob(t *testing.T) {
 
 func TestJobsService_GetJobLog(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/log", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -88,7 +88,7 @@ func TestJobsService_GetJobLog(t *testing.T) {
 
 func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	envVars := map[string]string{
 		"CI":                              "true",

--- a/buildkite/jobs_test.go
+++ b/buildkite/jobs_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestJobsService_UnblockJob(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/unblock", func(w http.ResponseWriter, r *http.Request) {
@@ -32,7 +34,9 @@ func TestJobsService_UnblockJob(t *testing.T) {
 }
 
 func TestJobsService_RetryJob(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/retry", func(w http.ResponseWriter, r *http.Request) {
@@ -57,7 +61,9 @@ func TestJobsService_RetryJob(t *testing.T) {
 }
 
 func TestJobsService_GetJobLog(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/log", func(w http.ResponseWriter, r *http.Request) {
@@ -87,7 +93,9 @@ func TestJobsService_GetJobLog(t *testing.T) {
 }
 
 func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	envVars := map[string]string{

--- a/buildkite/misc_test.go
+++ b/buildkite/misc_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestListEmojis(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/emojis", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/misc_test.go
+++ b/buildkite/misc_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestListEmojis(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/emojis", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/buildkite/organizations_test.go
+++ b/buildkite/organizations_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestOrganizationsService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations", func(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +30,9 @@ func TestOrganizationsService_List(t *testing.T) {
 }
 
 func TestOrganizationsService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/babelstoemp", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/organizations_test.go
+++ b/buildkite/organizations_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestOrganizationsService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -29,7 +29,7 @@ func TestOrganizationsService_List(t *testing.T) {
 
 func TestOrganizationsService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/babelstoemp", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/buildkite/pipeline_templates_test.go
+++ b/buildkite/pipeline_templates_test.go
@@ -10,7 +10,9 @@ import (
 )
 
 func TestPipelineTemplatesService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
@@ -133,7 +135,9 @@ func TestPipelineTemplatesService_List(t *testing.T) {
 }
 
 func TestPipelineTemplatesService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e", func(w http.ResponseWriter, r *http.Request) {
@@ -209,7 +213,9 @@ func TestPipelineTemplatesService_Get(t *testing.T) {
 }
 
 func TestPipelineTemplatesService_Create(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &PipelineTemplateCreateUpdate{
@@ -262,7 +268,9 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 }
 
 func TestPipelineTemplatesService_Update(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &PipelineTemplateCreateUpdate{
@@ -346,7 +354,9 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 }
 
 func TestPipelineTemplatesService_Delete(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/19dbd05a-96d7-430f-bac0-14b791558562", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/pipeline_templates_test.go
+++ b/buildkite/pipeline_templates_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestPipelineTemplatesService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -134,7 +134,7 @@ func TestPipelineTemplatesService_List(t *testing.T) {
 
 func TestPipelineTemplatesService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -210,7 +210,7 @@ func TestPipelineTemplatesService_Get(t *testing.T) {
 
 func TestPipelineTemplatesService_Create(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &PipelineTemplateCreateUpdate{
 		Name:          String("Production Pipeline uploader"),
@@ -263,7 +263,7 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 
 func TestPipelineTemplatesService_Update(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &PipelineTemplateCreateUpdate{
 		Name:          String("Production Pipeline uploader"),
@@ -347,7 +347,7 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 
 func TestPipelineTemplatesService_Delete(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/19dbd05a-96d7-430f-bac0-14b791558562", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/buildkite/pipeline_templates_test.go
+++ b/buildkite/pipeline_templates_test.go
@@ -83,9 +83,9 @@ func TestPipelineTemplatesService_List(t *testing.T) {
 		t.Errorf("TestPipelineTemplates.List returned error: %v", err)
 	}
 
-	basicTemplateCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-11T01:22:05.650Z")
-	devTemplateCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-11T02:24:33.602Z")
-	userCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z")
+	basicTemplateCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-11T01:22:05.650Z"))
+	devTemplateCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-11T02:24:33.602Z"))
+	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
 	pipelineTemplateCreator := &PipelineTemplateCreator{
 		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
@@ -176,8 +176,8 @@ func TestPipelineTemplatesService_Get(t *testing.T) {
 		t.Errorf("TestPipelineTemplates.Get returned error: %v", err)
 	}
 
-	basicTemplateCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-08-11T01:22:05.650Z")
-	userCreatedAt, err := time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z")
+	basicTemplateCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-11T01:22:05.650Z"))
+	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
 	pipelineTemplateCreator := &PipelineTemplateCreator{
 		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestPipelinesService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
@@ -29,7 +31,9 @@ func TestPipelinesService_List(t *testing.T) {
 }
 
 func TestPipelinesService_Create(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -121,7 +125,9 @@ func TestPipelinesService_Create(t *testing.T) {
 }
 
 func TestPipelinesService_CreateByConfiguration(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -188,7 +194,9 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 }
 
 func TestPipelinesService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
@@ -214,7 +222,9 @@ func TestPipelinesService_Get(t *testing.T) {
 }
 
 func TestPipelinesService_Delete(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
@@ -228,7 +238,9 @@ func TestPipelinesService_Delete(t *testing.T) {
 }
 
 func TestPipelinesService_Update(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -346,7 +358,9 @@ func TestPipelinesService_Update(t *testing.T) {
 }
 
 func TestPipelinesService_AddWebhook(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/webhook", func(w http.ResponseWriter, r *http.Request) {
@@ -360,7 +374,9 @@ func TestPipelinesService_AddWebhook(t *testing.T) {
 }
 
 func TestPipelinesService_Archive(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/archive", func(w http.ResponseWriter, r *http.Request) {
@@ -374,7 +390,9 @@ func TestPipelinesService_Archive(t *testing.T) {
 }
 
 func TestPipelinesService_Unarchive(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/unarchive", func(w http.ResponseWriter, r *http.Request) {
@@ -388,8 +406,7 @@ func TestPipelinesService_Unarchive(t *testing.T) {
 }
 
 func TestPluginsUnmarshal(t *testing.T) {
-	setup(t)
-	t.Cleanup(teardown)
+	t.Parallel()
 
 	for _, tc := range []struct {
 		name string
@@ -405,6 +422,8 @@ func TestPluginsUnmarshal(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			var plugins Plugins
 			err := json.Unmarshal([]byte(tc.json), &plugins)
 			if err != nil {

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPipelinesService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -30,7 +30,7 @@ func TestPipelinesService_List(t *testing.T) {
 
 func TestPipelinesService_Create(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
 		Repository: *String("my-great-repo"),
@@ -122,7 +122,7 @@ func TestPipelinesService_Create(t *testing.T) {
 
 func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
 		Repository:    *String("my-great-repo"),
@@ -189,7 +189,7 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 
 func TestPipelinesService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -215,7 +215,7 @@ func TestPipelinesService_Get(t *testing.T) {
 
 func TestPipelinesService_Delete(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
@@ -229,7 +229,7 @@ func TestPipelinesService_Delete(t *testing.T) {
 
 func TestPipelinesService_Update(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
 		Repository: *String("my-great-repo"),
@@ -347,7 +347,7 @@ func TestPipelinesService_Update(t *testing.T) {
 
 func TestPipelinesService_AddWebhook(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/webhook", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -361,7 +361,7 @@ func TestPipelinesService_AddWebhook(t *testing.T) {
 
 func TestPipelinesService_Archive(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -375,7 +375,7 @@ func TestPipelinesService_Archive(t *testing.T) {
 
 func TestPipelinesService_Unarchive(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/unarchive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
@@ -389,7 +389,7 @@ func TestPipelinesService_Unarchive(t *testing.T) {
 
 func TestPluginsUnmarshal(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	for _, tc := range []struct {
 		name string

--- a/buildkite/teams_test.go
+++ b/buildkite/teams_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestTeamsService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {
@@ -28,7 +30,9 @@ func TestTeamsService_List(t *testing.T) {
 }
 
 func TestTeamsService_ListForUser(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/teams_test.go
+++ b/buildkite/teams_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestTeamsService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -29,7 +29,7 @@ func TestTeamsService_List(t *testing.T) {
 
 func TestTeamsService_ListForUser(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/buildkite/test_helpers_test.go
+++ b/buildkite/test_helpers_test.go
@@ -1,0 +1,9 @@
+package buildkite
+
+func must[T any](val T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+
+	return val
+}

--- a/buildkite/test_runs.go
+++ b/buildkite/test_runs.go
@@ -16,7 +16,7 @@ type TestRun struct {
 	WebURL    *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
 	Branch    *string    `json:"branch,omitempty" yaml:"branch,omitempty"`
 	CommitSHA *string    `json:"commit_sha,omitempty" yaml:"commit_sha,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty`
+	CreatedAt *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 }
 
 type TestRunsListOptions struct {

--- a/buildkite/test_runs_test.go
+++ b/buildkite/test_runs_test.go
@@ -43,8 +43,8 @@ func TestTestRunsService_List(t *testing.T) {
 	}
 
 	// Create Time instances from strings in BuildKiteDateFormat friendly format
-	parsedTime1, err := time.Parse(BuildKiteDateFormat, "2023-05-20T10:25:50.264Z")
-	parsedTime2, err := time.Parse(BuildKiteDateFormat, "2023-05-20T10:52:22.254Z")
+	parsedTime1 := must(time.Parse(BuildKiteDateFormat, "2023-05-20T10:25:50.264Z"))
+	parsedTime2 := must(time.Parse(BuildKiteDateFormat, "2023-05-20T10:52:22.254Z"))
 
 	if err != nil {
 		t.Errorf("TestSuites.List time.Parse error: %v", err)

--- a/buildkite/test_runs_test.go
+++ b/buildkite/test_runs_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTestRunsService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -76,7 +76,7 @@ func TestTestRunsService_List(t *testing.T) {
 
 func TestTestRunsService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/buildkite/test_runs_test.go
+++ b/buildkite/test_runs_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestTestRunsService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs", func(w http.ResponseWriter, r *http.Request) {
@@ -75,7 +77,9 @@ func TestTestRunsService_List(t *testing.T) {
 }
 
 func TestTestRunsService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/test_suites_test.go
+++ b/buildkite/test_suites_test.go
@@ -9,7 +9,9 @@ import (
 )
 
 func TestTestSuitesService_List(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
@@ -70,7 +72,9 @@ func TestTestSuitesService_List(t *testing.T) {
 }
 
 func TestTestSuitesService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-1", func(w http.ResponseWriter, r *http.Request) {
@@ -110,7 +114,9 @@ func TestTestSuitesService_Get(t *testing.T) {
 }
 
 func TestTestSuitesService_Create(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &TestSuiteCreate{
@@ -155,7 +161,9 @@ func TestTestSuitesService_Create(t *testing.T) {
 }
 
 func TestTestSuitesService_Update(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &TestSuiteCreate{
@@ -227,7 +235,9 @@ func TestTestSuitesService_Update(t *testing.T) {
 }
 
 func TestTestSuitesService_Delete(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-5", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/test_suites_test.go
+++ b/buildkite/test_suites_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTestSuitesService_List(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -71,7 +71,7 @@ func TestTestSuitesService_List(t *testing.T) {
 
 func TestTestSuitesService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
@@ -111,7 +111,7 @@ func TestTestSuitesService_Get(t *testing.T) {
 
 func TestTestSuitesService_Create(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &TestSuiteCreate{
 		Name:          "Suite 3",
@@ -156,7 +156,7 @@ func TestTestSuitesService_Create(t *testing.T) {
 
 func TestTestSuitesService_Update(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	input := &TestSuiteCreate{
 		Name:          "Suite 4",
@@ -228,7 +228,7 @@ func TestTestSuitesService_Update(t *testing.T) {
 
 func TestTestSuitesService_Delete(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")

--- a/buildkite/tests_test.go
+++ b/buildkite/tests_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestTestsService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/buildkite/tests_test.go
+++ b/buildkite/tests_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestTestsService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f", func(w http.ResponseWriter, r *http.Request) {

--- a/buildkite/user_test.go
+++ b/buildkite/user_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUserService_Get(t *testing.T) {
 	setup(t)
-	defer teardown()
+	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/user", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")

--- a/buildkite/user_test.go
+++ b/buildkite/user_test.go
@@ -8,7 +8,9 @@ import (
 )
 
 func TestUserService_Get(t *testing.T) {
-	setup(t)
+	t.Parallel()
+
+	mux, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	mux.HandleFunc("/v2/user", func(w http.ResponseWriter, r *http.Request) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   app:
-    image: golang:1.20
+    image: golang:1.22
     volumes:
       - .:/work
     working_dir: /work

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/buildkite/go-buildkite/v3
 
-go 1.20
+go 1.22
 
 require (
 	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf


### PR DESCRIPTION
**This PR:** Makes a grab-bag of improvements to the testing of this library. Most notably, it updates the buildkite pipeline to include some basic linting, and splits the existing step up into two separate steps, but it also:
- Fixes some invalid struct tags
- Parallelises the tests (and makes each test case independent from one another by making them not share global vars)
- Updates to go 1.22
- Makes tests fail when an unexpected HTTP request is received by the test server
- Uses `t.Cleanup()` instead of `defer` in tests

**This PR is best reviewed commit-by-commit**