### PR TITLE
Add context parameters to all methods provided by this library

### DIFF
--- a/buildkite/access_tokens.go
+++ b/buildkite/access_tokens.go
@@ -1,6 +1,9 @@
 package buildkite
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 type AccessTokensService struct {
 	client *Client
@@ -14,13 +17,13 @@ type AccessToken struct {
 // Get gets the current token which was used to authenticate the request
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/access-token
-func (ats *AccessTokensService) Get() (*AccessToken, *Response, error) {
+func (ats *AccessTokensService) Get(ctx context.Context) (*AccessToken, *Response, error) {
 
 	var u string
 
 	u = fmt.Sprintf("v2/access-token")
 
-	req, err := ats.client.NewRequest("GET", u, nil)
+	req, err := ats.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -38,13 +41,13 @@ func (ats *AccessTokensService) Get() (*AccessToken, *Response, error) {
 // Revokes the current token which was used to authenticate the request
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/access-token
-func (ats *AccessTokensService) Revoke() (*Response, error) {
+func (ats *AccessTokensService) Revoke(ctx context.Context) (*Response, error) {
 
 	var u string
 
 	u = fmt.Sprintf("v2/access-token")
 
-	req, err := ats.client.NewRequest("DELETE", u, nil)
+	req, err := ats.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/access_tokens_test.go
+++ b/buildkite/access_tokens_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -18,7 +19,7 @@ func TestAccessTokensService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"uuid": "b63254c0-3271-4a98-8270-7cfbd6c2f14e","scopes": ["read_build"]}`)
 	})
 
-	ats, _, err := client.AccessTokens.Get()
+	ats, _, err := client.AccessTokens.Get(context.Background())
 	if err != nil {
 		t.Errorf("AccessTokens.Get returned error: %v", err)
 	}
@@ -43,7 +44,7 @@ func TestAccessTokensService_Revoke(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := client.AccessTokens.Revoke()
+	resp, err := client.AccessTokens.Revoke(context.Background())
 	if err != nil {
 		t.Errorf("AccessTokens.Revoke returned error: %v", err)
 	}

--- a/buildkite/agents.go
+++ b/buildkite/agents.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -54,7 +55,7 @@ type AgentListOptions struct {
 // List the agents for a given orginisation.
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#list-agents
-func (as *AgentsService) List(org string, opt *AgentListOptions) ([]Agent, *Response, error) {
+func (as *AgentsService) List(ctx context.Context, org string, opt *AgentListOptions) ([]Agent, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/agents", org)
@@ -64,7 +65,7 @@ func (as *AgentsService) List(org string, opt *AgentListOptions) ([]Agent, *Resp
 		return nil, nil, err
 	}
 
-	req, err := as.client.NewRequest("GET", u, nil)
+	req, err := as.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -81,11 +82,11 @@ func (as *AgentsService) List(org string, opt *AgentListOptions) ([]Agent, *Resp
 // Get fetches an agent.
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#get-an-agent
-func (as *AgentsService) Get(org string, id string) (*Agent, *Response, error) {
+func (as *AgentsService) Get(ctx context.Context, org string, id string) (*Agent, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/agents/%s", org, id)
 
-	req, err := as.client.NewRequest("GET", u, nil)
+	req, err := as.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,13 +103,13 @@ func (as *AgentsService) Get(org string, id string) (*Agent, *Response, error) {
 // Create a new buildkite agent.
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#create-an-agent
-func (as *AgentsService) Create(org string, agent *Agent) (*Agent, *Response, error) {
+func (as *AgentsService) Create(ctx context.Context, org string, agent *Agent) (*Agent, *Response, error) {
 
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/agents", org)
 
-	req, err := as.client.NewRequest("POST", u, agent)
+	req, err := as.client.NewRequest(ctx, "POST", u, agent)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,11 +126,11 @@ func (as *AgentsService) Create(org string, agent *Agent) (*Agent, *Response, er
 // Delete an agent.
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#delete-an-agent
-func (as *AgentsService) Delete(org string, id string) (*Response, error) {
+func (as *AgentsService) Delete(ctx context.Context, org string, id string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/agents/%s", org, id)
 
-	req, err := as.client.NewRequest("DELETE", u, nil)
+	req, err := as.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +141,7 @@ func (as *AgentsService) Delete(org string, id string) (*Response, error) {
 // Stop an agent.
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/agents#stop-an-agent
-func (as *AgentsService) Stop(org string, id string, force bool) (*Response, error) {
+func (as *AgentsService) Stop(ctx context.Context, org string, id string, force bool) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/agents/%s/stop", org, id)
 
@@ -148,7 +149,7 @@ func (as *AgentsService) Stop(org string, id string, force bool) (*Response, err
 		Force bool `json:"force"`
 	}{force}
 
-	req, err := as.client.NewRequest("PUT", u, body)
+	req, err := as.client.NewRequest(ctx, "PUT", u, body)
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/agents_test.go
+++ b/buildkite/agents_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -21,7 +22,7 @@ func TestAgentsService_List(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
 
-	agents, _, err := client.Agents.List("my-great-org", nil)
+	agents, _, err := client.Agents.List(context.Background(), "my-great-org", nil)
 	if err != nil {
 		t.Errorf("Agents.List returned error: %v", err)
 	}
@@ -43,7 +44,7 @@ func TestAgentsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id":"123"}`)
 	})
 
-	agent, _, err := client.Agents.Get("my-great-org", "123")
+	agent, _, err := client.Agents.Get(context.Background(), "my-great-org", "123")
 	if err != nil {
 		t.Errorf("Agents.Get returned error: %v", err)
 	}
@@ -75,7 +76,7 @@ func TestAgentsService_Create(t *testing.T) {
 		fmt.Fprint(w, `{"id":"123"}`)
 	})
 
-	agent, _, err := client.Agents.Create("my-great-org", input)
+	agent, _, err := client.Agents.Create(context.Background(), "my-great-org", input)
 	if err != nil {
 		t.Errorf("Agents.Create returned error: %v", err)
 	}
@@ -97,7 +98,7 @@ func TestAgentsService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Agents.Delete("my-great-org", "123")
+	_, err := client.Agents.Delete(context.Background(), "my-great-org", "123")
 	if err != nil {
 		t.Errorf("Agents.Delete returned error: %v", err)
 	}
@@ -122,7 +123,7 @@ func TestAgentsService_Stop(t *testing.T) {
 		}
 	})
 
-	_, err := client.Agents.Stop("my-great-org", "123", true)
+	_, err := client.Agents.Stop(context.Background(), "my-great-org", "123", true)
 	if err != nil {
 		t.Errorf("Agents.Stop returned error: %v", err)
 	}

