### PR TITLE
Package improvements grab bag

### DIFF
--- a/buildkite/access_tokens_test.go
+++ b/buildkite/access_tokens_test.go
@@ -11,10 +11,10 @@ import (
 func TestAccessTokensService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"uuid": "b63254c0-3271-4a98-8270-7cfbd6c2f14e","scopes": ["read_build"]}`)
 	})
@@ -36,10 +36,10 @@ func TestAccessTokensService_Get(t *testing.T) {
 func TestAccessTokensService_Revoke(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/access-token", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/buildkite/agents_test.go
+++ b/buildkite/agents_test.go
@@ -14,10 +14,10 @@ import (
 func TestAgentsService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
@@ -36,10 +36,10 @@ func TestAgentsService_List(t *testing.T) {
 func TestAgentsService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"id":"123"}`)
 	})
@@ -58,12 +58,12 @@ func TestAgentsService_Get(t *testing.T) {
 func TestAgentsService_Create(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &Agent{Name: String("new_agent_bob")}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
 		v := new(Agent)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -91,10 +91,10 @@ func TestAgentsService_Create(t *testing.T) {
 func TestAgentsService_Delete(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/agents/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -107,10 +107,10 @@ func TestAgentsService_Delete(t *testing.T) {
 func TestAgentsService_Stop(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/agents/123/stop", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/agents/123/stop", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		body, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -13,10 +13,10 @@ import (
 func TestAnnotationsService_ListByBuild(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/annotations", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/annotations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{
 			"id": "de0d4ab5-6360-467a-a34b-e5ef5db5320d",
@@ -67,7 +67,7 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 func TestAnnotationsService_Create(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &AnnotationCreate{
@@ -77,7 +77,7 @@ func TestAnnotationsService_Create(t *testing.T) {
 		Append:  Bool(false),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline/builds/10/annotations", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline/builds/10/annotations", func(w http.ResponseWriter, r *http.Request) {
 		v := new(AnnotationCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -13,10 +13,10 @@ import (
 func TestBuildsService_Cancel(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/1/cancel", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/1/cancel", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		fmt.Fprint(w, `{
   "id": "1",
@@ -38,10 +38,10 @@ func TestBuildsService_Cancel(t *testing.T) {
 func TestBuildsService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
@@ -68,10 +68,10 @@ func TestBuildsService_Get(t *testing.T) {
 	t.Run("returns a build struct with expected id", func(t *testing.T) {
 		t.Parallel()
 
-		mux, client, teardown := newMockServerAndClient(t)
+		server, client, teardown := newMockServerAndClient(t)
 		t.Cleanup(teardown)
 
-		mux.HandleFunc(requestSlug,
+		server.HandleFunc(requestSlug,
 			func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
 				_, _ = fmt.Fprintf(w, `{"id":"%s"}`, buildNumber)
@@ -91,11 +91,11 @@ func TestBuildsService_Get(t *testing.T) {
 	t.Run("returns a build struct with expected job containing a group key", func(t *testing.T) {
 		t.Parallel()
 
-		mux, client, teardown := newMockServerAndClient(t)
+		server, client, teardown := newMockServerAndClient(t)
 		t.Cleanup(teardown)
 
 		expectedGroup := "job_group"
-		mux.HandleFunc(requestSlug,
+		server.HandleFunc(requestSlug,
 			func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
 				_, _ = fmt.Fprintf(w, `{"id":"%s", "jobs": [ {"group_key": "%s" }]}`,
@@ -118,14 +118,14 @@ func TestBuildsService_Get(t *testing.T) {
 	t.Run("returns a build struct with expected manual job values", func(t *testing.T) {
 		t.Parallel()
 
-		mux, client, teardown := newMockServerAndClient(t)
+		server, client, teardown := newMockServerAndClient(t)
 		t.Cleanup(teardown)
 
 		jobType := "manual"
 		unblockedAt := "2023-01-01T15:00:00.00Z"
 		parsedTime := must(time.Parse(BuildKiteDateFormat, unblockedAt))
 
-		mux.HandleFunc(requestSlug,
+		server.HandleFunc(requestSlug,
 			func(w http.ResponseWriter, r *http.Request) {
 				testMethod(t, r, "GET")
 				_, _ = fmt.Fprintf(w, `{"id":"%s", "jobs": [ {"type": "%s", "unblocked_at": "%s" }]}`,
@@ -150,10 +150,10 @@ func TestBuildsService_Get(t *testing.T) {
 func TestBuildsService_List_by_status(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
 			"state[]": "running",
@@ -180,10 +180,10 @@ func TestBuildsService_List_by_status(t *testing.T) {
 func TestBuildsService_List_by_multiple_status(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValuesList(t, r, valuesList{
 			{"state[]", "running"},
@@ -211,7 +211,7 @@ func TestBuildsService_List_by_multiple_status(t *testing.T) {
 func TestBuildsService_List_by_created_date(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	ts, err := time.Parse(BuildKiteDateFormat, "2016-03-24T01:00:00Z")
@@ -219,7 +219,7 @@ func TestBuildsService_List_by_created_date(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
 			"created_from": "2016-03-24T01:00:00Z",
@@ -246,10 +246,10 @@ func TestBuildsService_List_by_created_date(t *testing.T) {
 func TestBuildsService_ListByOrg(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
@@ -268,10 +268,10 @@ func TestBuildsService_ListByOrg(t *testing.T) {
 func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
 			"branch[]": "my-great-branch",
@@ -299,10 +299,10 @@ func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
 func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValuesList(t, r, valuesList{
 			{"branch[]", "my-great-branch"},
@@ -328,10 +328,10 @@ func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 func TestBuildsService_ListByPipeline(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})

--- a/buildkite/cluster_queues_test.go
+++ b/buildkite/cluster_queues_test.go
@@ -13,10 +13,10 @@ import (
 func TestClusterQueuesService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -130,10 +130,10 @@ func TestClusterQueuesService_List(t *testing.T) {
 func TestClusterQueuesService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -211,7 +211,7 @@ func TestClusterQueuesService_Get(t *testing.T) {
 func TestClusterQueuesService_Create(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
@@ -219,7 +219,7 @@ func TestClusterQueuesService_Create(t *testing.T) {
 		Description: String("Development 1 queue"),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterQueueCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -256,7 +256,7 @@ func TestClusterQueuesService_Create(t *testing.T) {
 func TestClusterQueuesService_Update(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
@@ -264,7 +264,7 @@ func TestClusterQueuesService_Update(t *testing.T) {
 		Description: String("Development 1 queue"),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterQueueCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -292,7 +292,7 @@ func TestClusterQueuesService_Update(t *testing.T) {
 	// Lets update the description of the cluster queue
 	queue.Description = String("Development 1 Team queue")
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterQueueUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -331,10 +331,10 @@ func TestClusterQueuesService_Update(t *testing.T) {
 func TestClusterQueuesService_Delete(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -348,7 +348,7 @@ func TestClusterQueuesService_Delete(t *testing.T) {
 func TestClusterQueuesService_Pause(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterQueueCreate{
@@ -356,7 +356,7 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 		Description: String("Development 1 Team queue"),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterQueueCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -384,7 +384,7 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 	// Update the dispatch paused note of the queue
 	queue.DispatchPausedNote = String("Pausing dispatch for the weekend")
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/5cadac07-51dd-4e12-bea3-d91be4655c2f/pause_dispatch", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/5cadac07-51dd-4e12-bea3-d91be4655c2f/pause_dispatch", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterQueueUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -425,10 +425,10 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 func TestClusterQueuesService_Resume(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/5cadac07-51dd-4e12-bea3-d91be4655c2f/resume_dispatch", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/5cadac07-51dd-4e12-bea3-d91be4655c2f/resume_dispatch", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -13,10 +13,10 @@ import (
 func TestClusterTokensService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -106,10 +106,10 @@ func TestClusterTokensService_List(t *testing.T) {
 func TestClusterTokensService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -169,14 +169,14 @@ func TestClusterTokensService_Get(t *testing.T) {
 func TestClusterTokensService_Create(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterTokenCreateUpdate{
 		Description: String("Development 2 cluster token"),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterTokenCreateUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -211,14 +211,14 @@ func TestClusterTokensService_Create(t *testing.T) {
 func TestClusterTokensService_Update(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterTokenCreateUpdate{
 		Description: String("Development 1 Fleet Token"),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterTokenCreateUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -245,7 +245,7 @@ func TestClusterTokensService_Update(t *testing.T) {
 	// Lets update the description of the cluster token
 	token.Description = String("Development 1 agent token")
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterTokenCreateUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -282,10 +282,10 @@ func TestClusterTokensService_Update(t *testing.T) {
 func TestClusterTokensService_Delete(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -13,10 +13,10 @@ import (
 func TestClustersService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -120,10 +120,10 @@ func TestClustersService_List(t *testing.T) {
 func TestClustersService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -189,7 +189,7 @@ func TestClustersService_Get(t *testing.T) {
 func TestClustersService_Create(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterCreate{
@@ -199,7 +199,7 @@ func TestClustersService_Create(t *testing.T) {
 		Color:       String("E5F185"),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -240,7 +240,7 @@ func TestClustersService_Create(t *testing.T) {
 func TestClustersService_Update(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &ClusterCreate{
@@ -250,7 +250,7 @@ func TestClustersService_Update(t *testing.T) {
 		Color:       String("E5F185"),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -280,7 +280,7 @@ func TestClustersService_Update(t *testing.T) {
 	// Lets update the description of the cluster
 	cluster.Description = String("A test cluster")
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/a32cbe81-82b2-45f7-bd97-66f1ac2c0cc1", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/a32cbe81-82b2-45f7-bd97-66f1ac2c0cc1", func(w http.ResponseWriter, r *http.Request) {
 		v := new(ClusterUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -324,10 +324,10 @@ func TestClustersService_Update(t *testing.T) {
 func TestClustersService_Delete(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/clusters/7d2aa9b5-bf2a-4ce0-b9d7-90d3d9b8942c", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/7d2aa9b5-bf2a-4ce0-b9d7-90d3d9b8942c", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/buildkite/flaky_tests_test.go
+++ b/buildkite/flaky_tests_test.go
@@ -12,10 +12,10 @@ import (
 func TestFlakyTestsService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/flaky-tests", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/flaky-tests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`

--- a/buildkite/jobs_test.go
+++ b/buildkite/jobs_test.go
@@ -12,10 +12,10 @@ import (
 func TestJobsService_UnblockJob(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/unblock", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/unblock", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		fmt.Fprint(w, `{
   "id": "awesome-job-id",
@@ -37,10 +37,10 @@ func TestJobsService_UnblockJob(t *testing.T) {
 func TestJobsService_RetryJob(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/retry", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/retry", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PUT")
 		fmt.Fprint(w, `{
   "id": "awesome-job-id",
@@ -64,10 +64,10 @@ func TestJobsService_RetryJob(t *testing.T) {
 func TestJobsService_GetJobLog(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/log", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/log", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sub-keith/builds/awesome-build/jobs/awesome-job-id/log",
@@ -96,7 +96,7 @@ func TestJobsService_GetJobLog(t *testing.T) {
 func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	envVars := map[string]string{
@@ -123,7 +123,7 @@ func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
 		"BUILDKITE_BUILD_CREATOR_EMAIL":   "keith@buildkite.com",
 		"BUILDKITE_AGENT_META_DATA_LOCAL": "true",
 	}
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/15/jobs/awesome-job-id/env", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/15/jobs/awesome-job-id/env", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		body := map[string]map[string]string{
 			"env": envVars,

--- a/buildkite/misc_test.go
+++ b/buildkite/misc_test.go
@@ -11,10 +11,10 @@ import (
 func TestListEmojis(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/emojis", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/emojis", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"name":"rocket","url":"https://a.buildboxassets.com/assets/emoji2/unicode/1f680.png?v2"}]`)
 	})

--- a/buildkite/organizations_test.go
+++ b/buildkite/organizations_test.go
@@ -11,10 +11,10 @@ import (
 func TestOrganizationsService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
@@ -33,10 +33,10 @@ func TestOrganizationsService_List(t *testing.T) {
 func TestOrganizationsService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/babelstoemp", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/babelstoemp", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"id":"123"}`)
 	})

--- a/buildkite/package_registries.go
+++ b/buildkite/package_registries.go
@@ -28,9 +28,27 @@ type PackageRegistry struct {
 
 // CreatePackageRegistryInput represents the input to create a package registry.
 type CreatePackageRegistryInput struct {
-	Name        string `json:"name,omitempty"`        // The name of the package registry
-	Ecosystem   string `json:"ecosystem,omitempty"`   // The ecosystem of the package registry
-	Description string `json:"description,omitempty"` // A description for the package registry
+	Name        string                    `json:"name,omitempty"`        // The name of the package registry
+	Ecosystem   string                    `json:"ecosystem,omitempty"`   // The ecosystem of the package registry
+	Description string                    `json:"description,omitempty"` // A description for the package registry
+	Emoji       string                    `json:"emoji,omitempty"`       // An emoji for the package registry, in buildkite format (eg ":rocket:")
+	Color       string                    `json:"color,omitempty"`       // A color for the package registry, in hex format (eg "#FF0000")
+	OIDCPolicy  PackageRegistryOIDCPolicy `json:"oidc_policy,omitempty"` // The OIDC policy for the package registry, as a YAML or JSON string
+}
+
+type PackageRegistryOIDCPolicy []OIDCPolicyStatement
+
+type OIDCPolicyStatement struct {
+	Issuer string               `json:"iss"`
+	Claims map[string]ClaimRule `json:"claims"`
+}
+
+type ClaimRule struct {
+	Equals    any      `json:"equals,omitempty"`
+	NotEquals any      `json:"not_equals,omitempty"`
+	In        []any    `json:"in,omitempty"`
+	NotIn     []any    `json:"not_in,omitempty"`
+	Matches   []string `json:"matches,omitempty"`
 }
 
 // Create creates a package registry for an organization
@@ -51,8 +69,11 @@ func (rs *PackageRegistriesService) Create(ctx context.Context, organizationSlug
 }
 
 type UpdatePackageRegistryInput struct {
-	Name        string `json:"name,omitempty"`        // The name of the package registry
-	Description string `json:"description,omitempty"` // A description for the package registry
+	Name        string                    `json:"name,omitempty"`        // The name of the package registry
+	Description string                    `json:"description,omitempty"` // A description for the package registry
+	Emoji       string                    `json:"emoji,omitempty"`       // An emoji for the package registry, in buildkite format (eg ":rocket:")
+	Color       string                    `json:"color,omitempty"`       // A color for the package registry, in hex format (eg "#FF0000")
+	OIDCPolicy  PackageRegistryOIDCPolicy `json:"oidc_policy,omitempty"` // The OIDC policy for the package registry, as a YAML or JSON string
 }
 
 // Update updates a package registry for an organization

--- a/buildkite/package_registries_test.go
+++ b/buildkite/package_registries_test.go
@@ -45,11 +45,11 @@ var (
 func TestPackageRegistryGet(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	want := registry
-	mux.HandleFunc("/v2/packages/organizations/test-org/registries/my-cool-registry", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/packages/organizations/test-org/registries/my-cool-registry", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 
 		err := json.NewEncoder(w).Encode(want)
@@ -71,11 +71,11 @@ func TestPackageRegistryGet(t *testing.T) {
 func TestPackageRegistryList(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	want := registries
-	mux.HandleFunc("/v2/packages/organizations/test-org/registries", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/packages/organizations/test-org/registries", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 
 		err := json.NewEncoder(w).Encode(want)
@@ -97,7 +97,7 @@ func TestPackageRegistryList(t *testing.T) {
 func TestPackageRegistryCreate(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	wantInput := CreatePackageRegistryInput{
@@ -107,7 +107,7 @@ func TestPackageRegistryCreate(t *testing.T) {
 	}
 
 	want := registry
-	mux.HandleFunc("/v2/packages/organizations/test-org/registries", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/packages/organizations/test-org/registries", func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
 		testMethod(t, r, "POST")
@@ -143,7 +143,7 @@ func TestPackageRegistryCreate(t *testing.T) {
 func TestPackageRegistryUpdate(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	wantInput := UpdatePackageRegistryInput{
@@ -155,7 +155,7 @@ func TestPackageRegistryUpdate(t *testing.T) {
 	want.Name = wantInput.Name
 	want.Description = wantInput.Description
 
-	mux.HandleFunc("/v2/packages/organizations/test-org/registries/my-cool-registry", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/packages/organizations/test-org/registries/my-cool-registry", func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()
 
 		testMethod(t, r, "PATCH")
@@ -191,10 +191,10 @@ func TestPackageRegistryUpdate(t *testing.T) {
 func TestPackageRegistryDelete(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/packages/organizations/test-org/registries/my-cool-registry", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/packages/organizations/test-org/registries/my-cool-registry", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/buildkite/packages.go
+++ b/buildkite/packages.go
@@ -102,7 +102,7 @@ func normalizeToFile(r io.Reader, filename string) (*os.File, error) {
 		return nil, fmt.Errorf("writing to temporary file: %v", err)
 	}
 
-	_, err = f.Seek(0, 0)
+	_, err = f.Seek(0, io.SeekStart)
 	if err != nil {
 		return nil, fmt.Errorf("seeking to beginning of temporary file: %v", err)
 	}

--- a/buildkite/packages.go
+++ b/buildkite/packages.go
@@ -1,12 +1,13 @@
 package buildkite
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
-	"mime/multipart"
 	"os"
+	"path/filepath"
+
+	"github.com/buildkite/go-buildkite/v3/internal/bkmultipart"
 )
 
 const fileFormKey = "file"
@@ -56,26 +57,24 @@ func (ps *PackagesService) Create(ctx context.Context, organizationSlug, registr
 		filename = f.Name()
 	}
 
-	var b bytes.Buffer
-	w := multipart.NewWriter(&b)
-	fw, err := w.CreateFormFile(fileFormKey, filename)
+	packageTempFile, err := normalizeToFile(cpi.Package, filename)
 	if err != nil {
-		return Package{}, nil, fmt.Errorf("creating multipart form file: %v", err)
+		return Package{}, nil, fmt.Errorf("writing package to tempfile: %v", err)
 	}
+	defer os.Remove(packageTempFile.Name())
+	defer packageTempFile.Close()
 
-	_, err = io.Copy(fw, cpi.Package)
-	if err != nil {
-		return Package{}, nil, fmt.Errorf("copying data into multipart payload: %v", err)
-	}
-	w.Close()
+	s := bkmultipart.NewStreamer()
+	s.WriteFile(fileFormKey, packageTempFile, filename)
 
 	url := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages", organizationSlug, registrySlug)
-	req, err := ps.client.NewRequest(ctx, "POST", url, &b)
+	req, err := ps.client.NewRequest(ctx, "POST", url, s)
 	if err != nil {
 		return Package{}, nil, fmt.Errorf("creating POST package request: %v", err)
 	}
 
-	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.Header.Set("Content-Type", s.ContentType)
+	req.Header.Set("Content-Length", fmt.Sprintf("%d", s.Len()))
 
 	var p Package
 	resp, err := ps.client.Do(req, &p)
@@ -84,4 +83,36 @@ func (ps *PackagesService) Create(ctx context.Context, organizationSlug, registr
 	}
 
 	return p, resp, err
+}
+
+// normalizeToFile takes and io.Reader (which might itself already be a file, but could be a stream or other source) and
+// writes it to a temporary file, returning the file handle.
+// The file is written to a temporary directory, and then renamed to the desired filename.
+// We do this normalization to ensure that we can accurately calculate the Content-Length of the request body, which is
+// required by S3. We write to disk (instead of buffering in memory) to avoid memory exhaustion for large files.
+func normalizeToFile(r io.Reader, filename string) (*os.File, error) {
+	basename := filepath.Base(filename)
+	f, err := os.CreateTemp("", basename)
+	if err != nil {
+		return nil, fmt.Errorf("creating temporary file: %v", err)
+	}
+
+	_, err = io.Copy(f, r)
+	if err != nil {
+		return nil, fmt.Errorf("writing to temporary file: %v", err)
+	}
+
+	_, err = f.Seek(0, 0)
+	if err != nil {
+		return nil, fmt.Errorf("seeking to beginning of temporary file: %v", err)
+	}
+
+	// Rename the temporary file to the desired filename, which is important for Buildkite Package indexing
+	tempFileDir := filepath.Dir(f.Name())
+	err = os.Rename(f.Name(), filepath.Join(tempFileDir, basename))
+	if err != nil {
+		return nil, fmt.Errorf("renaming temporary file: %v", err)
+	}
+
+	return f, nil
 }

--- a/buildkite/packages_test.go
+++ b/buildkite/packages_test.go
@@ -23,7 +23,7 @@ var (
 		WebURL:   "https://buildkite.com/my-org/my-registry/my-package",
 		Registry: registry,
 		Organization: Organization{
-			ID:   String("my-org"),
+			ID:   String(uuid.NewString()),
 			Slug: String("my-org"),
 			Name: String("My Org"),
 		},
@@ -33,12 +33,12 @@ var (
 func TestGetPackage(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	want := pkg
 	endpoint := fmt.Sprintf("/v2/packages/organizations/my-org/registries/my-registry/packages/%s", pkg.ID)
-	mux.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 
 		err := json.NewEncoder(w).Encode(pkg)

--- a/buildkite/pipeline_templates_test.go
+++ b/buildkite/pipeline_templates_test.go
@@ -13,10 +13,10 @@ import (
 func TestPipelineTemplatesService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -138,10 +138,10 @@ func TestPipelineTemplatesService_List(t *testing.T) {
 func TestPipelineTemplatesService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -216,7 +216,7 @@ func TestPipelineTemplatesService_Get(t *testing.T) {
 func TestPipelineTemplatesService_Create(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &PipelineTemplateCreateUpdate{
@@ -226,7 +226,7 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 		Available:     Bool(true),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
 		v := new(PipelineTemplateCreateUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -271,7 +271,7 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 func TestPipelineTemplatesService_Update(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &PipelineTemplateCreateUpdate{
@@ -281,7 +281,7 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 		Available:     Bool(true),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
 		v := new(PipelineTemplateCreateUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -312,7 +312,7 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 	// Lets update the description of the pipeline template
 	pipelineTemplate.Description = String("A pipeline template for uploading a production pipeline YAML (pipeline-production.yml)")
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", func(w http.ResponseWriter, r *http.Request) {
 		v := new(PipelineTemplateCreateUpdate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -357,10 +357,10 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 func TestPipelineTemplatesService_Delete(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/19dbd05a-96d7-430f-bac0-14b791558562", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/19dbd05a-96d7-430f-bac0-14b791558562", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -12,10 +12,10 @@ import (
 func TestPipelinesService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
@@ -34,7 +34,7 @@ func TestPipelinesService_List(t *testing.T) {
 func TestPipelinesService_Create(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -59,7 +59,7 @@ func TestPipelinesService_Create(t *testing.T) {
 		},
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		v := new(CreatePipeline)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -128,7 +128,7 @@ func TestPipelinesService_Create(t *testing.T) {
 func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -136,7 +136,7 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 		Configuration: *String("steps:\n  - command: \"script/release.sh\"\n    label: \"Build :package:\""),
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		v := new(CreatePipeline)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -197,10 +197,10 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 func TestPipelinesService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"id":"123",
 						"slug":"my-great-pipeline-slug",
@@ -225,10 +225,10 @@ func TestPipelinesService_Get(t *testing.T) {
 func TestPipelinesService_Delete(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 
@@ -241,7 +241,7 @@ func TestPipelinesService_Delete(t *testing.T) {
 func TestPipelinesService_Update(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &CreatePipeline{Name: *String("my-great-pipeline"),
@@ -261,7 +261,7 @@ func TestPipelinesService_Update(t *testing.T) {
 		},
 	}
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		v := new(CreatePipeline)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -298,7 +298,7 @@ func TestPipelinesService_Update(t *testing.T) {
 
 	pipeline.Name = String("derp")
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-repo", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-repo", func(w http.ResponseWriter, r *http.Request) {
 		v := new(CreatePipeline)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -361,10 +361,10 @@ func TestPipelinesService_Update(t *testing.T) {
 func TestPipelinesService_AddWebhook(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/webhook", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/webhook", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -377,10 +377,10 @@ func TestPipelinesService_AddWebhook(t *testing.T) {
 func TestPipelinesService_Archive(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/archive", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/archive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 
@@ -393,10 +393,10 @@ func TestPipelinesService_Archive(t *testing.T) {
 func TestPipelinesService_Unarchive(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/unarchive", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline-slug/unarchive", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 	})
 

--- a/buildkite/teams_test.go
+++ b/buildkite/teams_test.go
@@ -11,10 +11,10 @@ import (
 func TestTeamsService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
 	})
@@ -33,10 +33,10 @@ func TestTeamsService_List(t *testing.T) {
 func TestTeamsService_ListForUser(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/organizations/my-great-org/teams", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		testFormValues(t, r, values{
 			"user_id": "abc",

--- a/buildkite/test_runs_test.go
+++ b/buildkite/test_runs_test.go
@@ -12,10 +12,10 @@ import (
 func TestTestRunsService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -80,10 +80,10 @@ func TestTestRunsService_List(t *testing.T) {
 func TestTestRunsService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`

--- a/buildkite/test_suites_test.go
+++ b/buildkite/test_suites_test.go
@@ -12,10 +12,10 @@ import (
 func TestTestSuitesService_List(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -75,10 +75,10 @@ func TestTestSuitesService_List(t *testing.T) {
 func TestTestSuitesService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-1", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-1", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`
@@ -117,7 +117,7 @@ func TestTestSuitesService_Get(t *testing.T) {
 func TestTestSuitesService_Create(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &TestSuiteCreate{
@@ -126,7 +126,7 @@ func TestTestSuitesService_Create(t *testing.T) {
 		TeamUUIDs:     []string{"8369b300-fff0-4ef1-91de-010f72f4458d"},
 	}
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
 		v := new(TestSuiteCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -164,7 +164,7 @@ func TestTestSuitesService_Create(t *testing.T) {
 func TestTestSuitesService_Update(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
 	input := &TestSuiteCreate{
@@ -173,7 +173,7 @@ func TestTestSuitesService_Update(t *testing.T) {
 		TeamUUIDs:     []string{"818b0849-9718-4898-8de3-42d591a7fe26"},
 	}
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
 		v := new(TestSuiteCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -202,7 +202,7 @@ func TestTestSuitesService_Update(t *testing.T) {
 	// Lets update the default branch to develop
 	suite.DefaultBranch = String("develop")
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-4", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-4", func(w http.ResponseWriter, r *http.Request) {
 		v := new(TestSuiteCreate)
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -238,10 +238,10 @@ func TestTestSuitesService_Update(t *testing.T) {
 func TestTestSuitesService_Delete(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-5", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-5", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "DELETE")
 	})
 

--- a/buildkite/tests_test.go
+++ b/buildkite/tests_test.go
@@ -11,10 +11,10 @@ import (
 func TestTestsService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w,
 			`

--- a/buildkite/user_test.go
+++ b/buildkite/user_test.go
@@ -11,10 +11,10 @@ import (
 func TestUserService_Get(t *testing.T) {
 	t.Parallel()
 
-	mux, client, teardown := newMockServerAndClient(t)
+	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	mux.HandleFunc("/v2/user", func(w http.ResponseWriter, r *http.Request) {
+	server.HandleFunc("/v2/user", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
 		fmt.Fprint(w, `{"id":"123","name":"Jane Doe","email":"jane@doe.com"}`)
 	})

--- a/examples/package_registries/create/main.go
+++ b/examples/package_registries/create/main.go
@@ -30,6 +30,17 @@ func main() {
 		Name:        *registryName,
 		Ecosystem:   *registryEcosystem,
 		Description: *registryDescription,
+
+		OIDCPolicy: buildkite.PackageRegistryOIDCPolicy{
+			buildkite.OIDCPolicyStatement{
+				Issuer: "https://agent.buildkite.com",
+				Claims: map[string]buildkite.ClaimRule{
+					"pipeline_slug": {
+						Equals: "my-pipeline",
+					},
+				},
+			},
+		},
 	})
 	if err != nil {
 		log.Fatalf("Creating registry failed: %v", err)

--- a/internal/bkmultipart/streamer.go
+++ b/internal/bkmultipart/streamer.go
@@ -1,0 +1,91 @@
+package bkmultipart
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"os"
+)
+
+// A wrapper around the complexities of streaming a multipart file and fields to
+// an http endpoint that infuriatingly requires a Content-Length
+// Derived from https://github.com/technoweenie/multipartstreamer
+type Streamer struct {
+	ContentType string
+
+	bodyBuffer  *bytes.Buffer
+	closeBuffer *bytes.Buffer
+	bodyWriter  *multipart.Writer
+
+	reader        io.Reader
+	contentLength int64
+	writtenFile   bool
+}
+
+// NewStreamer initializes a new Streamer.
+func NewStreamer() *Streamer {
+	s := &Streamer{bodyBuffer: &bytes.Buffer{}}
+
+	s.bodyWriter = multipart.NewWriter(s.bodyBuffer)
+	boundary := s.bodyWriter.Boundary()
+	s.ContentType = "multipart/form-data; boundary=" + boundary
+
+	closeBoundary := fmt.Sprintf("\r\n--%s--\r\n", boundary)
+	s.closeBuffer = bytes.NewBufferString(closeBoundary)
+
+	// if a file is added, the reader will be set up to read from the body, the file and the closer
+	s.reader = io.MultiReader(s.bodyBuffer, s.closeBuffer)
+
+	return s
+}
+
+// WriteField writes a form field to the multipart.Writer.
+func (s *Streamer) WriteField(key, value string) error {
+	return s.bodyWriter.WriteField(key, value)
+}
+
+func (s *Streamer) WriteFields(fields map[string]string) error {
+	for key, value := range fields {
+		if err := s.WriteField(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteFile writes the multi-part preamble which will be followed by file data
+// This can only be called once and must be the last thing written to the streamer
+func (s *Streamer) WriteFile(key string, file *os.File, displayedFilename string) error {
+	if s.writtenFile {
+		return errors.New("WriteFile can't be called multiple times")
+	}
+
+	fi, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	s.contentLength = fi.Size()
+
+	_, err = s.bodyWriter.CreateFormFile(key, displayedFilename)
+	if err != nil {
+		return fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	// Set up a reader that combines the body, the file and the closer in a stream
+	s.reader = io.MultiReader(s.bodyBuffer, file, s.closeBuffer)
+	s.writtenFile = true
+
+	return nil
+}
+
+// Len calculates the byte size of the multipart content.
+func (s *Streamer) Len() int64 {
+	return int64(s.bodyBuffer.Len()) + s.contentLength + int64(s.closeBuffer.Len())
+}
+
+func (s *Streamer) Read(p []byte) (n int, err error) {
+	return s.reader.Read(p)
+}

--- a/internal/bkmultipart/streamer.go
+++ b/internal/bkmultipart/streamer.go
@@ -9,9 +9,10 @@ import (
 	"os"
 )
 
-// A wrapper around the complexities of streaming a multipart file and fields to
-// an http endpoint that infuriatingly requires a Content-Length
-// Derived from https://github.com/technoweenie/multipartstreamer
+// A wrapper around the complexities of streaming a multipart file and fields to an http endpoint that infuriatingly
+// requires a Content-Length
+// Stolen/adapted from the multipart streamer in https://github.com/buildkite/agentv/v3/internal/artifact, which itself
+// was derived from https://github.com/technoweenie/multipartstreamer
 type Streamer struct {
 	ContentType string
 

--- a/internal/bkmultipart/streamer_test.go
+++ b/internal/bkmultipart/streamer_test.go
@@ -101,7 +101,7 @@ func parseForm(t *testing.T, streamer *bkmultipart.Streamer) *multipart.Form {
 	}
 
 	b := &bytes.Buffer{}
-	_, err = io.Copy(b, streamer)
+	_, err = io.Copy(b, streamer.Reader())
 	if err != nil {
 		t.Fatalf("io.Copy(bytes.Buffer, s) = %v, want nil", err)
 	}

--- a/internal/bkmultipart/streamer_test.go
+++ b/internal/bkmultipart/streamer_test.go
@@ -43,8 +43,10 @@ func TestEncodingFile(t *testing.T) {
 		t.Fatalf("os.CreateTemp() = %v, want nil", err)
 	}
 
-	t.Cleanup(func() { os.Remove(tempFile.Name()) })
-	t.Cleanup(func() { tempFile.Close() })
+	t.Cleanup(func() {
+		tempFile.Close()
+		os.Remove(tempFile.Name())
+	})
 
 	if _, err := tempFile.WriteString("hello world"); err != nil {
 		t.Fatalf(`tempFile.WriteString("hello world") = %v, want nil`, err)

--- a/internal/bkmultipart/streamer_test.go
+++ b/internal/bkmultipart/streamer_test.go
@@ -50,8 +50,8 @@ func TestEncodingFile(t *testing.T) {
 		t.Fatalf(`tempFile.WriteString("hello world") = %v, want nil`, err)
 	}
 
-	if _, err := tempFile.Seek(0, 0); err != nil {
-		t.Fatalf("tempFile.Seek(0, 0) = %v, want nil", err)
+	if _, err := tempFile.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("tempFile.Seek(0, io.SeekStart) = %v, want nil", err)
 	}
 
 	s := bkmultipart.NewStreamer()

--- a/internal/bkmultipart/streamer_test.go
+++ b/internal/bkmultipart/streamer_test.go
@@ -1,0 +1,114 @@
+package bkmultipart_test
+
+import (
+	"bytes"
+	"io"
+	"mime"
+	"mime/multipart"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/buildkite/go-buildkite/v3/internal/bkmultipart"
+)
+
+func TestEncodingFormFields(t *testing.T) {
+	t.Parallel()
+
+	s := bkmultipart.NewStreamer()
+	fields := map[string]string{
+		"mountain": "cotopaxi",
+		"city":     "guayaquil",
+	}
+	if err := s.WriteFields(fields); err != nil {
+		t.Fatalf("WriteFields(%# v) = %v, want nil", fields, err)
+	}
+
+	form := parseForm(t, s)
+	for key, values := range form.Value {
+		if len(values) != 1 {
+			t.Fatalf("got %d values for %s, want 1", len(values), key)
+		}
+		if got, want := values[0], fields[key]; got != want {
+			t.Fatalf("form.Value[%q] = [%q], want [%q]", key, got, want)
+		}
+	}
+}
+
+func TestEncodingFile(t *testing.T) {
+	t.Parallel()
+
+	tempFile, err := os.CreateTemp("", "buildkite-go-sdk-test")
+	if err != nil {
+		t.Fatalf("os.CreateTemp() = %v, want nil", err)
+	}
+
+	t.Cleanup(func() { os.Remove(tempFile.Name()) })
+	t.Cleanup(func() { tempFile.Close() })
+
+	if _, err := tempFile.WriteString("hello world"); err != nil {
+		t.Fatalf(`tempFile.WriteString("hello world") = %v, want nil`, err)
+	}
+
+	if _, err := tempFile.Seek(0, 0); err != nil {
+		t.Fatalf("tempFile.Seek(0, 0) = %v, want nil", err)
+	}
+
+	s := bkmultipart.NewStreamer()
+
+	fileKey := "file"
+	if err := s.WriteFile(fileKey, tempFile, "test.txt"); err != nil {
+		t.Fatalf("WriteFile() = %v, want nil", err)
+	}
+
+	form := parseForm(t, s)
+
+	if got, want := len(form.File[fileKey]), 1; got != want {
+		t.Fatalf("len(form.File[\"file\"]) = %d, want %d", got, want)
+	}
+
+	file := form.File[fileKey][0]
+	if got, want := file.Filename, "test.txt"; got != want {
+		t.Fatalf("file.Filename = %q, want %q", got, want)
+	}
+
+	f, err := file.Open()
+	if err != nil {
+		t.Fatalf("file.Open() = %v, want nil", err)
+	}
+
+	b := &strings.Builder{}
+	if _, err := io.Copy(b, f); err != nil {
+		t.Fatalf("io.Copy(strings.Builder, file) = %v, want nil", err)
+	}
+
+	if got, want := b.String(), "hello world"; got != want {
+		t.Fatalf("file contents = %q, want %q", got, want)
+	}
+}
+
+func parseForm(t *testing.T, streamer *bkmultipart.Streamer) *multipart.Form {
+	_, params, err := mime.ParseMediaType(streamer.ContentType)
+	if err != nil {
+		t.Fatalf("mime.ParseMediaType(%q) = %v, want nil", streamer.ContentType, err)
+	}
+
+	boundary, ok := params["boundary"]
+	if !ok {
+		t.Fatalf("want boundary in content type")
+	}
+
+	b := &bytes.Buffer{}
+	_, err = io.Copy(b, streamer)
+	if err != nil {
+		t.Fatalf("io.Copy(bytes.Buffer, s) = %v, want nil", err)
+	}
+
+	mr := multipart.NewReader(b, boundary)
+	form, err := mr.ReadForm(1 << 20)
+	if err != nil {
+		t.Fatalf("mr.ReadForm() = %v, want nil", err)
+	}
+
+	return form
+}


### PR DESCRIPTION
**This PR:** Adds a couple of features/fixes to the package registry functions in this module, as well as a change to HTTP testing that'll allow for better multi-request testing.

The changes:
- Previously, we were buffering package files in memory twice(!!) before sending them off to buildkite - once in the multipart body, then again as part of sending the request off. This PR gets rid of the first buffer in 24ec51eb9dfa81220f63349c5ebf7f6f31e78c40, and the second in e080be79093c71fc00c037c4759361ba27b6ad4b. Files are now streamed to buildkite without being stored in memory.

  Part of this work was adapting/stealing the multipart streamer [from the agent](https://github.com/buildkite/agent/blob/main/internal/artifact/bk_uploader.go#L299-L370) and refining it a wee bit - this is all tested, but i'd love some extra eyes on it!
  
- We've recently added a bunch more fields to package registries in the Buildkite REST API (thanks @ensvo!!). This PR updates structs reflecting registries to include those new fields
  -  Note: we only return the OIDC policy as a string, as it's a non-consistent structure and tricky to parse idiomatically in go. We do, however, offer a type, `buildkite.OIDCPolicy` that allows for idiomatic construction of OIDC policies in raw go.
- I've added a feature to our HTTP testing in this module so that the test server records its calls - this makes it easier for us to assert that a certain number of calls were made, or which calls were made in which order.