### PR TITLE
V3.12.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [v3.12.0](https://github.com/buildkite/go-buildkite/compare/v3.11.0...v3.12.0) (2024-08-19)
+* Deprecate [`buildkite.NewClient`](https://pkg.go.dev/github.com/buildkite/go-buildkite/v3@v3.11.0/buildkite#NewClient) and its associated authenticating roundtrippers, and replace them with a new function `buildkite.NewOpts` [#185](https://github.com/buildkite/go-buildkite/pull/185) ([moskyb](https://github.com/moskyb))
+* Add bindings for Buildkite Packages APIs [#187](https://github.com/buildkite/go-buildkite/pull/186) ([moskyb](https://github.com/moskyb))
+
+
 ## [v3.11.0](https://github.com/buildkite/go-buildkite/compare/v3.10.0...v3.11.0) (2024-02-08)
 * Expose retry_source and retry_type on jobs [#171](https://github.com/buildkite/go-buildkite/pull/171) ([drcapulet](https://github.com/drcapulet))
 * Expose additional webhook fields on builds and jobs [#173](https://github.com/buildkite/go-buildkite/pull/173) ([mstifflin](https://github.com/mstifflin))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# buildkite-go [![Go Reference](https://pkg.go.dev/badge/github.com/buildkite/go-buildkite.svg)](https://pkg.go.dev/github.com/buildkite/go-buildkite/v2) [![Build status](https://badge.buildkite.com/b16a0d730b8732a1cfba06068f8450aa7cc4b2cf40eb6e6717.svg?branch=master)](https://buildkite.com/buildkite/go-buildkite)
+# buildkite-go [![Go Reference](https://pkg.go.dev/badge/github.com/buildkite/go-buildkite.svg)](https://pkg.go.dev/github.com/buildkite/go-buildkite/v3) [![Build status](https://badge.buildkite.com/b16a0d730b8732a1cfba06068f8450aa7cc4b2cf40eb6e6717.svg?branch=master)](https://buildkite.com/buildkite/go-buildkite)
 
 A [Go](http://golang.org) library and client for the [Buildkite API](https://buildkite.com/docs/api). This project draws a lot of its structure and testing methods from [go-github](https://github.com/google/go-github).
 

--- a/buildkite/version.go
+++ b/buildkite/version.go
@@ -1,4 +1,4 @@
 package buildkite
 
 // Version the library version number
-const Version = "3.11.0"
+const Version = "3.12.0"


### PR DESCRIPTION
## [v3.12.0](https://github.com/buildkite/go-buildkite/compare/v3.11.0...v3.12.0) (2024-08-19)
* Deprecate [`buildkite.NewClient`](https://pkg.go.dev/github.com/buildkite/go-buildkite/v3@v3.11.0/buildkite#NewClient) and its associated authenticating roundtrippers, and replace them with a new function `buildkite.NewOpts` [#185](https://github.com/buildkite/go-buildkite/pull/185) ([moskyb](https://github.com/moskyb))
* Add bindings for Buildkite Packages APIs [#187](https://github.com/buildkite/go-buildkite/pull/186) ([moskyb](https://github.com/moskyb))
