### PR TITLE
Add package name to Package type

### DIFF
--- a/buildkite/packages.go
+++ b/buildkite/packages.go
@@ -18,6 +18,7 @@ type PackagesService struct {
 // Package represents a package which has been stored in a registry
 type Package struct {
 	ID           string          `json:"id"`
+	Name         string          `json:"name"`
 	URL          string          `json:"url"`
 	WebURL       string          `json:"web_url"`
 	Organization Organization    `json:"organization"`


### PR DESCRIPTION
**This PR:** Adds a field to the `Package` type, adding the package's name to the struct.

See also: https://github.com/buildkite/buildkite/pull/18494