--- a/buildkite/annotations.go
+++ b/buildkite/annotations.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -38,7 +39,7 @@ type AnnotationListOptions struct {
 // ListByBuild gets annotations for a specific build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/annotations#list-annotations-for-a-build
-func (as *AnnotationsService) ListByBuild(org string, pipeline string, build string, opt *AnnotationListOptions) ([]Annotation, *Response, error) {
+func (as *AnnotationsService) ListByBuild(ctx context.Context, org string, pipeline string, build string, opt *AnnotationListOptions) ([]Annotation, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/annotations", org, pipeline, build)
@@ -47,7 +48,7 @@ func (as *AnnotationsService) ListByBuild(org string, pipeline string, build str
 		return nil, nil, err
 	}
 
-	req, err := as.client.NewRequest("GET", u, nil)
+	req, err := as.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -60,11 +61,11 @@ func (as *AnnotationsService) ListByBuild(org string, pipeline string, build str
 	return *annotations, resp, err
 }
 
-func (as *AnnotationsService) Create(org, pipeline, build string, ac *AnnotationCreate) (*Annotation, *Response, error) {
+func (as *AnnotationsService) Create(ctx context.Context, org, pipeline, build string, ac *AnnotationCreate) (*Annotation, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/annotations", org, pipeline, build)
 
-	req, err := as.client.NewRequest("POST", u, ac)
+	req, err := as.client.NewRequest(ctx, "POST", u, ac)
 
 	if err != nil {
 		return nil, nil, err

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -35,7 +36,7 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 		}]`)
 	})
 
-	annotations, _, err := client.Annotations.ListByBuild("my-great-org", "sup-keith", "awesome-build", nil)
+	annotations, _, err := client.Annotations.ListByBuild(context.Background(), "my-great-org", "sup-keith", "awesome-build", nil)
 	if err != nil {
 		t.Errorf("ListByBuild returned error: %v", err)
 	}
@@ -98,7 +99,7 @@ func TestAnnotationsService_Create(t *testing.T) {
 			}`)
 	})
 
-	annotation, _, err := client.Annotations.Create("my-great-org", "my-great-pipeline", "10", input)
+	annotation, _, err := client.Annotations.Create(context.Background(), "my-great-org", "my-great-pipeline", "10", input)
 
 	if err != nil {
 		t.Errorf("TestAnnotations.Create returned error: %v", err)

--- a/buildkite/artifacts.go
+++ b/buildkite/artifacts.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"io"
 )
@@ -39,7 +40,7 @@ type ArtifactListOptions struct {
 // ListByBuild gets artifacts for a specific build
 //
 // buildkite API docs: https://buildkite.com/docs/api/artifacts#list-artifacts-for-a-build
-func (as *ArtifactsService) ListByBuild(org string, pipeline string, build string, opt *ArtifactListOptions) ([]Artifact, *Response, error) {
+func (as *ArtifactsService) ListByBuild(ctx context.Context, org string, pipeline string, build string, opt *ArtifactListOptions) ([]Artifact, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/artifacts", org, pipeline, build)
@@ -48,7 +49,7 @@ func (as *ArtifactsService) ListByBuild(org string, pipeline string, build strin
 		return nil, nil, err
 	}
 
-	req, err := as.client.NewRequest("GET", u, nil)
+	req, err := as.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -64,7 +65,7 @@ func (as *ArtifactsService) ListByBuild(org string, pipeline string, build strin
 // ListByJob gets artifacts for a specific build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/artifacts#list-artifacts-for-a-job
-func (as *ArtifactsService) ListByJob(org string, pipeline string, build string, job string, opt *ArtifactListOptions) ([]Artifact, *Response, error) {
+func (as *ArtifactsService) ListByJob(ctx context.Context, org string, pipeline string, build string, job string, opt *ArtifactListOptions) ([]Artifact, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/artifacts", org, pipeline, build, job)
@@ -73,7 +74,7 @@ func (as *ArtifactsService) ListByJob(org string, pipeline string, build string,
 		return nil, nil, err
 	}
 
-	req, err := as.client.NewRequest("GET", u, nil)
+	req, err := as.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -89,8 +90,8 @@ func (as *ArtifactsService) ListByJob(org string, pipeline string, build string,
 // DownloadArtifactByURL gets artifacts for a specific build
 //
 // buildkite API docs: https://buildkite.com/docs/api/artifacts#list-artifacts-for-a-build
-func (as *ArtifactsService) DownloadArtifactByURL(url string, w io.Writer) (*Response, error) {
-	req, err := as.client.NewRequest("GET", url, nil)
+func (as *ArtifactsService) DownloadArtifactByURL(ctx context.Context, url string, w io.Writer) (*Response, error) {
+	req, err := as.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -201,7 +202,7 @@ func SetHttpDebug(flag bool) {
 // Relative URLs should always be specified without a preceding slash.  If
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
-func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
 	rel, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, err
@@ -237,7 +238,7 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 		}
 	}
 
-	req, err := http.NewRequest(method, u.String(), buf)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), buf)
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/base64"
 	"io"
 	"net/http"
@@ -81,7 +82,7 @@ func TestNewRequest(t *testing.T) {
 	inBody := &User{ID: String("123"), Name: String("Jane Doe"), Email: String("jane@doe.com")}
 	outBody := `{"id":"123","name":"Jane Doe","email":"jane@doe.com"}` + "\n"
 
-	req, _ := c.NewRequest("GET", inURL, inBody)
+	req, _ := c.NewRequest(context.Background(), "GET", inURL, inBody)
 
 	// test that relative URL was expanded
 	if got, want := req.URL.String(), outURL; got != want {
@@ -112,7 +113,7 @@ func TestNewRequest_WhenBasicAuthIsConfigured_AddsBasicAuthToHeaders(t *testing.
 	}
 	encodedAuth := base64.StdEncoding.EncodeToString([]byte("shirley_dander:hunter2"))
 
-	req, _ := c.NewRequest("GET", "/foo", nil)
+	req, _ := c.NewRequest(context.Background(), "GET", "/foo", nil)
 
 	expectedAuthString := "Basic " + encodedAuth
 	if got, want := req.Header.Get("Authorization"), expectedAuthString; got != want {
@@ -125,7 +126,7 @@ func TestNewRequest_WhenTokenAuthIsConfigured_AddsBearerTokenToHeaders(t *testin
 	if err != nil {
 		t.Fatalf("unexpected NewOpts() error: %v", err)
 	}
-	req, _ := c.NewRequest("GET", "/foo", nil)
+	req, _ := c.NewRequest(context.Background(), "GET", "/foo", nil)
 
 	if got, want := req.Header.Get("Authorization"), "Bearer hunter2"; got != want {
 		t.Errorf("NewRequest() Authorization is %v, want %v", got, want)

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"time"
@@ -158,9 +159,9 @@ type BuildsListOptions struct {
 // Cancel - Trigger a cancel for the target build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/builds#cancel-a-build
-func (bs *BuildsService) Cancel(org, pipeline, build string) (*Build, error) {
+func (bs *BuildsService) Cancel(ctx context.Context, org, pipeline, build string) (*Build, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/cancel", org, pipeline, build)
-	req, err := bs.client.NewRequest("PUT", u, nil)
+	req, err := bs.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -175,10 +176,10 @@ func (bs *BuildsService) Cancel(org, pipeline, build string) (*Build, error) {
 // Create - Create a pipeline
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#create-a-build
-func (bs *BuildsService) Create(org string, pipeline string, b *CreateBuild) (*Build, *Response, error) {
+func (bs *BuildsService) Create(ctx context.Context, org string, pipeline string, b *CreateBuild) (*Build, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds", org, pipeline)
 
-	req, err := bs.client.NewRequest("POST", u, b)
+	req, err := bs.client.NewRequest(ctx, "POST", u, b)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -195,7 +196,7 @@ func (bs *BuildsService) Create(org string, pipeline string, b *CreateBuild) (*B
 // Get fetches a build.
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#get-a-build
-func (bs *BuildsService) Get(org string, pipeline string, id string, opt *BuildsListOptions) (*Build, *Response, error) {
+func (bs *BuildsService) Get(ctx context.Context, org string, pipeline string, id string, opt *BuildsListOptions) (*Build, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s", org, pipeline, id)
 
 	u, err := addOptions(u, opt)
@@ -203,7 +204,7 @@ func (bs *BuildsService) Get(org string, pipeline string, id string, opt *Builds
 		return nil, nil, err
 	}
 
-	req, err := bs.client.NewRequest("GET", u, nil)
+	req, err := bs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -220,7 +221,7 @@ func (bs *BuildsService) Get(org string, pipeline string, id string, opt *Builds
 // List the builds for the current user.
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#list-all-builds
-func (bs *BuildsService) List(opt *BuildsListOptions) ([]Build, *Response, error) {
+func (bs *BuildsService) List(ctx context.Context, opt *BuildsListOptions) ([]Build, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/builds")
@@ -230,7 +231,7 @@ func (bs *BuildsService) List(opt *BuildsListOptions) ([]Build, *Response, error
 		return nil, nil, err
 	}
 
-	req, err := bs.client.NewRequest("GET", u, nil)
+	req, err := bs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -247,7 +248,7 @@ func (bs *BuildsService) List(opt *BuildsListOptions) ([]Build, *Response, error
 // ListByOrg lists the builds within the specified orginisation.
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#list-builds-for-an-organization
-func (bs *BuildsService) ListByOrg(org string, opt *BuildsListOptions) ([]Build, *Response, error) {
+func (bs *BuildsService) ListByOrg(ctx context.Context, org string, opt *BuildsListOptions) ([]Build, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/builds", org)
@@ -257,7 +258,7 @@ func (bs *BuildsService) ListByOrg(org string, opt *BuildsListOptions) ([]Build,
 		return nil, nil, err
 	}
 
-	req, err := bs.client.NewRequest("GET", u, nil)
+	req, err := bs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -274,7 +275,7 @@ func (bs *BuildsService) ListByOrg(org string, opt *BuildsListOptions) ([]Build,
 // ListByPipeline lists the builds for a pipeline within the specified originisation.
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#list-builds-for-a-pipeline
-func (bs *BuildsService) ListByPipeline(org string, pipeline string, opt *BuildsListOptions) ([]Build, *Response, error) {
+func (bs *BuildsService) ListByPipeline(ctx context.Context, org string, pipeline string, opt *BuildsListOptions) ([]Build, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds", org, pipeline)
@@ -284,7 +285,7 @@ func (bs *BuildsService) ListByPipeline(org string, pipeline string, opt *Builds
 		return nil, nil, err
 	}
 
-	req, err := bs.client.NewRequest("GET", u, nil)
+	req, err := bs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -301,9 +302,9 @@ func (bs *BuildsService) ListByPipeline(org string, pipeline string, opt *Builds
 // Rebuild triggers a rebuild for the target build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/builds#rebuild-a-build
-func (bs *BuildsService) Rebuild(org, pipeline, build string) (*Build, error) {
+func (bs *BuildsService) Rebuild(ctx context.Context, org, pipeline, build string) (*Build, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/rebuild", org, pipeline, build)
-	req, err := bs.client.NewRequest("PUT", u, nil)
+	req, err := bs.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -23,7 +24,7 @@ func TestBuildsService_Cancel(t *testing.T) {
 }`)
 	})
 
-	build, err := client.Builds.Cancel("my-great-org", "sup-keith", "1")
+	build, err := client.Builds.Cancel(context.Background(), "my-great-org", "sup-keith", "1")
 	if err != nil {
 		t.Errorf("Cancel returned error: %v", err)
 	}
@@ -45,7 +46,7 @@ func TestBuildsService_List(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
 
-	builds, _, err := client.Builds.List(nil)
+	builds, _, err := client.Builds.List(context.Background(), nil)
 	if err != nil {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
@@ -76,7 +77,7 @@ func TestBuildsService_Get(t *testing.T) {
 				_, _ = fmt.Fprintf(w, `{"id":"%s"}`, buildNumber)
 			})
 
-		build, _, err := client.Builds.Get(orgName, pipelineName, buildNumber, nil)
+		build, _, err := client.Builds.Get(context.Background(), orgName, pipelineName, buildNumber, nil)
 		if err != nil {
 			t.Errorf("Builds.Get (expected id) returned error: %v", err)
 		}
@@ -103,7 +104,7 @@ func TestBuildsService_Get(t *testing.T) {
 				)
 			})
 
-		build, _, err := client.Builds.Get(orgName, pipelineName, buildNumber, nil)
+		build, _, err := client.Builds.Get(context.Background(), orgName, pipelineName, buildNumber, nil)
 		if err != nil {
 			t.Errorf("Builds.Get (group key) returned error: %v", err)
 		}
@@ -134,7 +135,7 @@ func TestBuildsService_Get(t *testing.T) {
 				)
 			})
 
-		build, _, err := client.Builds.Get(orgName, pipelineName, buildNumber, nil)
+		build, _, err := client.Builds.Get(context.Background(), orgName, pipelineName, buildNumber, nil)
 		if err != nil {
 			t.Errorf("Builds.Get (manual job) returned error: %v", err)
 		}
@@ -165,7 +166,7 @@ func TestBuildsService_List_by_status(t *testing.T) {
 		State:       []string{"running"},
 		ListOptions: ListOptions{Page: 2},
 	}
-	builds, _, err := client.Builds.List(opt)
+	builds, _, err := client.Builds.List(context.Background(), opt)
 	if err != nil {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
@@ -196,7 +197,7 @@ func TestBuildsService_List_by_multiple_status(t *testing.T) {
 		State:       []string{"running", "scheduled"},
 		ListOptions: ListOptions{Page: 2},
 	}
-	builds, _, err := client.Builds.List(opt)
+	builds, _, err := client.Builds.List(context.Background(), opt)
 	if err != nil {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
@@ -231,7 +232,7 @@ func TestBuildsService_List_by_created_date(t *testing.T) {
 		CreatedFrom: ts,
 		CreatedTo:   ts.Add(time.Hour),
 	}
-	builds, _, err := client.Builds.List(opt)
+	builds, _, err := client.Builds.List(context.Background(), opt)
 	if err != nil {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
@@ -253,7 +254,7 @@ func TestBuildsService_ListByOrg(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
 
-	builds, _, err := client.Builds.ListByOrg("my-great-org", nil)
+	builds, _, err := client.Builds.ListByOrg(context.Background(), "my-great-org", nil)
 	if err != nil {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
@@ -284,7 +285,7 @@ func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
 		Commit: "my-commit-sha1",
 	}
 
-	builds, _, err := client.Builds.ListByOrg("my-great-org", opt)
+	builds, _, err := client.Builds.ListByOrg(context.Background(), "my-great-org", opt)
 	if err != nil {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
@@ -313,7 +314,7 @@ func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 	opt := &BuildsListOptions{
 		Branch: []string{"my-great-branch", "my-other-great-branch"},
 	}
-	builds, _, err := client.Builds.List(opt)
+	builds, _, err := client.Builds.List(context.Background(), opt)
 	if err != nil {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
@@ -335,7 +336,7 @@ func TestBuildsService_ListByPipeline(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
 
-	builds, _, err := client.Builds.ListByPipeline("my-great-org", "sup-keith", nil)
+	builds, _, err := client.Builds.ListByPipeline(context.Background(), "my-great-org", "sup-keith", nil)
 	if err != nil {
 		t.Errorf("Builds.List returned error: %v", err)
 	}

--- a/buildkite/cluster_queues.go
+++ b/buildkite/cluster_queues.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 )
@@ -46,7 +47,7 @@ type ClusterQueuesListOptions struct {
 	ListOptions
 }
 
-func (cqs *ClusterQueuesService) List(org, clusterID string, opt *ClusterQueuesListOptions) ([]ClusterQueue, *Response, error) {
+func (cqs *ClusterQueuesService) List(ctx context.Context, org, clusterID string, opt *ClusterQueuesListOptions) ([]ClusterQueue, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues", org, clusterID)
 
@@ -56,7 +57,7 @@ func (cqs *ClusterQueuesService) List(org, clusterID string, opt *ClusterQueuesL
 		return nil, nil, err
 	}
 
-	req, err := cqs.client.NewRequest("GET", u, nil)
+	req, err := cqs.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -73,11 +74,11 @@ func (cqs *ClusterQueuesService) List(org, clusterID string, opt *ClusterQueuesL
 	return *queues, resp, err
 }
 
-func (cqs *ClusterQueuesService) Get(org, clusterID, queueID string) (*ClusterQueue, *Response, error) {
+func (cqs *ClusterQueuesService) Get(ctx context.Context, org, clusterID, queueID string) (*ClusterQueue, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s", org, clusterID, queueID)
 
-	req, err := cqs.client.NewRequest("GET", u, nil)
+	req, err := cqs.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -94,7 +95,7 @@ func (cqs *ClusterQueuesService) Get(org, clusterID, queueID string) (*ClusterQu
 	return queue, resp, err
 }
 
-func (cqs *ClusterQueuesService) Create(org, clusterID string, qc *ClusterQueueCreate) (*ClusterQueue, *Response, error) {
+func (cqs *ClusterQueuesService) Create(ctx context.Context, org, clusterID string, qc *ClusterQueueCreate) (*ClusterQueue, *Response, error) {
 
 	if qc == nil {
 		return nil, nil, errors.New("ClusterQueueCreate struct instance must not be nil")
@@ -102,7 +103,7 @@ func (cqs *ClusterQueuesService) Create(org, clusterID string, qc *ClusterQueueC
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues", org, clusterID)
 
-	req, err := cqs.client.NewRequest("POST", u, qc)
+	req, err := cqs.client.NewRequest(ctx, "POST", u, qc)
 
 	if err != nil {
 		return nil, nil, err
@@ -119,7 +120,7 @@ func (cqs *ClusterQueuesService) Create(org, clusterID string, qc *ClusterQueueC
 	return queue, resp, err
 }
 
-func (cqs *ClusterQueuesService) Update(org, clusterID, queueID string, qu *ClusterQueueUpdate) (*Response, error) {
+func (cqs *ClusterQueuesService) Update(ctx context.Context, org, clusterID, queueID string, qu *ClusterQueueUpdate) (*Response, error) {
 
 	if qu == nil {
 		return nil, errors.New("ClusterQueueUpdate struct instance must not be nil")
@@ -127,7 +128,7 @@ func (cqs *ClusterQueuesService) Update(org, clusterID, queueID string, qu *Clus
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s", org, clusterID, queueID)
 
-	req, err := cqs.client.NewRequest("PATCH", u, qu)
+	req, err := cqs.client.NewRequest(ctx, "PATCH", u, qu)
 
 	if err != nil {
 		return nil, err
@@ -142,11 +143,11 @@ func (cqs *ClusterQueuesService) Update(org, clusterID, queueID string, qu *Clus
 	return resp, err
 }
 
-func (cqs *ClusterQueuesService) Delete(org, clusterID, queueID string) (*Response, error) {
+func (cqs *ClusterQueuesService) Delete(ctx context.Context, org, clusterID, queueID string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s", org, clusterID, queueID)
 
-	req, err := cqs.client.NewRequest("DELETE", u, nil)
+	req, err := cqs.client.NewRequest(ctx, "DELETE", u, nil)
 
 	if err != nil {
 		return nil, err
@@ -155,7 +156,7 @@ func (cqs *ClusterQueuesService) Delete(org, clusterID, queueID string) (*Respon
 	return cqs.client.Do(req, nil)
 }
 
-func (cqs *ClusterQueuesService) Pause(org, clusterID, queueID string, qp *ClusterQueuePause) (*Response, error) {
+func (cqs *ClusterQueuesService) Pause(ctx context.Context, org, clusterID, queueID string, qp *ClusterQueuePause) (*Response, error) {
 
 	if qp == nil {
 		return nil, errors.New("ClusterQueuePause struct instance must not be nil")
@@ -163,7 +164,7 @@ func (cqs *ClusterQueuesService) Pause(org, clusterID, queueID string, qp *Clust
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s/pause_dispatch", org, clusterID, queueID)
 
-	req, err := cqs.client.NewRequest("POST", u, qp)
+	req, err := cqs.client.NewRequest(ctx, "POST", u, qp)
 
 	if err != nil {
 		return nil, err
@@ -172,11 +173,11 @@ func (cqs *ClusterQueuesService) Pause(org, clusterID, queueID string, qp *Clust
 	return cqs.client.Do(req, nil)
 }
 
-func (cqs *ClusterQueuesService) Resume(org, clusterID, queueID string) (*Response, error) {
+func (cqs *ClusterQueuesService) Resume(ctx context.Context, org, clusterID, queueID string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s/resume_dispatch", org, clusterID, queueID)
 
-	req, err := cqs.client.NewRequest("POST", u, nil)
+	req, err := cqs.client.NewRequest(ctx, "POST", u, nil)
 
 	if err != nil {
 		return nil, err

--- a/buildkite/cluster_queues_test.go
+++ b/buildkite/cluster_queues_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -71,7 +72,7 @@ func TestClusterQueuesService_List(t *testing.T) {
 			]`)
 	})
 
-	queues, _, err := client.ClusterQueues.List("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", nil)
+	queues, _, err := client.ClusterQueues.List(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", nil)
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.List returned error: %v", err)
@@ -167,7 +168,7 @@ func TestClusterQueuesService_Get(t *testing.T) {
 			}`)
 	})
 
-	queue, _, err := client.ClusterQueues.Get("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "46718bb6-3b2a-48da-9dcb-922c6b7ba140")
+	queue, _, err := client.ClusterQueues.Get(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "46718bb6-3b2a-48da-9dcb-922c6b7ba140")
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Get returned error: %v", err)
@@ -236,7 +237,7 @@ func TestClusterQueuesService_Create(t *testing.T) {
 			}`)
 	})
 
-	queue, _, err := client.ClusterQueues.Create("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
+	queue, _, err := client.ClusterQueues.Create(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Create returned error: %v", err)
@@ -282,7 +283,7 @@ func TestClusterQueuesService_Update(t *testing.T) {
 			}`)
 	})
 
-	queue, _, err := client.ClusterQueues.Create("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
+	queue, _, err := client.ClusterQueues.Create(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Update returned error: %v", err)
@@ -310,7 +311,7 @@ func TestClusterQueuesService_Update(t *testing.T) {
 		Description: String("Development 1 Team queue"),
 	}
 
-	_, err = client.ClusterQueues.Update("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "1374ffd0-c5ed-49a5-aebe-67ce906e68ca", &queueUpdate)
+	_, err = client.ClusterQueues.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "1374ffd0-c5ed-49a5-aebe-67ce906e68ca", &queueUpdate)
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Update returned error: %v", err)
@@ -337,7 +338,7 @@ func TestClusterQueuesService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.ClusterQueues.Delete("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "1374ffd0-c5ed-49a5-aebe-67ce906e68ca")
+	_, err := client.ClusterQueues.Delete(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "1374ffd0-c5ed-49a5-aebe-67ce906e68ca")
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Delete returned error: %v", err)
@@ -374,7 +375,7 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 			}`)
 	})
 
-	queue, _, err := client.ClusterQueues.Create("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
+	queue, _, err := client.ClusterQueues.Create(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Pause returned error: %v", err)
@@ -403,7 +404,7 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 		Note: String("Pausing dispatch for the weekend"),
 	}
 
-	_, err = client.ClusterQueues.Pause("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "5cadac07-51dd-4e12-bea3-d91be4655c2f", &queuePause)
+	_, err = client.ClusterQueues.Pause(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "5cadac07-51dd-4e12-bea3-d91be4655c2f", &queuePause)
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Pause returned error: %v", err)
@@ -431,7 +432,7 @@ func TestClusterQueuesService_Resume(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	_, err := client.ClusterQueues.Resume("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "5cadac07-51dd-4e12-bea3-d91be4655c2f")
+	_, err := client.ClusterQueues.Resume(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "5cadac07-51dd-4e12-bea3-d91be4655c2f")
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Resume returned error: %v", err)

--- a/buildkite/cluster_tokens.go
+++ b/buildkite/cluster_tokens.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 )
@@ -34,7 +35,7 @@ type ClusterTokensListOptions struct {
 	ListOptions
 }
 
-func (cts *ClusterTokensService) List(org, clusterID string, opt *ClusterTokensListOptions) ([]ClusterToken, *Response, error) {
+func (cts *ClusterTokensService) List(ctx context.Context, org, clusterID string, opt *ClusterTokensListOptions) ([]ClusterToken, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens", org, clusterID)
 
@@ -44,7 +45,7 @@ func (cts *ClusterTokensService) List(org, clusterID string, opt *ClusterTokensL
 		return nil, nil, err
 	}
 
-	req, err := cts.client.NewRequest("GET", u, nil)
+	req, err := cts.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -61,11 +62,11 @@ func (cts *ClusterTokensService) List(org, clusterID string, opt *ClusterTokensL
 	return *tokens, resp, err
 }
 
-func (cts *ClusterTokensService) Get(org, clusterID, tokenID string) (*ClusterToken, *Response, error) {
+func (cts *ClusterTokensService) Get(ctx context.Context, org, clusterID, tokenID string) (*ClusterToken, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens/%s", org, clusterID, tokenID)
 
-	req, err := cts.client.NewRequest("GET", u, nil)
+	req, err := cts.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -82,7 +83,7 @@ func (cts *ClusterTokensService) Get(org, clusterID, tokenID string) (*ClusterTo
 	return token, resp, err
 }
 
-func (cts *ClusterTokensService) Create(org, clusterID string, ctc *ClusterTokenCreateUpdate) (*ClusterToken, *Response, error) {
+func (cts *ClusterTokensService) Create(ctx context.Context, org, clusterID string, ctc *ClusterTokenCreateUpdate) (*ClusterToken, *Response, error) {
 
 	if ctc == nil {
 		return nil, nil, errors.New("ClusterTokenCreateUpdate struct instance must not be nil")
@@ -90,7 +91,7 @@ func (cts *ClusterTokensService) Create(org, clusterID string, ctc *ClusterToken
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens", org, clusterID)
 
-	req, err := cts.client.NewRequest("POST", u, ctc)
+	req, err := cts.client.NewRequest(ctx, "POST", u, ctc)
 
 	if err != nil {
 		return nil, nil, err
@@ -107,7 +108,7 @@ func (cts *ClusterTokensService) Create(org, clusterID string, ctc *ClusterToken
 	return token, resp, err
 }
 
-func (cts *ClusterTokensService) Update(org, clusterID, tokenID string, ctc *ClusterTokenCreateUpdate) (*Response, error) {
+func (cts *ClusterTokensService) Update(ctx context.Context, org, clusterID, tokenID string, ctc *ClusterTokenCreateUpdate) (*Response, error) {
 
 	if ctc == nil {
 		return nil, errors.New("ClusterTokenCreateUpdate struct instance must not be nil")
@@ -115,7 +116,7 @@ func (cts *ClusterTokensService) Update(org, clusterID, tokenID string, ctc *Clu
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens/%s", org, clusterID, tokenID)
 
-	req, err := cts.client.NewRequest("PATCH", u, ctc)
+	req, err := cts.client.NewRequest(ctx, "PATCH", u, ctc)
 
 	if err != nil {
 		return nil, err
@@ -130,11 +131,11 @@ func (cts *ClusterTokensService) Update(org, clusterID, tokenID string, ctc *Clu
 	return resp, err
 }
 
-func (cts *ClusterTokensService) Delete(org, clusterID, tokenID string) (*Response, error) {
+func (cts *ClusterTokensService) Delete(ctx context.Context, org, clusterID, tokenID string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens/%s", org, clusterID, tokenID)
 
-	req, err := cts.client.NewRequest("DELETE", u, nil)
+	req, err := cts.client.NewRequest(ctx, "DELETE", u, nil)
 
 	if err != nil {
 		return nil, err

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -56,7 +57,7 @@ func TestClusterTokensService_List(t *testing.T) {
 			]`)
 	})
 
-	tokens, _, err := client.ClusterTokens.List("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", nil)
+	tokens, _, err := client.ClusterTokens.List(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", nil)
 
 	if err != nil {
 		t.Errorf("TestClusterTokens.List returned error: %v", err)
@@ -131,7 +132,7 @@ func TestClusterTokensService_Get(t *testing.T) {
 			}`)
 	})
 
-	token, _, err := client.ClusterTokens.Get("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "38e8fdb0-52bf-4e73-ad82-ce93cfbaa724")
+	token, _, err := client.ClusterTokens.Get(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "38e8fdb0-52bf-4e73-ad82-ce93cfbaa724")
 
 	if err != nil {
 		t.Errorf("TestClusterTokens.Get returned error: %v", err)
@@ -192,7 +193,7 @@ func TestClusterTokensService_Create(t *testing.T) {
 			}`)
 	})
 
-	token, _, err := client.ClusterTokens.Create("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
+	token, _, err := client.ClusterTokens.Create(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
 
 	if err != nil {
 		t.Errorf("TestClusterTokens.Create returned error: %v", err)
@@ -235,7 +236,7 @@ func TestClusterTokensService_Update(t *testing.T) {
 			}`)
 	})
 
-	token, _, err := client.ClusterTokens.Create("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
+	token, _, err := client.ClusterTokens.Create(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
 
 	if err != nil {
 		t.Errorf("TestClusterTokens.Update returned error: %v", err)
@@ -262,7 +263,7 @@ func TestClusterTokensService_Update(t *testing.T) {
 		Description: String("Development 1 agent token"),
 	}
 
-	_, err = client.ClusterTokens.Update("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054", &tokenUpdate)
+	_, err = client.ClusterTokens.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054", &tokenUpdate)
 
 	if err != nil {
 		t.Errorf("TestClusterTokens.Update returned error: %v", err)
@@ -288,7 +289,7 @@ func TestClusterTokensService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.ClusterTokens.Delete("my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054")
+	_, err := client.ClusterTokens.Delete(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054")
 
 	if err != nil {
 		t.Errorf("TestClusterTokens.Delete returned error: %v", err)

--- a/buildkite/clusters.go
+++ b/buildkite/clusters.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 )
@@ -57,7 +58,7 @@ type ClustersListOptions struct {
 	ListOptions
 }
 
-func (cs *ClustersService) List(org string, opt *ClustersListOptions) ([]Cluster, *Response, error) {
+func (cs *ClustersService) List(ctx context.Context, org string, opt *ClustersListOptions) ([]Cluster, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters", org)
 
@@ -67,7 +68,7 @@ func (cs *ClustersService) List(org string, opt *ClustersListOptions) ([]Cluster
 		return nil, nil, err
 	}
 
-	req, err := cs.client.NewRequest("GET", u, nil)
+	req, err := cs.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -84,11 +85,11 @@ func (cs *ClustersService) List(org string, opt *ClustersListOptions) ([]Cluster
 	return *clusters, resp, err
 }
 
-func (cs *ClustersService) Get(org, id string) (*Cluster, *Response, error) {
+func (cs *ClustersService) Get(ctx context.Context, org, id string) (*Cluster, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s", org, id)
 
-	req, err := cs.client.NewRequest("GET", u, nil)
+	req, err := cs.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -105,7 +106,7 @@ func (cs *ClustersService) Get(org, id string) (*Cluster, *Response, error) {
 	return cluster, resp, err
 }
 
-func (cs *ClustersService) Create(org string, cc *ClusterCreate) (*Cluster, *Response, error) {
+func (cs *ClustersService) Create(ctx context.Context, org string, cc *ClusterCreate) (*Cluster, *Response, error) {
 
 	if cc == nil {
 		return nil, nil, errors.New("ClusterCreate struct instance must not be nil")
@@ -113,7 +114,7 @@ func (cs *ClustersService) Create(org string, cc *ClusterCreate) (*Cluster, *Res
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters", org)
 
-	req, err := cs.client.NewRequest("POST", u, cc)
+	req, err := cs.client.NewRequest(ctx, "POST", u, cc)
 
 	if err != nil {
 		return nil, nil, err
@@ -130,7 +131,7 @@ func (cs *ClustersService) Create(org string, cc *ClusterCreate) (*Cluster, *Res
 	return cluster, resp, err
 }
 
-func (cs *ClustersService) Update(org, id string, cu *ClusterUpdate) (*Response, error) {
+func (cs *ClustersService) Update(ctx context.Context, org, id string, cu *ClusterUpdate) (*Response, error) {
 
 	if cu == nil {
 		return nil, errors.New("ClusterUpdate struct instance must not be nil")
@@ -138,7 +139,7 @@ func (cs *ClustersService) Update(org, id string, cu *ClusterUpdate) (*Response,
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s", org, id)
 
-	req, err := cs.client.NewRequest("PATCH", u, cu)
+	req, err := cs.client.NewRequest(ctx, "PATCH", u, cu)
 
 	if err != nil {
 		return nil, nil
@@ -153,11 +154,11 @@ func (cs *ClustersService) Update(org, id string, cu *ClusterUpdate) (*Response,
 	return resp, err
 }
 
-func (cs *ClustersService) Delete(org, id string) (*Response, error) {
+func (cs *ClustersService) Delete(ctx context.Context, org, id string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s", org, id)
 
-	req, err := cs.client.NewRequest("DELETE", u, nil)
+	req, err := cs.client.NewRequest(ctx, "DELETE", u, nil)
 
 	if err != nil {
 		return nil, err

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -63,7 +64,7 @@ func TestClustersService_List(t *testing.T) {
 			]`)
 	})
 
-	clusters, _, err := client.Clusters.List("my-great-org", nil)
+	clusters, _, err := client.Clusters.List(context.Background(), "my-great-org", nil)
 
 	if err != nil {
 		t.Errorf("TestClusters.List returned error: %v", err)
@@ -148,7 +149,7 @@ func TestClustersService_Get(t *testing.T) {
 			}`)
 	})
 
-	cluster, _, err := client.Clusters.Get("my-great-org", "528000d8-4ee1-4479-8af1-032b143185f0")
+	cluster, _, err := client.Clusters.Get(context.Background(), "my-great-org", "528000d8-4ee1-4479-8af1-032b143185f0")
 
 	if err != nil {
 		t.Errorf("TestClusters.Get returned error: %v", err)
@@ -218,7 +219,7 @@ func TestClustersService_Create(t *testing.T) {
 			}`)
 	})
 
-	cluster, _, err := client.Clusters.Create("my-great-org", input)
+	cluster, _, err := client.Clusters.Create(context.Background(), "my-great-org", input)
 
 	if err != nil {
 		t.Errorf("TestClusters.Create returned error: %v", err)
@@ -270,7 +271,7 @@ func TestClustersService_Update(t *testing.T) {
 			}`)
 	})
 
-	cluster, _, err := client.Clusters.Create("my-great-org", input)
+	cluster, _, err := client.Clusters.Create(context.Background(), "my-great-org", input)
 
 	if err != nil {
 		t.Errorf("TestClusters.Create returned error: %v", err)
@@ -300,7 +301,7 @@ func TestClustersService_Update(t *testing.T) {
 		Description: String("A test cluster"),
 	}
 
-	_, err = client.Clusters.Update("my-great-org", *cluster.ID, &clusterUpdate)
+	_, err = client.Clusters.Update(context.Background(), "my-great-org", *cluster.ID, &clusterUpdate)
 
 	if err != nil {
 		t.Errorf("TestClusters.Update returned error: %v", err)
@@ -330,7 +331,7 @@ func TestClustersService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Clusters.Delete("my-great-org", "7d2aa9b5-bf2a-4ce0-b9d7-90d3d9b8942c")
+	_, err := client.Clusters.Delete(context.Background(), "my-great-org", "7d2aa9b5-bf2a-4ce0-b9d7-90d3d9b8942c")
 
 	if err != nil {
 		t.Errorf("TestClusters.Delete returned error: %v", err)

--- a/buildkite/flaky_tests.go
+++ b/buildkite/flaky_tests.go
@@ -1,6 +1,9 @@
 package buildkite
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // FlakyTestsService handles communication with flaky test related
 // methods of the Buildkite Test Analytics API.
@@ -25,7 +28,7 @@ type FlakyTestsListOptions struct {
 	ListOptions
 }
 
-func (fts *FlakyTestsService) List(org, slug string, opt *FlakyTestsListOptions) ([]FlakyTest, *Response, error) {
+func (fts *FlakyTestsService) List(ctx context.Context, org, slug string, opt *FlakyTestsListOptions) ([]FlakyTest, *Response, error) {
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/flaky-tests", org, slug)
 
@@ -35,7 +38,7 @@ func (fts *FlakyTestsService) List(org, slug string, opt *FlakyTestsListOptions)
 		return nil, nil, err
 	}
 
-	req, err := fts.client.NewRequest("GET", u, nil)
+	req, err := fts.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err

--- a/buildkite/flaky_tests_test.go
+++ b/buildkite/flaky_tests_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -42,7 +43,7 @@ func TestFlakyTestsService_List(t *testing.T) {
 			]`)
 	})
 
-	flakyTests, _, err := client.FlakyTests.List("my-great-org", "suite-example", nil)
+	flakyTests, _, err := client.FlakyTests.List(context.Background(), "my-great-org", "suite-example", nil)
 
 	if err != nil {
 		t.Errorf("TestSuites.List returned error: %v", err)

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -102,7 +103,7 @@ type JobPriority struct {
 // UnblockJob - unblock a job
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#unblock-a-job
-func (js *JobsService) UnblockJob(org string, pipeline string, buildNumber string, jobID string, opt *JobUnblockOptions) (*Job, *Response, error) {
+func (js *JobsService) UnblockJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string, opt *JobUnblockOptions) (*Job, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/unblock", org, pipeline, buildNumber, jobID)
@@ -116,7 +117,7 @@ func (js *JobsService) UnblockJob(org string, pipeline string, buildNumber strin
 		opt = &JobUnblockOptions{}
 	}
 
-	req, err := js.client.NewRequest("PUT", u, opt)
+	req, err := js.client.NewRequest(ctx, "PUT", u, opt)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -133,12 +134,12 @@ func (js *JobsService) UnblockJob(org string, pipeline string, buildNumber strin
 // RetryJob - retry a job
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#retry-a-job
-func (js *JobsService) RetryJob(org string, pipeline string, buildNumber string, jobID string) (*Job, *Response, error) {
+func (js *JobsService) RetryJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (*Job, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/retry", org, pipeline, buildNumber, jobID)
 
-	req, err := js.client.NewRequest("PUT", u, nil)
+	req, err := js.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -155,11 +156,11 @@ func (js *JobsService) RetryJob(org string, pipeline string, buildNumber string,
 // GetJobLog - get a job’s log output
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-log-output
-func (js *JobsService) GetJobLog(org string, pipeline string, buildNumber string, jobID string) (*JobLog, *Response, error) {
+func (js *JobsService) GetJobLog(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (*JobLog, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/log", org, pipeline, buildNumber, jobID)
-	req, err := js.client.NewRequest("GET", u, nil)
+	req, err := js.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -178,11 +179,11 @@ func (js *JobsService) GetJobLog(org string, pipeline string, buildNumber string
 // GetJobEnvironmentVariables - get a job’s environment variables
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-environment-variables
-func (js *JobsService) GetJobEnvironmentVariables(org string, pipeline string, buildNumber string, jobID string) (*JobEnvs, *Response, error) {
+func (js *JobsService) GetJobEnvironmentVariables(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (*JobEnvs, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/env", org, pipeline, buildNumber, jobID)
-	req, err := js.client.NewRequest("GET", u, nil)
+	req, err := js.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/buildkite/jobs_test.go
+++ b/buildkite/jobs_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -22,7 +23,7 @@ func TestJobsService_UnblockJob(t *testing.T) {
 }`)
 	})
 
-	job, _, err := client.Jobs.UnblockJob("my-great-org", "sup-keith", "awesome-build", "awesome-job-id", nil)
+	job, _, err := client.Jobs.UnblockJob(context.Background(), "my-great-org", "sup-keith", "awesome-build", "awesome-job-id", nil)
 	if err != nil {
 		t.Errorf("UnblockJob returned error: %v", err)
 	}
@@ -49,7 +50,7 @@ func TestJobsService_RetryJob(t *testing.T) {
 }`)
 	})
 
-	job, _, err := client.Jobs.RetryJob("my-great-org", "sup-keith", "awesome-build", "awesome-job-id")
+	job, _, err := client.Jobs.RetryJob(context.Background(), "my-great-org", "sup-keith", "awesome-build", "awesome-job-id")
 	if err != nil {
 		t.Errorf("RetryJob returned error: %v", err)
 	}
@@ -76,7 +77,7 @@ func TestJobsService_GetJobLog(t *testing.T) {
 }`)
 	})
 
-	job, _, err := client.Jobs.GetJobLog("my-great-org", "sup-keith", "awesome-build", "awesome-job-id")
+	job, _, err := client.Jobs.GetJobLog(context.Background(), "my-great-org", "sup-keith", "awesome-build", "awesome-job-id")
 	if err != nil {
 		t.Errorf("GetJobLog returned error: %v", err)
 	}
@@ -134,7 +135,7 @@ func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
 		fmt.Fprintf(w, `%s`, jsonString)
 	})
 
-	jobEnvVars, _, err := client.Jobs.GetJobEnvironmentVariables("my-great-org", "sup-keith", "15", "awesome-job-id")
+	jobEnvVars, _, err := client.Jobs.GetJobEnvironmentVariables(context.Background(), "my-great-org", "sup-keith", "15", "awesome-job-id")
 	if err != nil {
 		t.Errorf("GetJobEnvironmentVariables returned error: %v", err)
 	}

--- a/buildkite/misc.go
+++ b/buildkite/misc.go
@@ -1,6 +1,9 @@
 package buildkite
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // Emoji emoji, what else can you say?
 type Emoji struct {
@@ -11,13 +14,13 @@ type Emoji struct {
 // ListEmojis list all the emojis for a given account, including custom emojis and aliases.
 //
 // buildkite API docs: https://buildkite.com/docs/api/emojis
-func (c *Client) ListEmojis(org string) ([]Emoji, *Response, error) {
+func (c *Client) ListEmojis(ctx context.Context, org string) ([]Emoji, *Response, error) {
 
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/emojis", org)
 
-	req, err := c.NewRequest("GET", u, nil)
+	req, err := c.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/buildkite/misc_test.go
+++ b/buildkite/misc_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -18,7 +19,7 @@ func TestListEmojis(t *testing.T) {
 		fmt.Fprint(w, `[{"name":"rocket","url":"https://a.buildboxassets.com/assets/emoji2/unicode/1f680.png?v2"}]`)
 	})
 
-	emoji, _, err := client.ListEmojis("my-great-org")
+	emoji, _, err := client.ListEmojis(context.Background(), "my-great-org")
 	if err != nil {
 		t.Errorf("ListEmojis returned error: %v", err)
 	}

--- a/buildkite/organizations.go
+++ b/buildkite/organizations.go
@@ -1,6 +1,9 @@
 package buildkite
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // OrganizationsService handles communication with the organization related
 // methods of the buildkite API.
@@ -34,7 +37,7 @@ type OrganizationListOptions struct {
 // List the organizations for the current user.
 //
 // buildkite API docs: https://buildkite.com/docs/api/organizations#list-organizations
-func (os *OrganizationsService) List(opt *OrganizationListOptions) ([]Organization, *Response, error) {
+func (os *OrganizationsService) List(ctx context.Context, opt *OrganizationListOptions) ([]Organization, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations")
@@ -44,7 +47,7 @@ func (os *OrganizationsService) List(opt *OrganizationListOptions) ([]Organizati
 		return nil, nil, err
 	}
 
-	req, err := os.client.NewRequest("GET", u, nil)
+	req, err := os.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -61,11 +64,11 @@ func (os *OrganizationsService) List(opt *OrganizationListOptions) ([]Organizati
 // Get fetches an organization
 //
 // buildkite API docs: https://buildkite.com/docs/api/organizations#get-an-organization
-func (os *OrganizationsService) Get(slug string) (*Organization, *Response, error) {
+func (os *OrganizationsService) Get(ctx context.Context, slug string) (*Organization, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s", slug)
 
-	req, err := os.client.NewRequest("GET", u, nil)
+	req, err := os.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/buildkite/organizations_test.go
+++ b/buildkite/organizations_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -18,7 +19,7 @@ func TestOrganizationsService_List(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
 
-	orgs, _, err := client.Organizations.List(nil)
+	orgs, _, err := client.Organizations.List(context.Background(), nil)
 	if err != nil {
 		t.Errorf("Organizations.List returned error: %v", err)
 	}
@@ -40,7 +41,7 @@ func TestOrganizationsService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id":"123"}`)
 	})
 
-	org, _, err := client.Organizations.Get("babelstoemp")
+	org, _, err := client.Organizations.Get(context.Background(), "babelstoemp")
 	if err != nil {
 		t.Errorf("Organizations.Get returned error: %v", err)
 	}

--- a/buildkite/package_registries.go
+++ b/buildkite/package_registries.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 )
 
@@ -33,9 +34,9 @@ type CreatePackageRegistryInput struct {
 }
 
 // Create creates a package registry for an organization
-func (rs *PackageRegistriesService) Create(organizationSlug string, cpri CreatePackageRegistryInput) (PackageRegistry, *Response, error) {
+func (rs *PackageRegistriesService) Create(ctx context.Context, organizationSlug string, cpri CreatePackageRegistryInput) (PackageRegistry, *Response, error) {
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries", organizationSlug)
-	req, err := rs.client.NewRequest("POST", u, cpri)
+	req, err := rs.client.NewRequest(ctx, "POST", u, cpri)
 	if err != nil {
 		return PackageRegistry{}, nil, fmt.Errorf("creating POST package registry request: %v", err)
 	}
@@ -55,9 +56,9 @@ type UpdatePackageRegistryInput struct {
 }
 
 // Update updates a package registry for an organization
-func (rs *PackageRegistriesService) Update(organizationSlug, registrySlug string, upri UpdatePackageRegistryInput) (PackageRegistry, *Response, error) {
+func (rs *PackageRegistriesService) Update(ctx context.Context, organizationSlug, registrySlug string, upri UpdatePackageRegistryInput) (PackageRegistry, *Response, error) {
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s", organizationSlug, registrySlug)
-	req, err := rs.client.NewRequest("PATCH", u, upri)
+	req, err := rs.client.NewRequest(ctx, "PATCH", u, upri)
 	if err != nil {
 		return PackageRegistry{}, nil, fmt.Errorf("creating PATCH package registry request: %v", err)
 	}
@@ -72,9 +73,9 @@ func (rs *PackageRegistriesService) Update(organizationSlug, registrySlug string
 }
 
 // Get retrieves a package registry for an organization
-func (rs *PackageRegistriesService) Get(organizationSlug, registrySlug string) (PackageRegistry, *Response, error) {
+func (rs *PackageRegistriesService) Get(ctx context.Context, organizationSlug, registrySlug string) (PackageRegistry, *Response, error) {
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s", organizationSlug, registrySlug)
-	req, err := rs.client.NewRequest("GET", u, nil)
+	req, err := rs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return PackageRegistry{}, nil, fmt.Errorf("creating GET package registry request: %v", err)
 	}
@@ -89,9 +90,9 @@ func (rs *PackageRegistriesService) Get(organizationSlug, registrySlug string) (
 }
 
 // List retrieves a list of package all package registries for an organization
-func (rs *PackageRegistriesService) List(organizationSlug string) ([]PackageRegistry, *Response, error) {
+func (rs *PackageRegistriesService) List(ctx context.Context, organizationSlug string) ([]PackageRegistry, *Response, error) {
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries", organizationSlug)
-	req, err := rs.client.NewRequest("GET", u, nil)
+	req, err := rs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating GET package registry request: %v", err)
 	}
@@ -106,9 +107,9 @@ func (rs *PackageRegistriesService) List(organizationSlug string) ([]PackageRegi
 }
 
 // Delete deletes a package registry for an organization
-func (rs *PackageRegistriesService) Delete(organizationSlug, registrySlug string) (*Response, error) {
+func (rs *PackageRegistriesService) Delete(ctx context.Context, organizationSlug, registrySlug string) (*Response, error) {
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s", organizationSlug, registrySlug)
-	req, err := rs.client.NewRequest("DELETE", u, nil)
+	req, err := rs.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating DELETE package registry request: %v", err)
 	}

--- a/buildkite/package_registries_test.go
+++ b/buildkite/package_registries_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"testing"
@@ -57,13 +58,13 @@ func TestPackageRegistryGet(t *testing.T) {
 		}
 	})
 
-	got, _, err := client.PackageRegistriesService.Get("test-org", "my-cool-registry")
+	got, _, err := client.PackageRegistriesService.Get(context.Background(), "test-org", "my-cool-registry")
 	if err != nil {
 		t.Fatalf("PackageRegistries.Get returned error: %v", err)
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("client.PackageRegistriesService.Get(%q, %q) diff: (-got +want)\n%s", "test-org", "my-cool-registry", diff)
+		t.Fatalf("client.PackageRegistriesService.Get(context.Background(),%q, %q) diff: (-got +want)\n%s", "test-org", "my-cool-registry", diff)
 	}
 }
 
@@ -83,13 +84,13 @@ func TestPackageRegistryList(t *testing.T) {
 		}
 	})
 
-	got, _, err := client.PackageRegistriesService.List("test-org")
+	got, _, err := client.PackageRegistriesService.List(context.Background(), "test-org")
 	if err != nil {
 		t.Fatalf("PackageRegistries.List returned error: %v", err)
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("client.PackageRegistriesService.List(%q) diff: (-got +want)\n%s", "test-org", diff)
+		t.Fatalf("client.PackageRegistriesService.List(context.Background(),%q) diff: (-got +want)\n%s", "test-org", diff)
 	}
 }
 
@@ -129,13 +130,13 @@ func TestPackageRegistryCreate(t *testing.T) {
 		}
 	})
 
-	got, _, err := client.PackageRegistriesService.Create("test-org", wantInput)
+	got, _, err := client.PackageRegistriesService.Create(context.Background(), "test-org", wantInput)
 	if err != nil {
 		t.Fatalf("PackageRegistries.Create returned error: %v", err)
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("client.PackageRegistriesService.Create(%q, %#v) diff: (-got +want)\n%s", "test-org", wantInput, diff)
+		t.Fatalf("client.PackageRegistriesService.Create(context.Background(),%q, %#v) diff: (-got +want)\n%s", "test-org", wantInput, diff)
 	}
 }
 
@@ -177,13 +178,13 @@ func TestPackageRegistryUpdate(t *testing.T) {
 		}
 	})
 
-	got, _, err := client.PackageRegistriesService.Update("test-org", "my-cool-registry", wantInput)
+	got, _, err := client.PackageRegistriesService.Update(context.Background(), "test-org", "my-cool-registry", wantInput)
 	if err != nil {
 		t.Fatalf("PackageRegistries.Update returned error: %v", err)
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
-		t.Fatalf("client.PackageRegistriesService.Update(%q, %q, %#v) diff: (-got +want)\n%s", "test-org", "my-cool-registry", wantInput, diff)
+		t.Fatalf("client.PackageRegistriesService.Update(context.Background(),%q, %q, %#v) diff: (-got +want)\n%s", "test-org", "my-cool-registry", wantInput, diff)
 	}
 }
 
@@ -198,12 +199,12 @@ func TestPackageRegistryDelete(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	resp, err := client.PackageRegistriesService.Delete("test-org", "my-cool-registry")
+	resp, err := client.PackageRegistriesService.Delete(context.Background(), "test-org", "my-cool-registry")
 	if err != nil {
 		t.Fatalf("PackageRegistries.Delete returned error: %v", err)
 	}
 
 	if got, want := resp.StatusCode, http.StatusNoContent; got != want {
-		t.Fatalf("client.PackageRegistriesService.Delete(%q, %q) status: %d, want %d", "test-org", "my-cool-registry", got, want)
+		t.Fatalf("client.PackageRegistriesService.Delete(context.Background(),%q, %q) status: %d, want %d", "test-org", "my-cool-registry", got, want)
 	}
 }

--- a/buildkite/packages.go
+++ b/buildkite/packages.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -24,9 +25,9 @@ type Package struct {
 	Registry     PackageRegistry `json:"registry"`
 }
 
-func (ps *PackagesService) Get(organizationSlug, registrySlug, packageID string) (Package, *Response, error) {
+func (ps *PackagesService) Get(ctx context.Context, organizationSlug, registrySlug, packageID string) (Package, *Response, error) {
 	url := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages/%s", organizationSlug, registrySlug, packageID)
-	req, err := ps.client.NewRequest("GET", url, nil)
+	req, err := ps.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
 		return Package{}, nil, fmt.Errorf("creating GET package request: %v", err)
 	}
@@ -48,7 +49,7 @@ type CreatePackageInput struct {
 }
 
 // Create creates a package in a registry for an organization
-func (ps *PackagesService) Create(organizationSlug, registrySlug string, cpi CreatePackageInput) (Package, *Response, error) {
+func (ps *PackagesService) Create(ctx context.Context, organizationSlug, registrySlug string, cpi CreatePackageInput) (Package, *Response, error) {
 	filename := cpi.Filename
 	if f, ok := cpi.Package.(*os.File); ok && filename == "" {
 		filename = f.Name()
@@ -68,7 +69,7 @@ func (ps *PackagesService) Create(organizationSlug, registrySlug string, cpi Cre
 	w.Close()
 
 	url := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages", organizationSlug, registrySlug)
-	req, err := ps.client.NewRequest("POST", url, &b)
+	req, err := ps.client.NewRequest(ctx, "POST", url, &b)
 	if err != nil {
 		return Package{}, nil, fmt.Errorf("creating POST package request: %v", err)
 	}

--- a/buildkite/packages_test.go
+++ b/buildkite/packages_test.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -46,13 +47,13 @@ func TestGetPackage(t *testing.T) {
 		}
 	})
 
-	p, _, err := client.PackagesService.Get("my-org", "my-registry", pkg.ID)
+	p, _, err := client.PackagesService.Get(context.Background(), "my-org", "my-registry", pkg.ID)
 	if err != nil {
 		t.Fatalf("Packages.Get returned error: %v", err)
 	}
 
 	if diff := cmp.Diff(p, want); diff != "" {
-		t.Fatalf("client.PackagesService.Get(%q, %q, %q) diff: (-got +want)\n%s", "test-org", "my-cool-registry", pkg.ID, diff)
+		t.Fatalf("client.PackagesService.Get(context.Background(),%q, %q, %q) diff: (-got +want)\n%s", "test-org", "my-cool-registry", pkg.ID, diff)
 	}
 }
 
@@ -141,13 +142,13 @@ func TestCreatePackage(t *testing.T) {
 				}
 			})
 
-			p, _, err := client.PackagesService.Create("my-org", "my-registry", tc.in)
+			p, _, err := client.PackagesService.Create(context.Background(), "my-org", "my-registry", tc.in)
 			if err != nil {
 				t.Fatalf("Packages.Create returned error: %v", err)
 			}
 
 			if diff := cmp.Diff(p, pkg); diff != "" {
-				t.Fatalf("client.PackagesService.Create(%q, %q, %v) diff: (-got +want)\n%s", "test-org", "my-cool-registry", tc.in, diff)
+				t.Fatalf("client.PackagesService.Create(context.Background(),%q, %q, %v) diff: (-got +want)\n%s", "test-org", "my-cool-registry", tc.in, diff)
 			}
 		})
 	}

--- a/buildkite/pipeline_templates.go
+++ b/buildkite/pipeline_templates.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 )
@@ -48,7 +49,7 @@ type PipelineTemplateListOptions struct {
 	ListOptions
 }
 
-func (pts *PipelineTemplatesService) List(org string, opt *PipelineTemplateListOptions) ([]PipelineTemplate, *Response, error) {
+func (pts *PipelineTemplatesService) List(ctx context.Context, org string, opt *PipelineTemplateListOptions) ([]PipelineTemplate, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates", org)
 
@@ -58,7 +59,7 @@ func (pts *PipelineTemplatesService) List(org string, opt *PipelineTemplateListO
 		return nil, nil, err
 	}
 
-	req, err := pts.client.NewRequest("GET", u, nil)
+	req, err := pts.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -75,11 +76,11 @@ func (pts *PipelineTemplatesService) List(org string, opt *PipelineTemplateListO
 	return *templates, resp, err
 }
 
-func (pts *PipelineTemplatesService) Get(org, templateUUID string) (*PipelineTemplate, *Response, error) {
+func (pts *PipelineTemplatesService) Get(ctx context.Context, org, templateUUID string) (*PipelineTemplate, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates/%s", org, templateUUID)
 
-	req, err := pts.client.NewRequest("GET", u, nil)
+	req, err := pts.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -96,7 +97,7 @@ func (pts *PipelineTemplatesService) Get(org, templateUUID string) (*PipelineTem
 	return template, resp, err
 }
 
-func (pts *PipelineTemplatesService) Create(org string, ptc *PipelineTemplateCreateUpdate) (*PipelineTemplate, *Response, error) {
+func (pts *PipelineTemplatesService) Create(ctx context.Context, org string, ptc *PipelineTemplateCreateUpdate) (*PipelineTemplate, *Response, error) {
 
 	if ptc == nil {
 		return nil, nil, errors.New("PipelineTemplateCreateUpdate struct instance must not be nil")
@@ -104,7 +105,7 @@ func (pts *PipelineTemplatesService) Create(org string, ptc *PipelineTemplateCre
 
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates", org)
 
-	req, err := pts.client.NewRequest("POST", u, ptc)
+	req, err := pts.client.NewRequest(ctx, "POST", u, ptc)
 
 	if err != nil {
 		return nil, nil, err
@@ -121,7 +122,7 @@ func (pts *PipelineTemplatesService) Create(org string, ptc *PipelineTemplateCre
 	return template, resp, err
 }
 
-func (pts *PipelineTemplatesService) Update(org, templateUUID string, ptu *PipelineTemplateCreateUpdate) (*Response, error) {
+func (pts *PipelineTemplatesService) Update(ctx context.Context, org, templateUUID string, ptu *PipelineTemplateCreateUpdate) (*Response, error) {
 
 	if ptu == nil {
 		return nil, errors.New("PipelineTemplateCreateUpdate struct instance must not be nil")
@@ -129,7 +130,7 @@ func (pts *PipelineTemplatesService) Update(org, templateUUID string, ptu *Pipel
 
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates/%s", org, templateUUID)
 
-	req, err := pts.client.NewRequest("PATCH", u, ptu)
+	req, err := pts.client.NewRequest(ctx, "PATCH", u, ptu)
 
 	if err != nil {
 		return nil, nil
@@ -144,11 +145,11 @@ func (pts *PipelineTemplatesService) Update(org, templateUUID string, ptu *Pipel
 	return resp, err
 }
 
-func (pts *PipelineTemplatesService) Delete(org, templateUUID string) (*Response, error) {
+func (pts *PipelineTemplatesService) Delete(ctx context.Context, org, templateUUID string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates/%s", org, templateUUID)
 
-	req, err := pts.client.NewRequest("DELETE", u, nil)
+	req, err := pts.client.NewRequest(ctx, "DELETE", u, nil)
 
 	if err != nil {
 		return nil, err

--- a/buildkite/pipeline_templates_test.go
+++ b/buildkite/pipeline_templates_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -79,7 +80,7 @@ func TestPipelineTemplatesService_List(t *testing.T) {
 			]`)
 	})
 
-	pipelineTemplates, _, err := client.PipelineTemplates.List("my-great-org", nil)
+	pipelineTemplates, _, err := client.PipelineTemplates.List(context.Background(), "my-great-org", nil)
 
 	if err != nil {
 		t.Errorf("TestPipelineTemplates.List returned error: %v", err)
@@ -174,7 +175,7 @@ func TestPipelineTemplatesService_Get(t *testing.T) {
 			}`)
 	})
 
-	pipelineTemplate, _, err := client.PipelineTemplates.Get("my-great-org", "90333dc7-b86a-4485-98c3-9419a5dbc52e")
+	pipelineTemplate, _, err := client.PipelineTemplates.Get(context.Background(), "my-great-org", "90333dc7-b86a-4485-98c3-9419a5dbc52e")
 
 	if err != nil {
 		t.Errorf("TestPipelineTemplates.Get returned error: %v", err)
@@ -247,7 +248,7 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 			}`)
 	})
 
-	pipelineTemplate, _, err := client.PipelineTemplates.Create("my-great-org", input)
+	pipelineTemplate, _, err := client.PipelineTemplates.Create(context.Background(), "my-great-org", input)
 
 	if err != nil {
 		t.Errorf("TestPipelineTemplates.Create returned error: %v", err)
@@ -302,7 +303,7 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 			}`)
 	})
 
-	pipelineTemplate, _, err := client.PipelineTemplates.Create("my-great-org", input)
+	pipelineTemplate, _, err := client.PipelineTemplates.Create(context.Background(), "my-great-org", input)
 
 	if err != nil {
 		t.Errorf("TestPipelineTemplates.Update returned error: %v", err)
@@ -333,7 +334,7 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 		Description: String("A pipeline template for uploading a production pipeline YAML (pipeline-production.yml)"),
 	}
 
-	_, err = client.PipelineTemplates.Update("my-great-org", "b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", &pipelineTemplateUpdate)
+	_, err = client.PipelineTemplates.Update(context.Background(), "my-great-org", "b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", &pipelineTemplateUpdate)
 
 	if err != nil {
 		t.Errorf("TestPipelineTemplates.Update returned error: %v", err)
@@ -363,7 +364,7 @@ func TestPipelineTemplatesService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.PipelineTemplates.Delete("my-great-org", "19dbd05a-96d7-430f-bac0-14b791558562")
+	_, err := client.PipelineTemplates.Delete(context.Background(), "my-great-org", "19dbd05a-96d7-430f-bac0-14b791558562")
 
 	if err != nil {
 		t.Errorf("TestPipelineTemplates.Delete returned error: %v", err)

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -153,10 +154,10 @@ type PipelineListOptions struct {
 // Create - Creates a pipeline for a given organisation.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#create-a-pipeline
-func (ps *PipelinesService) Create(org string, p *CreatePipeline) (*Pipeline, *Response, error) {
+func (ps *PipelinesService) Create(ctx context.Context, org string, p *CreatePipeline) (*Pipeline, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines", org)
 
-	req, err := ps.client.NewRequest("POST", u, p)
+	req, err := ps.client.NewRequest(ctx, "POST", u, p)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -173,11 +174,11 @@ func (ps *PipelinesService) Create(org string, p *CreatePipeline) (*Pipeline, *R
 // Get fetches a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#get-a-pipeline
-func (ps *PipelinesService) Get(org string, slug string) (*Pipeline, *Response, error) {
+func (ps *PipelinesService) Get(ctx context.Context, org string, slug string) (*Pipeline, *Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
 
-	req, err := ps.client.NewRequest("GET", u, nil)
+	req, err := ps.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -194,7 +195,7 @@ func (ps *PipelinesService) Get(org string, slug string) (*Pipeline, *Response, 
 // List the pipelines for a given organisation.
 //
 // buildkite API docs: https://buildkite.com/docs/api/pipelines#list-pipelines
-func (ps *PipelinesService) List(org string, opt *PipelineListOptions) ([]Pipeline, *Response, error) {
+func (ps *PipelinesService) List(ctx context.Context, org string, opt *PipelineListOptions) ([]Pipeline, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/pipelines", org)
@@ -204,7 +205,7 @@ func (ps *PipelinesService) List(org string, opt *PipelineListOptions) ([]Pipeli
 		return nil, nil, err
 	}
 
-	req, err := ps.client.NewRequest("GET", u, nil)
+	req, err := ps.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -221,11 +222,11 @@ func (ps *PipelinesService) List(org string, opt *PipelineListOptions) ([]Pipeli
 // Delete a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#delete-a-pipeline
-func (ps *PipelinesService) Delete(org string, slug string) (*Response, error) {
+func (ps *PipelinesService) Delete(ctx context.Context, org string, slug string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
 
-	req, err := ps.client.NewRequest("DELETE", u, nil)
+	req, err := ps.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +237,7 @@ func (ps *PipelinesService) Delete(org string, slug string) (*Response, error) {
 // Update - Updates a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#update-a-pipeline
-func (ps *PipelinesService) Update(org string, p *Pipeline) (*Response, error) {
+func (ps *PipelinesService) Update(ctx context.Context, org string, p *Pipeline) (*Response, error) {
 	if p == nil {
 		return nil, errors.New("Pipeline must not be nil")
 	}
@@ -245,7 +246,7 @@ func (ps *PipelinesService) Update(org string, p *Pipeline) (*Response, error) {
 
 	pu := generateUpdatePipelineInstance(*p)
 
-	req, err := ps.client.NewRequest("PATCH", u, pu)
+	req, err := ps.client.NewRequest(ctx, "PATCH", u, pu)
 
 	if err != nil {
 		return nil, err
@@ -262,11 +263,11 @@ func (ps *PipelinesService) Update(org string, p *Pipeline) (*Response, error) {
 // AddWebhook - Adds webhook in github for pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipelines#add-a-webhook
-func (ps *PipelinesService) AddWebhook(org string, slug string) (*Response, error) {
+func (ps *PipelinesService) AddWebhook(ctx context.Context, org string, slug string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/webhook", org, slug)
 
-	req, err := ps.client.NewRequest("POST", u, nil)
+	req, err := ps.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -277,11 +278,11 @@ func (ps *PipelinesService) AddWebhook(org string, slug string) (*Response, erro
 // Archive - Archives a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipelines#archive-a-pipeline
-func (ps *PipelinesService) Archive(org string, slug string) (*Response, error) {
+func (ps *PipelinesService) Archive(ctx context.Context, org string, slug string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/archive", org, slug)
 
-	req, err := ps.client.NewRequest("POST", u, nil)
+	req, err := ps.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -292,11 +293,11 @@ func (ps *PipelinesService) Archive(org string, slug string) (*Response, error) 
 // Unarchive - Unarchive a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipelines#unarchive-a-pipeline
-func (ps *PipelinesService) Unarchive(org string, slug string) (*Response, error) {
+func (ps *PipelinesService) Unarchive(ctx context.Context, org string, slug string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/unarchive", org, slug)
 
-	req, err := ps.client.NewRequest("POST", u, nil)
+	req, err := ps.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -19,7 +20,7 @@ func TestPipelinesService_List(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
 
-	pipelines, _, err := client.Pipelines.List("my-great-org", nil)
+	pipelines, _, err := client.Pipelines.List(context.Background(), "my-great-org", nil)
 	if err != nil {
 		t.Errorf("Pipelines.List returned error: %v", err)
 	}
@@ -92,7 +93,7 @@ func TestPipelinesService_Create(t *testing.T) {
 					}`)
 	})
 
-	pipeline, _, err := client.Pipelines.Create("my-great-org", input)
+	pipeline, _, err := client.Pipelines.Create(context.Background(), "my-great-org", input)
 	if err != nil {
 		t.Errorf("Pipelines.Create returned error: %v", err)
 	}
@@ -165,7 +166,7 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 					}`)
 	})
 
-	pipeline, _, err := client.Pipelines.Create("my-great-org", input)
+	pipeline, _, err := client.Pipelines.Create(context.Background(), "my-great-org", input)
 	if err != nil {
 		t.Errorf("Pipelines.Create returned error: %v", err)
 	}
@@ -210,7 +211,7 @@ func TestPipelinesService_Get(t *testing.T) {
 						]}`)
 	})
 
-	pipeline, _, err := client.Pipelines.Get("my-great-org", "my-great-pipeline-slug")
+	pipeline, _, err := client.Pipelines.Get(context.Background(), "my-great-org", "my-great-pipeline-slug")
 	if err != nil {
 		t.Errorf("Pipelines.Get returned error: %v", err)
 	}
@@ -231,7 +232,7 @@ func TestPipelinesService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.Pipelines.Delete("my-great-org", "my-great-pipeline-slug")
+	_, err := client.Pipelines.Delete(context.Background(), "my-great-org", "my-great-pipeline-slug")
 	if err != nil {
 		t.Errorf("Pipelines.Delete returned error: %v", err)
 	}
@@ -290,7 +291,7 @@ func TestPipelinesService_Update(t *testing.T) {
 					}`)
 	})
 
-	pipeline, _, err := client.Pipelines.Create("my-great-org", input)
+	pipeline, _, err := client.Pipelines.Create(context.Background(), "my-great-org", input)
 	if err != nil {
 		t.Errorf("Pipelines.Create returned error: %v", err)
 	}
@@ -327,7 +328,7 @@ func TestPipelinesService_Update(t *testing.T) {
 					}`)
 	})
 
-	_, err = client.Pipelines.Update("my-great-org", pipeline)
+	_, err = client.Pipelines.Update(context.Background(), "my-great-org", pipeline)
 	if err != nil {
 		t.Errorf("Pipelines.Update returned error: %v", err)
 	}
@@ -367,7 +368,7 @@ func TestPipelinesService_AddWebhook(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	_, err := client.Pipelines.AddWebhook("my-great-org", "my-great-pipeline-slug")
+	_, err := client.Pipelines.AddWebhook(context.Background(), "my-great-org", "my-great-pipeline-slug")
 	if err != nil {
 		t.Errorf("Pipelines.AddWebhook returned error: %v", err)
 	}
@@ -383,7 +384,7 @@ func TestPipelinesService_Archive(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	_, err := client.Pipelines.Archive("my-great-org", "my-great-pipeline-slug")
+	_, err := client.Pipelines.Archive(context.Background(), "my-great-org", "my-great-pipeline-slug")
 	if err != nil {
 		t.Errorf("Pipelines.Archive returned error: %v", err)
 	}
@@ -399,7 +400,7 @@ func TestPipelinesService_Unarchive(t *testing.T) {
 		testMethod(t, r, "POST")
 	})
 
-	_, err := client.Pipelines.Unarchive("my-great-org", "my-great-pipeline-slug")
+	_, err := client.Pipelines.Unarchive(context.Background(), "my-great-org", "my-great-pipeline-slug")
 	if err != nil {
 		t.Errorf("Pipelines.UnArchive returned error: %v", err)
 	}

--- a/buildkite/teams.go
+++ b/buildkite/teams.go
@@ -3,7 +3,10 @@
 
 package buildkite
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // TeamService handles communication with the teams related
 // methods of the buildkite API.
@@ -35,7 +38,7 @@ type TeamsListOptions struct {
 // Get the teams for an org.
 //
 // buildkite API docs: https://buildkite.com/docs/api
-func (ts *TeamsService) List(org string, opt *TeamsListOptions) ([]Team, *Response, error) {
+func (ts *TeamsService) List(ctx context.Context, org string, opt *TeamsListOptions) ([]Team, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/organizations/%s/teams", org)
@@ -45,7 +48,7 @@ func (ts *TeamsService) List(org string, opt *TeamsListOptions) ([]Team, *Respon
 		return nil, nil, err
 	}
 
-	req, err := ts.client.NewRequest("GET", u, nil)
+	req, err := ts.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/buildkite/teams_test.go
+++ b/buildkite/teams_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -18,7 +19,7 @@ func TestTeamsService_List(t *testing.T) {
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
 
-	teams, _, err := client.Teams.List("my-great-org", nil)
+	teams, _, err := client.Teams.List(context.Background(), "my-great-org", nil)
 	if err != nil {
 		t.Errorf("Teams.List returned error: %v", err)
 	}
@@ -44,7 +45,7 @@ func TestTeamsService_ListForUser(t *testing.T) {
 	})
 
 	opt := &TeamsListOptions{UserID: "abc"}
-	teams, _, err := client.Teams.List("my-great-org", opt)
+	teams, _, err := client.Teams.List(context.Background(), "my-great-org", opt)
 	if err != nil {
 		t.Errorf("Teams.List returned error: %v", err)
 	}

--- a/buildkite/test_runs.go
+++ b/buildkite/test_runs.go
@@ -1,6 +1,9 @@
 package buildkite
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // TestRunsService handles communication with test run related
 // methods of the Buildkite Test Analytics API.
@@ -23,7 +26,7 @@ type TestRunsListOptions struct {
 	ListOptions
 }
 
-func (trs *TestRunsService) List(org, slug string, opt *TestRunsListOptions) ([]TestRun, *Response, error) {
+func (trs *TestRunsService) List(ctx context.Context, org, slug string, opt *TestRunsListOptions) ([]TestRun, *Response, error) {
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/runs", org, slug)
 
@@ -33,7 +36,7 @@ func (trs *TestRunsService) List(org, slug string, opt *TestRunsListOptions) ([]
 		return nil, nil, err
 	}
 
-	req, err := trs.client.NewRequest("GET", u, nil)
+	req, err := trs.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -50,11 +53,11 @@ func (trs *TestRunsService) List(org, slug string, opt *TestRunsListOptions) ([]
 	return *testRuns, resp, err
 }
 
-func (trs *TestRunsService) Get(org, slug, runID string) (*TestRun, *Response, error) {
+func (trs *TestRunsService) Get(ctx context.Context, org, slug, runID string) (*TestRun, *Response, error) {
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/runs/%s", org, slug, runID)
 
-	req, err := trs.client.NewRequest("GET", u, nil)
+	req, err := trs.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err

--- a/buildkite/test_runs_test.go
+++ b/buildkite/test_runs_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -38,7 +39,7 @@ func TestTestRunsService_List(t *testing.T) {
 			]`)
 	})
 
-	runs, _, err := client.TestRuns.List("my-great-org", "suite-example", nil)
+	runs, _, err := client.TestRuns.List(context.Background(), "my-great-org", "suite-example", nil)
 
 	if err != nil {
 		t.Errorf("TestSuites.List returned error: %v", err)
@@ -96,7 +97,7 @@ func TestTestRunsService_Get(t *testing.T) {
 			}`)
 	})
 
-	run, _, err := client.TestRuns.Get("my-great-org", "suite-example", "3c90a8ad-8e86-4e78-87b4-acae5e808de4")
+	run, _, err := client.TestRuns.Get(context.Background(), "my-great-org", "suite-example", "3c90a8ad-8e86-4e78-87b4-acae5e808de4")
 
 	if err != nil {
 		t.Errorf("TestSuites.Get returned error: %v", err)

--- a/buildkite/test_suites.go
+++ b/buildkite/test_suites.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"errors"
 	"fmt"
 )
@@ -34,7 +35,7 @@ type TestSuiteListOptions struct {
 	ListOptions
 }
 
-func (tss *TestSuitesService) List(org string, opt *TestSuiteListOptions) ([]TestSuite, *Response, error) {
+func (tss *TestSuitesService) List(ctx context.Context, org string, opt *TestSuiteListOptions) ([]TestSuite, *Response, error) {
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites", org)
 
@@ -44,7 +45,7 @@ func (tss *TestSuitesService) List(org string, opt *TestSuiteListOptions) ([]Tes
 		return nil, nil, err
 	}
 
-	req, err := tss.client.NewRequest("GET", u, nil)
+	req, err := tss.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -61,11 +62,11 @@ func (tss *TestSuitesService) List(org string, opt *TestSuiteListOptions) ([]Tes
 	return *testSuites, resp, err
 }
 
-func (tss *TestSuitesService) Get(org, slug string) (*TestSuite, *Response, error) {
+func (tss *TestSuitesService) Get(ctx context.Context, org, slug string) (*TestSuite, *Response, error) {
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, slug)
 
-	req, err := tss.client.NewRequest("GET", u, nil)
+	req, err := tss.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -82,11 +83,11 @@ func (tss *TestSuitesService) Get(org, slug string) (*TestSuite, *Response, erro
 	return testSuite, resp, err
 }
 
-func (tss *TestSuitesService) Create(org string, ts *TestSuiteCreate) (*TestSuite, *Response, error) {
+func (tss *TestSuitesService) Create(ctx context.Context, org string, ts *TestSuiteCreate) (*TestSuite, *Response, error) {
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites", org)
 
-	req, err := tss.client.NewRequest("POST", u, ts)
+	req, err := tss.client.NewRequest(ctx, "POST", u, ts)
 
 	if err != nil {
 		return nil, nil, err
@@ -102,7 +103,7 @@ func (tss *TestSuitesService) Create(org string, ts *TestSuiteCreate) (*TestSuit
 	return testSuite, resp, err
 }
 
-func (tss *TestSuitesService) Update(org string, ts *TestSuite) (*Response, error) {
+func (tss *TestSuitesService) Update(ctx context.Context, org string, ts *TestSuite) (*Response, error) {
 
 	if ts == nil {
 		return nil, errors.New("Test suite must not be nil")
@@ -110,7 +111,7 @@ func (tss *TestSuitesService) Update(org string, ts *TestSuite) (*Response, erro
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, *ts.Slug)
 
-	req, err := tss.client.NewRequest("PATCH", u, ts)
+	req, err := tss.client.NewRequest(ctx, "PATCH", u, ts)
 
 	if err != nil {
 		return nil, nil
@@ -125,11 +126,11 @@ func (tss *TestSuitesService) Update(org string, ts *TestSuite) (*Response, erro
 	return resp, err
 }
 
-func (tss *TestSuitesService) Delete(org, slug string) (*Response, error) {
+func (tss *TestSuitesService) Delete(ctx context.Context, org, slug string) (*Response, error) {
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, slug)
 
-	req, err := tss.client.NewRequest("DELETE", u, nil)
+	req, err := tss.client.NewRequest(ctx, "DELETE", u, nil)
 
 	if err != nil {
 		return nil, err

--- a/buildkite/test_suites_test.go
+++ b/buildkite/test_suites_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -40,7 +41,7 @@ func TestTestSuitesService_List(t *testing.T) {
 			]`)
 	})
 
-	suites, _, err := client.TestSuites.List("my-great-org", nil)
+	suites, _, err := client.TestSuites.List(context.Background(), "my-great-org", nil)
 
 	if err != nil {
 		t.Errorf("TestSuites.List returned error: %v", err)
@@ -92,7 +93,7 @@ func TestTestSuitesService_Get(t *testing.T) {
 			}`)
 	})
 
-	suite, _, err := client.TestSuites.Get("my-great-org", "suite-1")
+	suite, _, err := client.TestSuites.Get(context.Background(), "my-great-org", "suite-1")
 
 	if err != nil {
 		t.Errorf("TestSuites.Get returned error: %v", err)
@@ -144,7 +145,7 @@ func TestTestSuitesService_Create(t *testing.T) {
 			}`)
 	})
 
-	suite, _, err := client.TestSuites.Create("my-great-org", input)
+	suite, _, err := client.TestSuites.Create(context.Background(), "my-great-org", input)
 
 	if err != nil {
 		t.Errorf("TestSuites.Create returned error: %v", err)
@@ -192,7 +193,7 @@ func TestTestSuitesService_Update(t *testing.T) {
 			}`)
 	})
 
-	suite, _, err := client.TestSuites.Create("my-great-org", input)
+	suite, _, err := client.TestSuites.Create(context.Background(), "my-great-org", input)
 
 	if err != nil {
 		t.Errorf("TestSuites.Create returned error: %v", err)
@@ -217,7 +218,7 @@ func TestTestSuitesService_Update(t *testing.T) {
 			}`)
 	})
 
-	_, err = client.TestSuites.Update("my-great-org", suite)
+	_, err = client.TestSuites.Update(context.Background(), "my-great-org", suite)
 
 	if err != nil {
 		t.Errorf("Pipelines.Update returned error: %v", err)
@@ -244,7 +245,7 @@ func TestTestSuitesService_Delete(t *testing.T) {
 		testMethod(t, r, "DELETE")
 	})
 
-	_, err := client.TestSuites.Delete("my-great-org", "suite-5")
+	_, err := client.TestSuites.Delete(context.Background(), "my-great-org", "suite-5")
 
 	if err != nil {
 		t.Errorf("TestSuites.Delete returned error: %v", err)

--- a/buildkite/tests.go
+++ b/buildkite/tests.go
@@ -1,6 +1,9 @@
 package buildkite
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // TestsService handles communication with test related
 // methods of the Buildkite Test Analytics API.
@@ -20,11 +23,11 @@ type Test struct {
 	FileName *string `json:"file_name,omitempty" yaml:"file_name,omitempty"`
 }
 
-func (ts *TestsService) Get(org, slug, testID string) (*Test, *Response, error) {
+func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (*Test, *Response, error) {
 
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/%s", org, slug, testID)
 
-	req, err := ts.client.NewRequest("GET", u, nil)
+	req, err := ts.client.NewRequest(ctx, "GET", u, nil)
 
 	if err != nil {
 		return nil, nil, err

--- a/buildkite/tests_test.go
+++ b/buildkite/tests_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -28,7 +29,7 @@ func TestTestsService_Get(t *testing.T) {
 			}`)
 	})
 
-	test, _, err := client.Tests.Get("my-great-org", "suite-example", "b3abe2e9-35c5-4905-85e1-8c9f2da3240f")
+	test, _, err := client.Tests.Get(context.Background(), "my-great-org", "suite-example", "b3abe2e9-35c5-4905-85e1-8c9f2da3240f")
 
 	if err != nil {
 		t.Errorf("TestSuites.Get returned error: %v", err)

--- a/buildkite/user.go
+++ b/buildkite/user.go
@@ -1,6 +1,9 @@
 package buildkite
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+)
 
 // UserService handles communication with the user related
 // methods of the buildkite API.
@@ -21,12 +24,12 @@ type User struct {
 // Get the current user.
 //
 // buildkite API docs: https://buildkite.com/docs/api
-func (os *UserService) Get() (*User, *Response, error) {
+func (os *UserService) Get(ctx context.Context) (*User, *Response, error) {
 	var u string
 
 	u = fmt.Sprintf("v2/user")
 
-	req, err := os.client.NewRequest("GET", u, nil)
+	req, err := os.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/buildkite/user_test.go
+++ b/buildkite/user_test.go
@@ -1,6 +1,7 @@
 package buildkite
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -18,7 +19,7 @@ func TestUserService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id":"123","name":"Jane Doe","email":"jane@doe.com"}`)
 	})
 
-	user, _, err := client.User.Get()
+	user, _, err := client.User.Get(context.Background())
 	if err != nil {
 		t.Errorf("User.Get returned error: %v", err)
 	}

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -34,7 +35,7 @@ func main() {
 		Append:  buildkite.Bool(false),
 	}
 
-	annotation, _, err := client.Annotations.Create(*org, *slug, *number, &annotationCreate)
+	annotation, _, err := client.Annotations.Create(context.Background(), *org, *slug, *number, &annotationCreate)
 
 	if err != nil {
 		log.Fatalf("Listing annotations for build %s in pipeline %s failed: %s", *number, *slug, err)

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -27,7 +28,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	annotations, _, err := client.Annotations.ListByBuild(*org, *slug, *number, nil)
+	annotations, _, err := client.Annotations.ListByBuild(context.Background(), *org, *slug, *number, nil)
 
 	if err != nil {
 		log.Fatalf("Listing annotations for build %s in pipeline %s failed: %s", *number, *slug, err)

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -27,7 +28,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	artifacts, _, err := client.Artifacts.ListByBuild(*org, *pipeline, *build, nil)
+	artifacts, _, err := client.Artifacts.ListByBuild(context.Background(), *org, *pipeline, *build, nil)
 
 	if err != nil {
 		log.Fatalf("list artifacts failed: %s", err)
@@ -44,7 +45,7 @@ func main() {
 			fmt.Fprintf(os.Stdout, "%s\n", string(data))
 		} else {
 			if *artifactName == *artifact.Filename || *artifactName == *artifact.ID {
-				_, err := client.Artifacts.DownloadArtifactByURL(*artifact.DownloadURL, os.Stdout)
+				_, err := client.Artifacts.DownloadArtifactByURL(context.Background(), *artifact.DownloadURL, os.Stdout)
 				if err != nil {
 					log.Fatalf("DownloadArtifactByURL failed: %s", err)
 				}

--- a/examples/builds/get/main.go
+++ b/examples/builds/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -27,7 +28,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	build, _, err := client.Builds.Get(*org, *slug, *number, nil)
+	build, _, err := client.Builds.Get(context.Background(), *org, *slug, *number, nil)
 
 	if err != nil {
 		log.Fatalf("Getting build %s of pipeline %s failed: %s", *number, *slug, err)

--- a/examples/cluster_queues/create/main.go
+++ b/examples/cluster_queues/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -31,7 +32,7 @@ func main() {
 		Description: buildkite.String("Development 1 Cluster queue"),
 	}
 
-	queue, _, err := client.ClusterQueues.Create(*org, *clusterID, &clusterQueueCreate)
+	queue, _, err := client.ClusterQueues.Create(context.Background(), *org, *clusterID, &clusterQueueCreate)
 
 	if err != nil {
 		log.Fatalf("Creating cluster queue failed: %s", err)

--- a/examples/cluster_queues/delete/main.go
+++ b/examples/cluster_queues/delete/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -25,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	resp, err := client.ClusterQueues.Delete(*org, *clusterID, *queueID)
+	resp, err := client.ClusterQueues.Delete(context.Background(), *org, *clusterID, *queueID)
 
 	if err != nil {
 		log.Fatalf("Deleting cluster queue %s failed: %s", *queueID, err)

--- a/examples/cluster_queues/get/main.go
+++ b/examples/cluster_queues/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -27,7 +28,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	queue, _, err := client.ClusterQueues.Get(*org, *clusterID, *queueID)
+	queue, _, err := client.ClusterQueues.Get(context.Background(), *org, *clusterID, *queueID)
 
 	if err != nil {
 		log.Fatalf("Getting cluster queue failed: %s", err)

--- a/examples/cluster_queues/list/main.go
+++ b/examples/cluster_queues/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	queues, _, err := client.ClusterQueues.List(*org, *clusterID, nil)
+	queues, _, err := client.ClusterQueues.List(context.Background(), *org, *clusterID, nil)
 
 	if err != nil {
 		log.Fatalf("Listing cluster queues failed: %s", err)

--- a/examples/cluster_queues/pause/main.go
+++ b/examples/cluster_queues/pause/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -29,7 +30,7 @@ func main() {
 		Note: buildkite.String("Pausing dispatch over the weekend"),
 	}
 
-	resp, err := client.ClusterQueues.Pause(*org, *clusterID, *queueID, &clusterQueuePause)
+	resp, err := client.ClusterQueues.Pause(context.Background(), *org, *clusterID, *queueID, &clusterQueuePause)
 
 	if err != nil {
 		log.Fatalf("Pausing dispatch on cluster queue %s failed: %s", *queueID, err)

--- a/examples/cluster_queues/resume/main.go
+++ b/examples/cluster_queues/resume/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -25,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	resp, err := client.ClusterQueues.Resume(*org, *clusterID, *queueID)
+	resp, err := client.ClusterQueues.Resume(context.Background(), *org, *clusterID, *queueID)
 
 	if err != nil {
 		log.Fatalf("Resuming dispatch on cluster queue %s failed: %s", *queueID, err)

--- a/examples/cluster_queues/update/main.go
+++ b/examples/cluster_queues/update/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -28,7 +29,7 @@ func main() {
 		Description: buildkite.String("Development team cluster queue"),
 	}
 
-	resp, err := client.ClusterQueues.Update(*org, *clusterID, *queueID, &clusterQueueUpdate)
+	resp, err := client.ClusterQueues.Update(context.Background(), *org, *clusterID, *queueID, &clusterQueueUpdate)
 
 	if err != nil {
 		log.Fatalf("Updating cluster queue failed: %s", err)

--- a/examples/cluster_tokens/create/main.go
+++ b/examples/cluster_tokens/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -30,7 +31,7 @@ func main() {
 		Description: buildkite.String("Dev squad agent fleet token"),
 	}
 
-	token, _, err := client.ClusterTokens.Create(*org, *clusterID, &clusterTokenCreate)
+	token, _, err := client.ClusterTokens.Create(context.Background(), *org, *clusterID, &clusterTokenCreate)
 
 	if err != nil {
 		log.Fatalf("Creating cluster token failed: %s", err)

--- a/examples/cluster_tokens/delete/main.go
+++ b/examples/cluster_tokens/delete/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -25,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	resp, err := client.ClusterTokens.Delete(*org, *clusterID, *tokenID)
+	resp, err := client.ClusterTokens.Delete(context.Background(), *org, *clusterID, *tokenID)
 
 	if err != nil {
 		log.Fatalf("Deleting cluster token %s failed: %s", *tokenID, err)

--- a/examples/cluster_tokens/get/main.go
+++ b/examples/cluster_tokens/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -27,7 +28,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	token, _, err := client.ClusterTokens.Get(*org, *clusterID, *tokenID)
+	token, _, err := client.ClusterTokens.Get(context.Background(), *org, *clusterID, *tokenID)
 
 	if err != nil {
 		log.Fatalf("Getting cluster token failed: %s", err)

--- a/examples/cluster_tokens/list/main.go
+++ b/examples/cluster_tokens/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	tokens, _, err := client.ClusterTokens.List(*org, *clusterID, nil)
+	tokens, _, err := client.ClusterTokens.List(context.Background(), *org, *clusterID, nil)
 
 	if err != nil {
 		log.Fatalf("Listing cluster tokens failed: %s", err)

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -29,7 +30,7 @@ func main() {
 		Description: buildkite.String("Dev squad agent token"),
 	}
 
-	resp, err := client.ClusterTokens.Update(*org, *clusterID, *tokenID, &clusterTokenUpdate)
+	resp, err := client.ClusterTokens.Update(context.Background(), *org, *clusterID, *tokenID, &clusterTokenUpdate)
 
 	if err != nil {
 		log.Fatalf("Updating cluster token failed: %s", err)

--- a/examples/clusters/create/main.go
+++ b/examples/clusters/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -32,7 +33,7 @@ func main() {
 		Color:       buildkite.String("#A9CCE3"),
 	}
 
-	cluster, _, err := client.Clusters.Create(*org, &clusterCreate)
+	cluster, _, err := client.Clusters.Create(context.Background(), *org, &clusterCreate)
 
 	if err != nil {
 		log.Fatalf("Creating cluster failed: %s", err)

--- a/examples/clusters/delete/main.go
+++ b/examples/clusters/delete/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -24,7 +25,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	resp, err := client.Clusters.Delete(*org, *clusterID)
+	resp, err := client.Clusters.Delete(context.Background(), *org, *clusterID)
 
 	if err != nil {
 		log.Fatalf("Deleting cluster %s failed: %s", *clusterID, err)

--- a/examples/clusters/get/main.go
+++ b/examples/clusters/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	cluster, _, err := client.Clusters.Get(*org, *clusterID)
+	cluster, _, err := client.Clusters.Get(context.Background(), *org, *clusterID)
 
 	if err != nil {
 		log.Fatalf("Getting cluster %s failed: %s", *clusterID, err)

--- a/examples/clusters/list/main.go
+++ b/examples/clusters/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusters, _, err := client.Clusters.List(*org, nil)
+	clusters, _, err := client.Clusters.List(context.Background(), *org, nil)
 
 	if err != nil {
 		log.Fatalf("listing clusters failed: %s", err)

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -28,7 +29,7 @@ func main() {
 		Description: buildkite.String("Development cluster"),
 	}
 
-	resp, err := client.Clusters.Update(*org, *clusterID, &clusterUpdate)
+	resp, err := client.Clusters.Update(context.Background(), *org, *clusterID, &clusterUpdate)
 
 	if err != nil {
 		log.Fatalf("Updating cluster %s failed: %s", *clusterID, err)

--- a/examples/flaky_tests/list/main.go
+++ b/examples/flaky_tests/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	flakyTests, _, err := client.FlakyTests.List(*org, *slug, nil)
+	flakyTests, _, err := client.FlakyTests.List(context.Background(), *org, *slug, nil)
 
 	if err != nil {
 		log.Fatalf("Listing Flaky tests failed: %s", err)

--- a/examples/package_registries/create/main.go
+++ b/examples/package_registries/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 
@@ -25,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	reg, _, err := client.PackageRegistriesService.Create(*org, buildkite.CreatePackageRegistryInput{
+	reg, _, err := client.PackageRegistriesService.Create(context.Background(), *org, buildkite.CreatePackageRegistryInput{
 		Name:        *registryName,
 		Ecosystem:   *registryEcosystem,
 		Description: *registryDescription,

--- a/examples/package_registries/delete/main.go
+++ b/examples/package_registries/delete/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 
 	"github.com/buildkite/go-buildkite/v3/buildkite"
@@ -22,7 +23,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	_, err = client.PackageRegistriesService.Delete(*org, *registrySlug)
+	_, err = client.PackageRegistriesService.Delete(context.Background(), *org, *registrySlug)
 	if err != nil {
 		log.Fatalf("Getting registry %s failed: %s", *registrySlug, err)
 	}

--- a/examples/package_registries/get/main.go
+++ b/examples/package_registries/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 
@@ -23,7 +24,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	reg, _, err := client.PackageRegistriesService.Get(*org, *registrySlug)
+	reg, _, err := client.PackageRegistriesService.Get(context.Background(), *org, *registrySlug)
 	if err != nil {
 		log.Fatalf("Getting registry %s failed: %s", *registrySlug, err)
 	}

--- a/examples/package_registries/list/main.go
+++ b/examples/package_registries/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 
@@ -22,7 +23,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	registries, _, err := client.PackageRegistriesService.List(*org)
+	registries, _, err := client.PackageRegistriesService.List(context.Background(), *org)
 	if err != nil {
 		log.Fatalf("Creating registry failed: %v", err)
 	}

--- a/examples/packages/create/main.go
+++ b/examples/packages/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"os"
@@ -32,7 +33,7 @@ func main() {
 
 	log.Println(file.Name())
 
-	pkg, _, err := client.PackagesService.Create(*org, *registrySlug, buildkite.CreatePackageInput{Package: file})
+	pkg, _, err := client.PackagesService.Create(context.Background(), *org, *registrySlug, buildkite.CreatePackageInput{Package: file})
 	if err != nil {
 		log.Fatalf("Creating package failed: %v", err)
 	}

--- a/examples/packages/get/main.go
+++ b/examples/packages/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 
@@ -24,7 +25,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pkg, _, err := client.PackagesService.Get(*org, *registrySlug, *packageID)
+	pkg, _, err := client.PackagesService.Get(context.Background(), *org, *registrySlug, *packageID)
 	if err != nil {
 		log.Fatalf("Getting registry %s failed: %s", *registrySlug, err)
 	}

--- a/examples/pipeline_templates/create/main.go
+++ b/examples/pipeline_templates/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -32,7 +33,7 @@ func main() {
 		Available:     buildkite.Bool(true),
 	}
 
-	pipelineTemplate, _, err := client.PipelineTemplates.Create(*org, &pipelineTemplateCreate)
+	pipelineTemplate, _, err := client.PipelineTemplates.Create(context.Background(), *org, &pipelineTemplateCreate)
 
 	if err != nil {
 		log.Fatalf("Creating pipeline template failed: %s", err)

--- a/examples/pipeline_templates/delete/main.go
+++ b/examples/pipeline_templates/delete/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -24,7 +25,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	resp, err := client.PipelineTemplates.Delete(*org, *templateUUID)
+	resp, err := client.PipelineTemplates.Delete(context.Background(), *org, *templateUUID)
 
 	if err != nil {
 		log.Fatalf("Deleting pipeline template %s failed: %s", *templateUUID, err)

--- a/examples/pipeline_templates/get/main.go
+++ b/examples/pipeline_templates/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pipelineTemplate, _, err := client.PipelineTemplates.Get(*org, *templateUUID)
+	pipelineTemplate, _, err := client.PipelineTemplates.Get(context.Background(), *org, *templateUUID)
 
 	if err != nil {
 		log.Fatalf("Getting pipeline template %s failed: %s", *templateUUID, err)

--- a/examples/pipeline_templates/list/main.go
+++ b/examples/pipeline_templates/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pipelineTemplates, _, err := client.PipelineTemplates.List(*org, nil)
+	pipelineTemplates, _, err := client.PipelineTemplates.List(context.Background(), *org, nil)
 
 	if err != nil {
 		log.Fatalf("listing pipeline templates failed: %s", err)

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -28,7 +29,7 @@ func main() {
 		Description: buildkite.String("Production pipeline template uploader"),
 	}
 
-	resp, err := client.PipelineTemplates.Update(*org, *templateUUID, &pipelineTemplateUpdate)
+	resp, err := client.PipelineTemplates.Update(context.Background(), *org, *templateUUID, &pipelineTemplateUpdate)
 
 	if err != nil {
 		log.Fatalf("Updating cluster %s failed: %s", *templateUUID, err)

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -36,7 +37,7 @@ func main() {
 		},
 	}
 
-	pipeline, _, err := client.Pipelines.Create(*org, &createPipeline)
+	pipeline, _, err := client.Pipelines.Create(context.Background(), *org, &createPipeline)
 
 	if err != nil {
 		log.Fatalf("Updating pipeline failed: %s", err)

--- a/examples/pipelines/list/main.go
+++ b/examples/pipelines/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pipelines, _, err := client.Pipelines.List(*org, nil)
+	pipelines, _, err := client.Pipelines.List(context.Background(), *org, nil)
 
 	if err != nil {
 		log.Fatalf("list pipelines failed: %s", err)

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -34,7 +35,7 @@ func main() {
 		},
 	}
 
-	resp, err := client.Pipelines.Update(*org, &pipeline)
+	resp, err := client.Pipelines.Update(context.Background(), *org, &pipeline)
 
 	if err != nil {
 		log.Fatalf("Updating pipeline failed: %s", err)

--- a/examples/test_runs/get/main.go
+++ b/examples/test_runs/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -27,7 +28,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	testRuns, _, err := client.TestRuns.Get(*org, *slug, *runID)
+	testRuns, _, err := client.TestRuns.Get(context.Background(), *org, *slug, *runID)
 
 	if err != nil {
 		log.Fatalf("Getting test run %s failed: %s", *runID, err)

--- a/examples/test_runs/list/main.go
+++ b/examples/test_runs/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	testRuns, _, err := client.TestRuns.List(*org, *slug, nil)
+	testRuns, _, err := client.TestRuns.List(context.Background(), *org, *slug, nil)
 
 	if err != nil {
 		log.Fatalf("listing test runs for suite %s failed: %s", *slug, err)

--- a/examples/test_suites/create/main.go
+++ b/examples/test_suites/create/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -31,7 +32,7 @@ func main() {
 		TeamUUIDs:     []string{"474de468-84d6-46dc-ba23-bac1add44a60"},
 	}
 
-	suite, _, err := client.TestSuites.Create(*org, &suiteCreate)
+	suite, _, err := client.TestSuites.Create(context.Background(), *org, &suiteCreate)
 
 	if err != nil {
 		log.Fatalf("Creating test suite failed: %s", err)

--- a/examples/test_suites/delete/main.go
+++ b/examples/test_suites/delete/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -24,7 +25,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	resp, err := client.TestSuites.Delete(*org, *slug)
+	resp, err := client.TestSuites.Delete(context.Background(), *org, *slug)
 
 	if err != nil {
 		log.Fatalf("Deleting test suite failed: %s", err)

--- a/examples/test_suites/get/main.go
+++ b/examples/test_suites/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -26,7 +27,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	suite, _, err := client.TestSuites.Get(*org, *slug)
+	suite, _, err := client.TestSuites.Get(context.Background(), *org, *slug)
 
 	if err != nil {
 		log.Fatalf("Getting test suite failed: %s", err)

--- a/examples/test_suites/list/main.go
+++ b/examples/test_suites/list/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -25,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	suites, _, err := client.TestSuites.List(*org, nil)
+	suites, _, err := client.TestSuites.List(context.Background(), *org, nil)
 
 	if err != nil {
 		log.Fatalf("listing test suites failed: %s", err)

--- a/examples/test_suites/update/main.go
+++ b/examples/test_suites/update/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -28,7 +29,7 @@ func main() {
 		Slug:          buildkite.String("example-slug"),
 	}
 
-	resp, err := client.TestSuites.Update(*org, &suiteUpdate)
+	resp, err := client.TestSuites.Update(context.Background(), *org, &suiteUpdate)
 
 	if err != nil {
 		log.Fatalf("Updating test suite failed: %s", err)

--- a/examples/tests/get/main.go
+++ b/examples/tests/get/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -27,7 +28,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	test, _, err := client.Tests.Get(*org, *slug, *testID)
+	test, _, err := client.Tests.Get(context.Background(), *org, *slug, *testID)
 
 	if err != nil {
 		log.Fatalf("Getting test %s failed: %s", *testID, err)


### PR DESCRIPTION
**This PR:** Adds `context.Context` parameters to all methods exported by this library that make API calls to the Buildkite API. **This is a breaking change to the API and will necessitate a v4 release.**

Contexts are useful in this case because they allow users to customise a lot of the behaviour of the requests, most notably by adding timeouts and allowing users to cancel requests - eg, a user would be able to do something like

```Go
ctx, cancel := context.WithDeadline(context.Background(), 5*time.Second)
client.Builds.List(ctx, /* ... */)
```
which would time the request out after five seconds. they'd also be able to use the `cancel` function to cancel the request from another goroutine, for whatever reason they choose.

Closes #98 