### PR TITLE
Updated README with NewOpts client/kingpin example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import (
 )
 
 var (
-	apiToken = kingpin.Flag("token", "API token").Required().String()
+    apiToken = kingpin.Flag("token", "API token").Required().String()
     org = kingpin.Flag("org", "Organization slug").Required().String()
 )
 

--- a/README.md
+++ b/README.md
@@ -15,19 +15,21 @@ Simple shortened example for listing all pipelines:
 ```go
 import (
     "github.com/buildkite/go-buildkite/v3/buildkite"
-)
-...
 
-config, err := buildkite.NewTokenConfig(*apiToken, false)
+    "gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+)
+
+client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 
 if err != nil {
-	log.Fatalf("client config failed: %s", err)
+	log.Fatalf("New client configuration failed: %s", err)
 }
 
-client := buildkite.NewClient(config.Client())
-
 pipelines, _, err := client.Pipelines.List(*org, nil)
-
 ```
 
 See the [examples](https://github.com/buildkite/go-buildkite/tree/master/examples) directory for additional examples.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ var (
 client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
 
 if err != nil {
-	log.Fatalf("New client configuration failed: %s", err)
+	log.Fatalf("client config failed: %s", err)
 }
 
 pipelines, _, err := client.Pipelines.List(*org, nil)

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Simple shortened example for listing all pipelines:
 ```go
 import (
     "github.com/buildkite/go-buildkite/v3/buildkite"
-
     "gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
 	apiToken = kingpin.Flag("token", "API token").Required().String()
+    org = kingpin.Flag("org", "Organization slug").Required().String()
 )
 
 client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))


### PR DESCRIPTION
Release [v3.12.0](https://github.com/buildkite/go-buildkite/releases/tag/v3.12.0) introduced a new client configuration constructor via `NewOpts`. The first example on the README was left with the older way of constructing a new client via `NewTokenConfig` - which this adjusts with `NewOpts` and a simplified example with kingpin.