### PR TITLE
Remove YAML bindings for exported data types

### DIFF
--- a/buildkite/access_tokens.go
+++ b/buildkite/access_tokens.go
@@ -10,8 +10,8 @@ type AccessTokensService struct {
 }
 
 type AccessToken struct {
-	UUID   *string   `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	Scopes *[]string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
+	UUID   *string   `json:"uuid,omitempty"`
+	Scopes *[]string `json:"scopes,omitempty"`
 }
 
 // Get gets the current token which was used to authenticate the request

--- a/buildkite/agents.go
+++ b/buildkite/agents.go
@@ -15,26 +15,26 @@ type AgentsService struct {
 
 // Agent represents a buildkite build agent.
 type Agent struct {
-	ID                *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID         *string    `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	URL               *string    `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL            *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	Name              *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	ConnectedState    *string    `json:"connection_state,omitempty" yaml:"connection_state,omitempty"`
-	AgentToken        *string    `json:"access_token,omitempty" yaml:"access_token,omitempty"`
-	Hostname          *string    `json:"hostname,omitempty" yaml:"hostname,omitempty"`
-	IPAddress         *string    `json:"ip_address,omitempty" yaml:"ip_address,omitempty"`
-	UserAgent         *string    `json:"user_agent,omitempty" yaml:"user_agent,omitempty"`
-	Version           *string    `json:"version,omitempty" yaml:"version,omitempty"`
-	CreatedAt         *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	LastJobFinishedAt *Timestamp `json:"last_job_finished_at,omitempty" yaml:"last_job_finished_at,omitempty"`
-	Priority          *int       `json:"priority,omitempty" yaml:"priority,omitempty"`
-	Metadata          []string   `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
+	ID                *string    `json:"id,omitempty"`
+	GraphQLID         *string    `json:"graphql_id,omitempty"`
+	URL               *string    `json:"url,omitempty"`
+	WebURL            *string    `json:"web_url,omitempty"`
+	Name              *string    `json:"name,omitempty"`
+	ConnectedState    *string    `json:"connection_state,omitempty"`
+	AgentToken        *string    `json:"access_token,omitempty"`
+	Hostname          *string    `json:"hostname,omitempty"`
+	IPAddress         *string    `json:"ip_address,omitempty"`
+	UserAgent         *string    `json:"user_agent,omitempty"`
+	Version           *string    `json:"version,omitempty"`
+	CreatedAt         *Timestamp `json:"created_at,omitempty"`
+	LastJobFinishedAt *Timestamp `json:"last_job_finished_at,omitempty"`
+	Priority          *int       `json:"priority,omitempty"`
+	Metadata          []string   `json:"meta_data,omitempty"`
 
 	// the user that created the agent
-	Creator *User `json:"creator,omitempty" yaml:"creator,omitempty"`
+	Creator *User `json:"creator,omitempty"`
 
-	Job *Job `json:"job,omitempty" yaml:"job,omitempty"`
+	Job *Job `json:"job,omitempty"`
 }
 
 // AgentListOptions specifies the optional parameters to the

--- a/buildkite/annotations.go
+++ b/buildkite/annotations.go
@@ -15,19 +15,19 @@ type AnnotationsService struct {
 
 // Annotation represents an annotation which has been stored from a build
 type Annotation struct {
-	ID        *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	Context   *string    `json:"context,omitempty" yaml:"context,omitempty"`
-	Style     *string    `json:"style,omitempty" yaml:"style,omitempty"`
-	BodyHTML  *string    `json:"body_html,omitempty" yaml:"body_html,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	UpdatedAt *Timestamp `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	ID        *string    `json:"id,omitempty"`
+	Context   *string    `json:"context,omitempty"`
+	Style     *string    `json:"style,omitempty"`
+	BodyHTML  *string    `json:"body_html,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
+	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
 }
 
 type AnnotationCreate struct {
-	Body    *string `json:"body,omitempty" yaml:"body,omitempty"`
-	Context *string `json:"context,omitempty" yaml:"context,omitempty"`
-	Style   *string `json:"style,omitempty" yaml:"style,omitempty"`
-	Append  *bool   `json:"append,omitempty" yaml:"append,omitempty"`
+	Body    *string `json:"body,omitempty"`
+	Context *string `json:"context,omitempty"`
+	Style   *string `json:"style,omitempty"`
+	Append  *bool   `json:"append,omitempty"`
 }
 
 // AnnotationListOptions specifies the optional parameters to the

--- a/buildkite/artifacts.go
+++ b/buildkite/artifacts.go
@@ -16,19 +16,19 @@ type ArtifactsService struct {
 
 // Artifact represents an artifact which has been stored from a build
 type Artifact struct {
-	ID           *string `json:"id,omitempty" yaml:"id,omitempty"`
-	JobID        *string `json:"job_id,omitempty" yaml:"job_id,omitempty"`
-	URL          *string `json:"url,omitempty" yaml:"url,omitempty"`
-	DownloadURL  *string `json:"download_url,omitempty" yaml:"download_url,omitempty"`
-	State        *string `json:"state,omitempty" yaml:"state,omitempty"`
-	Path         *string `json:"path,omitempty" yaml:"path,omitempty"`
-	Dirname      *string `json:"dirname,omitempty" yaml:"dirname,omitempty"`
-	Filename     *string `json:"filename,omitempty" yaml:"filename,omitempty"`
-	MimeType     *string `json:"mime_type,omitempty" yaml:"mime_type,omitempty"`
-	FileSize     *int64  `json:"file_size,omitempty" yaml:"file_size,omitempty"`
-	GlobPath     *string `json:"glob_path,omitempty" yaml:"glob_path,omitempty"`
-	OriginalPath *string `json:"original_path,omitempty" yaml:"original_path,omitempty"`
-	SHA1         *string `json:"sha1sum,omitempty" yaml:"sha1sum,omitempty"`
+	ID           *string `json:"id,omitempty"`
+	JobID        *string `json:"job_id,omitempty"`
+	URL          *string `json:"url,omitempty"`
+	DownloadURL  *string `json:"download_url,omitempty"`
+	State        *string `json:"state,omitempty"`
+	Path         *string `json:"path,omitempty"`
+	Dirname      *string `json:"dirname,omitempty"`
+	Filename     *string `json:"filename,omitempty"`
+	MimeType     *string `json:"mime_type,omitempty"`
+	FileSize     *int64  `json:"file_size,omitempty"`
+	GlobPath     *string `json:"glob_path,omitempty"`
+	OriginalPath *string `json:"original_path,omitempty"`
+	SHA1         *string `json:"sha1sum,omitempty"`
 }
 
 // ArtifactListOptions specifies the optional parameters to the

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -396,8 +396,8 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 // ErrorResponse provides a message.
 type ErrorResponse struct {
 	Response *http.Response // HTTP response that caused this error
-	Message  string         `json:"message" yaml:"message"` // error message
-	RawBody  []byte         `json:"-" yaml:"-"`             // Raw Response Body
+	Message  string         `json:"message"` // error message
+	RawBody  []byte         `json:"-"`       // Raw Response Body
 }
 
 func (r *ErrorResponse) Error() string {

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -17,94 +17,94 @@ type BuildsService struct {
 
 // Author of a commit (used in CreateBuild)
 type Author struct {
-	Username string `json:"username,omitempty" yaml:"username,omitempty"`
-	Name     string `json:"name,omitempty" yaml:"name,omitempty"`
-	Email    string `json:"email,omitempty" yaml:"email,omitempty"`
+	Username string `json:"username,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Email    string `json:"email,omitempty"`
 }
 
 // CreateBuild - Create a build.
 type CreateBuild struct {
-	Commit  string `json:"commit" yaml:"commit"`
-	Branch  string `json:"branch" yaml:"branch"`
-	Message string `json:"message" yaml:"message"`
+	Commit  string `json:"commit"`
+	Branch  string `json:"branch"`
+	Message string `json:"message"`
 
 	// Optional fields
-	Author                      Author            `json:"author,omitempty" yaml:"author,omitempty"`
-	CleanCheckout               bool              `json:"clean_checkout,omitempty" yaml:"clean_checkout,omitempty"`
-	Env                         map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	MetaData                    map[string]string `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
-	IgnorePipelineBranchFilters bool              `json:"ignore_pipeline_branch_filters,omitempty" yaml:"ignore_pipeline_branch_filters,omitempty"`
-	PullRequestBaseBranch       string            `json:"pull_request_base_branch,omitempty" yaml:"pull_request_base_branch,omitempty"`
-	PullRequestID               int64             `json:"pull_request_id,omitempty" yaml:"pull_request_id,omitempty"`
-	PullRequestRepository       string            `json:"pull_request_repository,omitempty" yaml:"pull_request_repository,omitempty"`
+	Author                      Author            `json:"author,omitempty"`
+	CleanCheckout               bool              `json:"clean_checkout,omitempty"`
+	Env                         map[string]string `json:"env,omitempty"`
+	MetaData                    map[string]string `json:"meta_data,omitempty"`
+	IgnorePipelineBranchFilters bool              `json:"ignore_pipeline_branch_filters,omitempty"`
+	PullRequestBaseBranch       string            `json:"pull_request_base_branch,omitempty"`
+	PullRequestID               int64             `json:"pull_request_id,omitempty"`
+	PullRequestRepository       string            `json:"pull_request_repository,omitempty"`
 }
 
 // Creator represents who created a build
 type Creator struct {
-	AvatarURL string     `json:"avatar_url" yaml:"avatar_url"`
-	CreatedAt *Timestamp `json:"created_at" yaml:"created_at"`
-	Email     string     `json:"email" yaml:"email"`
-	ID        string     `json:"id" yaml:"id"`
-	Name      string     `json:"name" yaml:"name"`
+	AvatarURL string     `json:"avatar_url"`
+	CreatedAt *Timestamp `json:"created_at"`
+	Email     string     `json:"email"`
+	ID        string     `json:"id"`
+	Name      string     `json:"name"`
 }
 
 // RebuiltFrom references a previous build
 type RebuiltFrom struct {
-	ID     string `json:"id" yaml:"id"`
-	Number int    `json:"number" yaml:"number"`
-	URL    string `json:"url" yaml:"url"`
+	ID     string `json:"id"`
+	Number int    `json:"number"`
+	URL    string `json:"url"`
 }
 
 // PullRequest represents a Github PR
 type PullRequest struct {
-	ID         *string `json:"id,omitempty" yaml:"id,omitempty"`
-	Base       *string `json:"base,omitempty" yaml:"base,omitempty"`
-	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
+	ID         *string `json:"id,omitempty"`
+	Base       *string `json:"base,omitempty"`
+	Repository *string `json:"repository,omitempty"`
 }
 
 type TriggeredFrom struct {
-	BuildID           *string `json:"build_id,omitempty" yaml:"build_id,omitempty"`
-	BuildNumber       *int    `json:"build_number,omitempty" yaml:"build_number,omitempty"`
-	BuildPipelineSlug *string `json:"build_pipeline_slug,omitempty" yaml:"build_pipeline_slug,omitempty"`
+	BuildID           *string `json:"build_id,omitempty"`
+	BuildNumber       *int    `json:"build_number,omitempty"`
+	BuildPipelineSlug *string `json:"build_pipeline_slug,omitempty"`
 }
 
 // Build represents a build which has run in buildkite
 type Build struct {
-	ID          *string                `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID   *string                `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	URL         *string                `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL      *string                `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	Number      *int                   `json:"number,omitempty" yaml:"number,omitempty"`
-	State       *string                `json:"state,omitempty" yaml:"state,omitempty"`
-	Blocked     *bool                  `json:"blocked,omitempty" yaml:"blocked,omitempty"`
-	Message     *string                `json:"message,omitempty" yaml:"message,omitempty"`
-	Commit      *string                `json:"commit,omitempty" yaml:"commit,omitempty"`
-	Branch      *string                `json:"branch,omitempty" yaml:"branch,omitempty"`
-	Author      *Author                `json:"author,omitempty" yaml:"author,omitempty"`
-	Env         map[string]interface{} `json:"env,omitempty" yaml:"env,omitempty"`
-	CreatedAt   *Timestamp             `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	ScheduledAt *Timestamp             `json:"scheduled_at,omitempty" yaml:"scheduled_at,omitempty"`
-	StartedAt   *Timestamp             `json:"started_at,omitempty" yaml:"started_at,omitempty"`
-	FinishedAt  *Timestamp             `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
-	MetaData    map[string]string      `json:"meta_data,omitempty" yaml:"meta_data,omitempty"`
-	Creator     *Creator               `json:"creator,omitempty" yaml:"creator,omitempty"`
-	Source      *string                `json:"source,omitempty" yaml:"source,omitempty"`
+	ID          *string                `json:"id,omitempty"`
+	GraphQLID   *string                `json:"graphql_id,omitempty"`
+	URL         *string                `json:"url,omitempty"`
+	WebURL      *string                `json:"web_url,omitempty"`
+	Number      *int                   `json:"number,omitempty"`
+	State       *string                `json:"state,omitempty"`
+	Blocked     *bool                  `json:"blocked,omitempty"`
+	Message     *string                `json:"message,omitempty"`
+	Commit      *string                `json:"commit,omitempty"`
+	Branch      *string                `json:"branch,omitempty"`
+	Author      *Author                `json:"author,omitempty"`
+	Env         map[string]interface{} `json:"env,omitempty"`
+	CreatedAt   *Timestamp             `json:"created_at,omitempty"`
+	ScheduledAt *Timestamp             `json:"scheduled_at,omitempty"`
+	StartedAt   *Timestamp             `json:"started_at,omitempty"`
+	FinishedAt  *Timestamp             `json:"finished_at,omitempty"`
+	MetaData    map[string]string      `json:"meta_data,omitempty"`
+	Creator     *Creator               `json:"creator,omitempty"`
+	Source      *string                `json:"source,omitempty"`
 
 	// jobs run during the build
-	Jobs []*Job `json:"jobs,omitempty" yaml:"jobs,omitempty"`
+	Jobs []*Job `json:"jobs,omitempty"`
 
 	// the pipeline this build is associated with
-	Pipeline *Pipeline `json:"pipeline,omitempty" yaml:"pipeline,omitempty"`
+	Pipeline *Pipeline `json:"pipeline,omitempty"`
 
 	// the build this build is a rebuild of
-	RebuiltFrom *RebuiltFrom `json:"rebuilt_from,omitempty" yaml:"rebuilt_from,omitempty"`
+	RebuiltFrom *RebuiltFrom `json:"rebuilt_from,omitempty"`
 
 	// the pull request this build is associated with
-	PullRequest *PullRequest `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
+	PullRequest *PullRequest `json:"pull_request,omitempty"`
 
 	// the build that this build is triggered from
 	// https://buildkite.com/docs/pipelines/trigger-step
-	TriggeredFrom *TriggeredFrom `json:"triggered_from,omitempty" yaml:"triggered_from,omitempty"`
+	TriggeredFrom *TriggeredFrom `json:"triggered_from,omitempty"`
 }
 
 type MetaDataFilters struct {

--- a/buildkite/cluster_queues.go
+++ b/buildkite/cluster_queues.go
@@ -15,32 +15,32 @@ type ClusterQueuesService struct {
 }
 
 type ClusterQueue struct {
-	ID                 *string         `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID          *string         `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	Key                *string         `json:"key,omitempty" yaml:"key,omitempty"`
-	Description        *string         `json:"description,omitempty" yaml:"description,omitempty"`
-	URL                *string         `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL             *string         `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	ClusterURL         *string         `json:"cluster_url,omitempty" yaml:"cluster_url,omitempty"`
-	DispatchPaused     *bool           `json:"dispatch_paused,omitempty" yaml:"dispatch_paused,omitempty"`
-	DispatchPausedBy   *ClusterCreator `json:"dispatch_paused_by,omitempty" yaml:"dispatch_paused_by,omitempty"`
-	DispatchPausedAt   *Timestamp      `json:"dispatch_paused_at,omitempty" yaml:"dispatch_paused_at,omitempty"`
-	DispatchPausedNote *string         `json:"dispatch_paused_note,omitempty" yaml:"dispatch_paused_note,omitempty"`
-	CreatedAt          *Timestamp      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	CreatedBy          *ClusterCreator `json:"created_by,omitempty" yaml:"created_by,omitempty"`
+	ID                 *string         `json:"id,omitempty"`
+	GraphQLID          *string         `json:"graphql_id,omitempty"`
+	Key                *string         `json:"key,omitempty"`
+	Description        *string         `json:"description,omitempty"`
+	URL                *string         `json:"url,omitempty"`
+	WebURL             *string         `json:"web_url,omitempty"`
+	ClusterURL         *string         `json:"cluster_url,omitempty"`
+	DispatchPaused     *bool           `json:"dispatch_paused,omitempty"`
+	DispatchPausedBy   *ClusterCreator `json:"dispatch_paused_by,omitempty"`
+	DispatchPausedAt   *Timestamp      `json:"dispatch_paused_at,omitempty"`
+	DispatchPausedNote *string         `json:"dispatch_paused_note,omitempty"`
+	CreatedAt          *Timestamp      `json:"created_at,omitempty"`
+	CreatedBy          *ClusterCreator `json:"created_by,omitempty"`
 }
 
 type ClusterQueueCreate struct {
-	Key         *string `json:"key,omitempty" yaml:"key,omitempty"`
-	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Key         *string `json:"key,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 type ClusterQueueUpdate struct {
-	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Description *string `json:"description,omitempty"`
 }
 
 type ClusterQueuePause struct {
-	Note *string `json:"dispatch_paused_note,omitempty" yaml:"dispatch_paused_note,omitempty"`
+	Note *string `json:"dispatch_paused_note,omitempty"`
 }
 
 type ClusterQueuesListOptions struct {

--- a/buildkite/cluster_tokens.go
+++ b/buildkite/cluster_tokens.go
@@ -15,20 +15,20 @@ type ClusterTokensService struct {
 }
 
 type ClusterToken struct {
-	ID                 *string         `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID          *string         `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	Description        *string         `json:"description,omitempty" yaml:"description,omitempty"`
-	AllowedIPAddresses *string         `json:"allowed_ip_addresses,omitempty" yaml:"allowed_ip_addresses,omitempty"`
-	URL                *string         `json:"url,omitempty" yaml:"url,omitempty"`
-	ClusterURL         *string         `json:"cluster_url,omitempty" yaml:"cluster_url,omitempty"`
-	CreatedAt          *Timestamp      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	CreatedBy          *ClusterCreator `json:"created_by,omitempty" yaml:"created_by,omitempty"`
-	Token              *string         `json:"token,omitempty" yaml:"token,omitempty"`
+	ID                 *string         `json:"id,omitempty"`
+	GraphQLID          *string         `json:"graphql_id,omitempty"`
+	Description        *string         `json:"description,omitempty"`
+	AllowedIPAddresses *string         `json:"allowed_ip_addresses,omitempty"`
+	URL                *string         `json:"url,omitempty"`
+	ClusterURL         *string         `json:"cluster_url,omitempty"`
+	CreatedAt          *Timestamp      `json:"created_at,omitempty"`
+	CreatedBy          *ClusterCreator `json:"created_by,omitempty"`
+	Token              *string         `json:"token,omitempty"`
 }
 
 type ClusterTokenCreateUpdate struct {
-	Description        *string `json:"description,omitempty" yaml:"description,omitempty"`
-	AllowedIPAddresses *string `json:"allowed_ip_addresses,omitempty" yaml:"allowed_ip_addresses,omitempty"`
+	Description        *string `json:"description,omitempty"`
+	AllowedIPAddresses *string `json:"allowed_ip_addresses,omitempty"`
 }
 
 type ClusterTokensListOptions struct {

--- a/buildkite/clusters.go
+++ b/buildkite/clusters.go
@@ -15,43 +15,43 @@ type ClustersService struct {
 }
 
 type ClusterCreate struct {
-	Name        string  `json:"name,omitempty" yaml:"name,omitempty"`
-	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
-	Emoji       *string `json:"emoji,omitempty" yaml:"emoji,omitempty"`
-	Color       *string `json:"color,omitempty" yaml:"color,omitempty"`
+	Name        string  `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Emoji       *string `json:"emoji,omitempty"`
+	Color       *string `json:"color,omitempty"`
 }
 
 type ClusterUpdate struct {
-	Name           *string `json:"name,omitempty" yaml:"name,omitempty"`
-	Description    *string `json:"description,omitempty" yaml:"description,omitempty"`
-	Emoji          *string `json:"emoji,omitempty" yaml:"emoji,omitempty"`
-	Color          *string `json:"color,omitempty" yaml:"color,omitempty"`
-	DefaultQueueID *string `json:"default_queue_id,omitempty" yaml:"default_queue_id,omitempty"`
+	Name           *string `json:"name,omitempty"`
+	Description    *string `json:"description,omitempty"`
+	Emoji          *string `json:"emoji,omitempty"`
+	Color          *string `json:"color,omitempty"`
+	DefaultQueueID *string `json:"default_queue_id,omitempty"`
 }
 
 type Cluster struct {
-	ID              *string         `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID       *string         `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	DefaultQueueID  *string         `json:"default_queue_id,omitempty" yaml:"default_queue_id,omitempty"`
-	Name            *string         `json:"name,omitempty" yaml:"name,omitempty"`
-	Description     *string         `json:"description,omitempty" yaml:"description,omitempty"`
-	Emoji           *string         `json:"emoji,omitempty" yaml:"emoji,omitempty"`
-	Color           *string         `json:"color,omitempty" yaml:"color,omitempty"`
-	URL             *string         `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL          *string         `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	QueuesURL       *string         `json:"queues_url,omitempty" yaml:"queues_url,omitempty"`
-	DefaultQueueURL *string         `json:"default_queue_url,omitempty" yaml:"default_queue_url,omitempty"`
-	CreatedAt       *Timestamp      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	CreatedBy       *ClusterCreator `json:"created_by,omitempty" yaml:"created_by,omitempty"`
+	ID              *string         `json:"id,omitempty"`
+	GraphQLID       *string         `json:"graphql_id,omitempty"`
+	DefaultQueueID  *string         `json:"default_queue_id,omitempty"`
+	Name            *string         `json:"name,omitempty"`
+	Description     *string         `json:"description,omitempty"`
+	Emoji           *string         `json:"emoji,omitempty"`
+	Color           *string         `json:"color,omitempty"`
+	URL             *string         `json:"url,omitempty"`
+	WebURL          *string         `json:"web_url,omitempty"`
+	QueuesURL       *string         `json:"queues_url,omitempty"`
+	DefaultQueueURL *string         `json:"default_queue_url,omitempty"`
+	CreatedAt       *Timestamp      `json:"created_at,omitempty"`
+	CreatedBy       *ClusterCreator `json:"created_by,omitempty"`
 }
 
 type ClusterCreator struct {
-	ID        *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID *string    `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	Name      *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	Email     *string    `json:"email,omitempty" yaml:"email,omitempty"`
-	AvatarURL *string    `json:"avatar_url,omitempty" yaml:"avatar_url,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ID        *string    `json:"id,omitempty"`
+	GraphQLID *string    `json:"graphql_id,omitempty"`
+	Name      *string    `json:"name,omitempty"`
+	Email     *string    `json:"email,omitempty"`
+	AvatarURL *string    `json:"avatar_url,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
 type ClustersListOptions struct {

--- a/buildkite/flaky_tests.go
+++ b/buildkite/flaky_tests.go
@@ -14,14 +14,14 @@ type FlakyTestsService struct {
 }
 
 type FlakyTest struct {
-	ID                   *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	WebURL               *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	Scope                *string    `json:"scope,omitempty" yaml:"scope,omitempty"`
-	Name                 *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	Location             *string    `json:"location,omitempty" yaml:"location,omitempty"`
-	FileName             *string    `json:"file_name,omitempty" yaml:"file_name,omitempty"`
-	Instances            *int       `json:"instances,omitempty" yaml:"instances,omitempty"`
-	MostRecentInstanceAt *Timestamp `json:"most_recent_instance_at,omitempty" yaml:"most_recent_instance_at,omitempty"`
+	ID                   *string    `json:"id,omitempty"`
+	WebURL               *string    `json:"web_url,omitempty"`
+	Scope                *string    `json:"scope,omitempty"`
+	Name                 *string    `json:"name,omitempty"`
+	Location             *string    `json:"location,omitempty"`
+	FileName             *string    `json:"file_name,omitempty"`
+	Instances            *int       `json:"instances,omitempty"`
+	MostRecentInstanceAt *Timestamp `json:"most_recent_instance_at,omitempty"`
 }
 
 type FlakyTestsListOptions struct {

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -15,64 +15,64 @@ type JobsService struct {
 
 // Job represents a job run during a build in buildkite
 type Job struct {
-	ID                 *string         `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID          *string         `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	Type               *string         `json:"type,omitempty" yaml:"type,omitempty"`
-	Name               *string         `json:"name,omitempty" yaml:"name,omitempty"`
-	Label              *string         `json:"label,omitempty" yaml:"label,omitempty"`
-	StepKey            *string         `json:"step_key,omitempty" yaml:"step_key,omitempty"`
-	GroupKey           *string         `json:"group_key,omitempty" yaml:"group_key,omitempty"`
-	State              *string         `json:"state,omitempty" yaml:"state,omitempty"`
-	LogsURL            *string         `json:"logs_url,omitempty" yaml:"logs_url,omitempty"`
-	RawLogsURL         *string         `json:"raw_log_url,omitempty" yaml:"raw_log_url,omitempty"`
-	Command            *string         `json:"command,omitempty" yaml:"command,omitempty"`
-	ExitStatus         *int            `json:"exit_status,omitempty" yaml:"exit_status,omitempty"`
-	ArtifactPaths      *string         `json:"artifact_paths,omitempty" yaml:"artifact_paths,omitempty"`
-	ArtifactsURL       *string         `json:"artifacts_url,omitempty" yaml:"artifacts_url,omitempty"`
-	CreatedAt          *Timestamp      `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	ScheduledAt        *Timestamp      `json:"scheduled_at,omitempty" yaml:"scheduled_at,omitempty"`
-	RunnableAt         *Timestamp      `json:"runnable_at,omitempty" yaml:"runnable_at,omitempty"`
-	StartedAt          *Timestamp      `json:"started_at,omitempty" yaml:"started_at,omitempty"`
-	FinishedAt         *Timestamp      `json:"finished_at,omitempty" yaml:"finished_at,omitempty"`
-	UnblockedAt        *Timestamp      `json:"unblocked_at,omitempty" yaml:"unblocked_at,omitempty"`
-	Agent              Agent           `json:"agent,omitempty" yaml:"agent,omitempty"`
-	AgentQueryRules    []string        `json:"agent_query_rules,omitempty" yaml:"agent_query_rules,omitempty"`
-	WebURL             string          `json:"web_url" yaml:"web_url"`
-	Retried            bool            `json:"retried,omitempty" yaml:"retried,omitempty"`
-	RetriedInJobID     string          `json:"retried_in_job_id,omitempty" yaml:"retried_in_job_id,omitempty"`
-	RetriesCount       int             `json:"retries_count,omitempty" yaml:"retries_count,omitempty"`
-	RetrySource        *JobRetrySource `json:"retry_source,omitempty" yaml:"retry_source,omitempty"`
-	RetryType          *string         `json:"retry_type,omitempty" yaml:"retry_type,omitempty"`
-	SoftFailed         bool            `json:"soft_failed,omitempty" yaml:"soft_failed,omitempty"`
-	UnblockedBy        *UnblockedBy    `json:"unblocked_by,omitempty" yaml:"unblocked_by,omitempty"`
-	Unblockable        *bool           `json:"unblockable,omitempty" yaml:"unblockable,omitempty"`
-	UnblockURL         *string         `json:"unblock_url,omitempty" yaml:"unblock_url,omitempty"`
-	ParallelGroupIndex *int            `json:"parallel_group_index,omitempty" yaml:"parallel_group_index,omitempty"`
-	ParallelGroupTotal *int            `json:"parallel_group_total,omitempty" yaml:"parallel_group_total,omitempty"`
-	ClusterID          *string         `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
-	ClusterQueueID     *string         `json:"cluster_queue_id,omitempty" yaml:"cluster_queue_id,omitempty"`
-	TriggeredBuild     *TriggeredBuild `json:"triggered_build,omitempty" yaml:"triggered_build,omitempty"`
-	Priority           *JobPriority    `json:"priority" yaml:"priority,omitempty"`
+	ID                 *string         `json:"id,omitempty"`
+	GraphQLID          *string         `json:"graphql_id,omitempty"`
+	Type               *string         `json:"type,omitempty"`
+	Name               *string         `json:"name,omitempty"`
+	Label              *string         `json:"label,omitempty"`
+	StepKey            *string         `json:"step_key,omitempty"`
+	GroupKey           *string         `json:"group_key,omitempty"`
+	State              *string         `json:"state,omitempty"`
+	LogsURL            *string         `json:"logs_url,omitempty"`
+	RawLogsURL         *string         `json:"raw_log_url,omitempty"`
+	Command            *string         `json:"command,omitempty"`
+	ExitStatus         *int            `json:"exit_status,omitempty"`
+	ArtifactPaths      *string         `json:"artifact_paths,omitempty"`
+	ArtifactsURL       *string         `json:"artifacts_url,omitempty"`
+	CreatedAt          *Timestamp      `json:"created_at,omitempty"`
+	ScheduledAt        *Timestamp      `json:"scheduled_at,omitempty"`
+	RunnableAt         *Timestamp      `json:"runnable_at,omitempty"`
+	StartedAt          *Timestamp      `json:"started_at,omitempty"`
+	FinishedAt         *Timestamp      `json:"finished_at,omitempty"`
+	UnblockedAt        *Timestamp      `json:"unblocked_at,omitempty"`
+	Agent              Agent           `json:"agent,omitempty"`
+	AgentQueryRules    []string        `json:"agent_query_rules,omitempty"`
+	WebURL             string          `json:"web_url"`
+	Retried            bool            `json:"retried,omitempty"`
+	RetriedInJobID     string          `json:"retried_in_job_id,omitempty"`
+	RetriesCount       int             `json:"retries_count,omitempty"`
+	RetrySource        *JobRetrySource `json:"retry_source,omitempty"`
+	RetryType          *string         `json:"retry_type,omitempty"`
+	SoftFailed         bool            `json:"soft_failed,omitempty"`
+	UnblockedBy        *UnblockedBy    `json:"unblocked_by,omitempty"`
+	Unblockable        *bool           `json:"unblockable,omitempty"`
+	UnblockURL         *string         `json:"unblock_url,omitempty"`
+	ParallelGroupIndex *int            `json:"parallel_group_index,omitempty"`
+	ParallelGroupTotal *int            `json:"parallel_group_total,omitempty"`
+	ClusterID          *string         `json:"cluster_id,omitempty"`
+	ClusterQueueID     *string         `json:"cluster_queue_id,omitempty"`
+	TriggeredBuild     *TriggeredBuild `json:"triggered_build,omitempty"`
+	Priority           *JobPriority    `json:"priority"`
 }
 
 // JobRetrySource represents what triggered this retry.
 type JobRetrySource struct {
-	JobID     string `json:"job_id,omitempty" yaml:"job_id,omitempty"`
-	RetryType string `json:"retry_type,omitempty" yaml:"retry_type,omitempty"`
+	JobID     string `json:"job_id,omitempty"`
+	RetryType string `json:"retry_type,omitempty"`
 }
 
 // UnblockedBy represents the unblocked status of a job, when present
 type UnblockedBy struct {
-	ID        string    `json:"id,omitempty" yaml:"id,omitempty"`
-	Name      string    `json:"name,omitempty" yaml:"name,omitempty"`
-	Email     string    `json:"email,omitempty" yaml:"email,omitempty"`
-	AvatarURL string    `json:"avatar_url,omitempty" yaml:"avatar_url,omitempty"`
-	CreatedAt Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ID        string    `json:"id,omitempty"`
+	Name      string    `json:"name,omitempty"`
+	Email     string    `json:"email,omitempty"`
+	AvatarURL string    `json:"avatar_url,omitempty"`
+	CreatedAt Timestamp `json:"created_at,omitempty"`
 }
 
 // JobUnblockOptions specifies the optional parameters to UnblockJob
 type JobUnblockOptions struct {
-	Fields map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
+	Fields map[string]string `json:"fields,omitempty"`
 }
 
 // JobLog represents a job log output
@@ -85,19 +85,19 @@ type JobLog struct {
 
 // JobEnvs represent job environments output
 type JobEnvs struct {
-	EnvironmentVariables *map[string]string `json:"env,string" yaml:"env,string"`
+	EnvironmentVariables *map[string]string `json:"env,string"`
 }
 
 type TriggeredBuild struct {
-	ID     *string `json:"id,omitempty" yaml:"id,omitempty"`
-	Number *int    `json:"number,omitempty" yaml:"number,omitempty"`
-	URL    *string `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL *string `json:"web_url,omitempty" yaml:"web_url,omitempty"`
+	ID     *string `json:"id,omitempty"`
+	Number *int    `json:"number,omitempty"`
+	URL    *string `json:"url,omitempty"`
+	WebURL *string `json:"web_url,omitempty"`
 }
 
 // JobPriority represents the priority of the job
 type JobPriority struct {
-	Number *int `json:"number,omitempty" yaml:"number,omitempty"`
+	Number *int `json:"number,omitempty"`
 }
 
 // UnblockJob - unblock a job

--- a/buildkite/misc.go
+++ b/buildkite/misc.go
@@ -7,8 +7,8 @@ import (
 
 // Emoji emoji, what else can you say?
 type Emoji struct {
-	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
-	URL  *string `json:"url,omitempty" yaml:"url,omitempty"`
+	Name *string `json:"name,omitempty"`
+	URL  *string `json:"url,omitempty"`
 }
 
 // ListEmojis list all the emojis for a given account, including custom emojis and aliases.
@@ -36,6 +36,6 @@ func (c *Client) ListEmojis(ctx context.Context, org string) ([]Emoji, *Response
 
 // Token an oauth access token for the buildkite service
 type Token struct {
-	AccessToken *string `json:"access_token,omitempty" yaml:"access_token,omitempty"`
-	Type        *string `json:"token_type,omitempty" yaml:"token_type,omitempty"`
+	AccessToken *string `json:"access_token,omitempty"`
+	Type        *string `json:"token_type,omitempty"`
 }

--- a/buildkite/organizations.go
+++ b/buildkite/organizations.go
@@ -15,17 +15,17 @@ type OrganizationsService struct {
 
 // Organization represents a buildkite organization.
 type Organization struct {
-	ID           *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID    *string    `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	URL          *string    `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL       *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	Name         *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	Slug         *string    `json:"slug,omitempty" yaml:"slug,omitempty"`
-	Repository   *string    `json:"repository,omitempty" yaml:"repository,omitempty"`
-	PipelinesURL *string    `json:"pipelines_url,omitempty" yaml:"pipelines_url,omitempty"`
-	EmojisURL    *string    `json:"emojis_url,omitempty" yaml:"emojis_url,omitempty"`
-	AgentsURL    *string    `json:"agents_url,omitempty" yaml:"agents_url,omitempty"`
-	CreatedAt    *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ID           *string    `json:"id,omitempty"`
+	GraphQLID    *string    `json:"graphql_id,omitempty"`
+	URL          *string    `json:"url,omitempty"`
+	WebURL       *string    `json:"web_url,omitempty"`
+	Name         *string    `json:"name,omitempty"`
+	Slug         *string    `json:"slug,omitempty"`
+	Repository   *string    `json:"repository,omitempty"`
+	PipelinesURL *string    `json:"pipelines_url,omitempty"`
+	EmojisURL    *string    `json:"emojis_url,omitempty"`
+	AgentsURL    *string    `json:"agents_url,omitempty"`
+	CreatedAt    *Timestamp `json:"created_at,omitempty"`
 }
 
 // OrganizationListOptions specifies the optional parameters to the

--- a/buildkite/pipeline_templates.go
+++ b/buildkite/pipeline_templates.go
@@ -15,34 +15,34 @@ type PipelineTemplatesService struct {
 }
 
 type PipelineTemplate struct {
-	UUID          *string                  `json:"uuid,omitempty" yaml:"uuid,omitempty"`
-	GraphQLID     *string                  `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	Name          *string                  `json:"name,omitempty" yaml:"name,omitempty"`
-	Description   *string                  `json:"description,omitempty" yaml:"description,omitempty"`
-	Configuration *string                  `json:"configuration,omitempty" yaml:"configuration,omitempty"`
-	Available     *bool                    `json:"available,omitempty" yaml:"available,omitempty"`
-	URL           *string                  `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL        *string                  `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	CreatedAt     *Timestamp               `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	CreatedBy     *PipelineTemplateCreator `json:"created_by,omitempty" yaml:"created_by,omitempty"`
-	UpdatedAt     *Timestamp               `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
-	UpdatedBy     *PipelineTemplateCreator `json:"updated_by,omitempty" yaml:"updated_by,omitempty"`
+	UUID          *string                  `json:"uuid,omitempty"`
+	GraphQLID     *string                  `json:"graphql_id,omitempty"`
+	Name          *string                  `json:"name,omitempty"`
+	Description   *string                  `json:"description,omitempty"`
+	Configuration *string                  `json:"configuration,omitempty"`
+	Available     *bool                    `json:"available,omitempty"`
+	URL           *string                  `json:"url,omitempty"`
+	WebURL        *string                  `json:"web_url,omitempty"`
+	CreatedAt     *Timestamp               `json:"created_at,omitempty"`
+	CreatedBy     *PipelineTemplateCreator `json:"created_by,omitempty"`
+	UpdatedAt     *Timestamp               `json:"updated_at,omitempty"`
+	UpdatedBy     *PipelineTemplateCreator `json:"updated_by,omitempty"`
 }
 
 type PipelineTemplateCreateUpdate struct {
-	Name          *string `json:"name,omitempty" yaml:"name,omitempty"`
-	Configuration *string `json:"configuration,omitempty" yaml:"configuration,omitempty"`
-	Description   *string `json:"description,omitempty" yaml:"description,omitempty"`
-	Available     *bool   `json:"available,omitempty" yaml:"available,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	Configuration *string `json:"configuration,omitempty"`
+	Description   *string `json:"description,omitempty"`
+	Available     *bool   `json:"available,omitempty"`
 }
 
 type PipelineTemplateCreator struct {
-	ID        *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID *string    `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	Name      *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	Email     *string    `json:"email,omitempty" yaml:"email,omitempty"`
-	AvatarURL *string    `json:"avatar_url,omitempty" yaml:"avatar_url,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ID        *string    `json:"id,omitempty"`
+	GraphQLID *string    `json:"graphql_id,omitempty"`
+	Name      *string    `json:"name,omitempty"`
+	Email     *string    `json:"email,omitempty"`
+	AvatarURL *string    `json:"avatar_url,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
 type PipelineTemplateListOptions struct {

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -17,100 +17,100 @@ type PipelinesService struct {
 
 // CreatePipeline - Create a Pipeline.
 type CreatePipeline struct {
-	Name       string `json:"name" yaml:"name"`
-	Repository string `json:"repository" yaml:"repository"`
+	Name       string `json:"name"`
+	Repository string `json:"repository"`
 
 	// Either configuration needs to be specified as a yaml string or steps.
-	Configuration string `json:"configuration,omitempty" yaml:"configuration,omitempty"`
-	Steps         []Step `json:"steps,omitempty" yaml:"steps,omitempty"`
+	Configuration string `json:"configuration,omitempty"`
+	Steps         []Step `json:"steps,omitempty"`
 
 	// Optional fields
-	DefaultBranch                   string            `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
-	Description                     string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Env                             map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty" yaml:"provider_settings,omitempty"`
-	BranchConfiguration             string            `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty" yaml:"skip_queued_branch_builds,omitempty"`
-	SkipQueuedBranchBuildsFilter    string            `json:"skip_queued_branch_builds_filter,omitempty" yaml:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds,omitempty" yaml:"cancel_running_branch_builds,omitempty"`
-	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty" yaml:"cancel_running_branch_builds_filter,omitempty"`
-	TeamUuids                       []string          `json:"team_uuids,omitempty" yaml:"team_uuids,omitempty"`
-	ClusterID                       string            `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
-	Visibility                      *string           `json:"visibility,omitempty" yaml:"visibility,omitempty"`
-	Tags                            []string          `json:"tags,omitempty" yaml:"tags,omitempty"`
+	DefaultBranch                   string            `json:"default_branch,omitempty"`
+	Description                     string            `json:"description,omitempty"`
+	Env                             map[string]string `json:"env,omitempty"`
+	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty"`
+	BranchConfiguration             string            `json:"branch_configuration,omitempty"`
+	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuildsFilter    string            `json:"skip_queued_branch_builds_filter,omitempty"`
+	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty"`
+	TeamUuids                       []string          `json:"team_uuids,omitempty"`
+	ClusterID                       string            `json:"cluster_id,omitempty"`
+	Visibility                      *string           `json:"visibility,omitempty"`
+	Tags                            []string          `json:"tags,omitempty"`
 }
 
 type UpdatePipeline struct {
 	// Either configuration needs to be specified as a yaml string or steps (based on what the pipeline uses)
-	Configuration string  `json:"configuration,omitempty" yaml:"configuration,omitempty"`
-	Steps         []*Step `json:"steps,omitempty" yaml:"steps,omitempty"`
+	Configuration string  `json:"configuration,omitempty"`
+	Steps         []*Step `json:"steps,omitempty"`
 
-	Name                            *string          `json:"name,omitempty" yaml:"name,omitempty"`
-	Repository                      *string          `json:"repository,omitempty" yaml:"repository,omitempty"`
-	DefaultBranch                   *string          `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
-	Description                     *string          `json:"description,omitempty" yaml:"description,omitempty"`
-	ProviderSettings                ProviderSettings `json:"provider_settings,omitempty" yaml:"provider_settings,omitempty"`
-	BranchConfiguration             *string          `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          *bool            `json:"skip_queued_branch_builds,omitempty" yaml:"skip_queued_branch_builds,omitempty"`
-	SkipQueuedBranchBuildsFilter    *string          `json:"skip_queued_branch_builds_filter,omitempty" yaml:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       *bool            `json:"cancel_running_branch_builds,omitempty" yaml:"cancel_running_branch_builds,omitempty"`
-	CancelRunningBranchBuildsFilter *string          `json:"cancel_running_branch_builds_filter,omitempty" yaml:"cancel_running_branch_builds_filter,omitempty"`
-	ClusterID                       *string          `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
-	Visibility                      *string          `json:"visibility,omitempty" yaml:"visibility,omitempty"`
-	Tags                            []string         `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Name                            *string          `json:"name,omitempty"`
+	Repository                      *string          `json:"repository,omitempty"`
+	DefaultBranch                   *string          `json:"default_branch,omitempty"`
+	Description                     *string          `json:"description,omitempty"`
+	ProviderSettings                ProviderSettings `json:"provider_settings,omitempty"`
+	BranchConfiguration             *string          `json:"branch_configuration,omitempty"`
+	SkipQueuedBranchBuilds          *bool            `json:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuildsFilter    *string          `json:"skip_queued_branch_builds_filter,omitempty"`
+	CancelRunningBranchBuilds       *bool            `json:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuildsFilter *string          `json:"cancel_running_branch_builds_filter,omitempty"`
+	ClusterID                       *string          `json:"cluster_id,omitempty"`
+	Visibility                      *string          `json:"visibility,omitempty"`
+	Tags                            []string         `json:"tags,omitempty"`
 }
 
 // Pipeline represents a buildkite pipeline.
 type Pipeline struct {
-	ID                              *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID                       *string    `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	URL                             *string    `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL                          *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	Name                            *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	Slug                            *string    `json:"slug,omitempty" yaml:"slug,omitempty"`
-	Repository                      *string    `json:"repository,omitempty" yaml:"repository,omitempty"`
-	BuildsURL                       *string    `json:"builds_url,omitempty" yaml:"builds_url,omitempty"`
-	BadgeURL                        *string    `json:"badge_url,omitempty" yaml:"badge_url,omitempty"`
-	CreatedAt                       *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	ArchivedAt                      *Timestamp `json:"archived_at,omitempty" yaml:"archived_at,omitempty"`
-	DefaultBranch                   *string    `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
-	Description                     *string    `json:"description,omitempty" yaml:"description,omitempty"`
-	BranchConfiguration             *string    `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          *bool      `json:"skip_queued_branch_builds,omitempty" yaml:"skip_queued_branch_builds,omitempty"`
-	SkipQueuedBranchBuildsFilter    *string    `json:"skip_queued_branch_builds_filter,omitempty" yaml:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       *bool      `json:"cancel_running_branch_builds,omitempty" yaml:"cancel_running_branch_builds,omitempty"`
-	CancelRunningBranchBuildsFilter *string    `json:"cancel_running_branch_builds_filter,omitempty" yaml:"cancel_running_branch_builds_filter,omitempty"`
-	ClusterID                       *string    `json:"cluster_id,omitempty" yaml:"cluster_id,omitempty"`
-	Visibility                      *string    `json:"visibility,omitempty" yaml:"visibility,omitempty"`
-	Tags                            []string   `json:"tags,omitempty" yaml:"tags,omitempty"`
+	ID                              *string    `json:"id,omitempty"`
+	GraphQLID                       *string    `json:"graphql_id,omitempty"`
+	URL                             *string    `json:"url,omitempty"`
+	WebURL                          *string    `json:"web_url,omitempty"`
+	Name                            *string    `json:"name,omitempty"`
+	Slug                            *string    `json:"slug,omitempty"`
+	Repository                      *string    `json:"repository,omitempty"`
+	BuildsURL                       *string    `json:"builds_url,omitempty"`
+	BadgeURL                        *string    `json:"badge_url,omitempty"`
+	CreatedAt                       *Timestamp `json:"created_at,omitempty"`
+	ArchivedAt                      *Timestamp `json:"archived_at,omitempty"`
+	DefaultBranch                   *string    `json:"default_branch,omitempty"`
+	Description                     *string    `json:"description,omitempty"`
+	BranchConfiguration             *string    `json:"branch_configuration,omitempty"`
+	SkipQueuedBranchBuilds          *bool      `json:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuildsFilter    *string    `json:"skip_queued_branch_builds_filter,omitempty"`
+	CancelRunningBranchBuilds       *bool      `json:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuildsFilter *string    `json:"cancel_running_branch_builds_filter,omitempty"`
+	ClusterID                       *string    `json:"cluster_id,omitempty"`
+	Visibility                      *string    `json:"visibility,omitempty"`
+	Tags                            []string   `json:"tags,omitempty"`
 
-	ScheduledBuildsCount *int `json:"scheduled_builds_count,omitempty" yaml:"scheduled_builds_count,omitempty"`
-	RunningBuildsCount   *int `json:"running_builds_count,omitempty" yaml:"running_builds_count,omitempty"`
-	ScheduledJobsCount   *int `json:"scheduled_jobs_count,omitempty" yaml:"scheduled_jobs_count,omitempty"`
-	RunningJobsCount     *int `json:"running_jobs_count,omitempty" yaml:"running_jobs_count,omitempty"`
-	WaitingJobsCount     *int `json:"waiting_jobs_count,omitempty" yaml:"waiting_jobs_count,omitempty"`
+	ScheduledBuildsCount *int `json:"scheduled_builds_count,omitempty"`
+	RunningBuildsCount   *int `json:"running_builds_count,omitempty"`
+	ScheduledJobsCount   *int `json:"scheduled_jobs_count,omitempty"`
+	RunningJobsCount     *int `json:"running_jobs_count,omitempty"`
+	WaitingJobsCount     *int `json:"waiting_jobs_count,omitempty"`
 
 	// the provider of sources
-	Provider *Provider `json:"provider,omitempty" yaml:"provider,omitempty"`
+	Provider *Provider `json:"provider,omitempty"`
 
 	// build steps
-	Steps         []*Step                `json:"steps,omitempty" yaml:"steps,omitempty"`
-	Configuration string                 `json:"configuration,omitempty" yaml:"configuration,omitempty"`
-	Env           map[string]interface{} `json:"env,omitempty" yaml:"env,omitempty"`
+	Steps         []*Step                `json:"steps,omitempty"`
+	Configuration string                 `json:"configuration,omitempty"`
+	Env           map[string]interface{} `json:"env,omitempty"`
 }
 
 // Step represents a build step in buildkites build pipeline
 type Step struct {
-	Type                *string           `json:"type,omitempty" yaml:"type,omitempty"`
-	Name                *string           `json:"name,omitempty" yaml:"name,omitempty"`
-	Label               *string           `json:"label,omitempty" yaml:"label,omitempty"`
-	Command             *string           `json:"command,omitempty" yaml:"command,omitempty"`
-	ArtifactPaths       *string           `json:"artifact_paths,omitempty" yaml:"artifact_paths,omitempty"`
-	BranchConfiguration *string           `json:"branch_configuration,omitempty" yaml:"branch_configuration,omitempty"`
-	Env                 map[string]string `json:"env,omitempty" yaml:"env,omitempty"`
-	TimeoutInMinutes    *int              `json:"timeout_in_minutes,omitempty" yaml:"timeout_in_minutes,omitempty"`
-	AgentQueryRules     []string          `json:"agent_query_rules,omitempty" yaml:"agent_query_rules,omitempty"`
-	Plugins             Plugins           `json:"plugins,omitempty" yaml:"plugins,omitempty"`
+	Type                *string           `json:"type,omitempty"`
+	Name                *string           `json:"name,omitempty"`
+	Label               *string           `json:"label,omitempty"`
+	Command             *string           `json:"command,omitempty"`
+	ArtifactPaths       *string           `json:"artifact_paths,omitempty"`
+	BranchConfiguration *string           `json:"branch_configuration,omitempty"`
+	Env                 map[string]string `json:"env,omitempty"`
+	TimeoutInMinutes    *int              `json:"timeout_in_minutes,omitempty"`
+	AgentQueryRules     []string          `json:"agent_query_rules,omitempty"`
+	Plugins             Plugins           `json:"plugins,omitempty"`
 }
 
 type Plugins map[string]Plugin

--- a/buildkite/providers.go
+++ b/buildkite/providers.go
@@ -4,9 +4,9 @@ import "encoding/json"
 
 // Provider represents a source code provider. It is read-only, but settings may be written using Pipeline.ProviderSettings.
 type Provider struct {
-	ID         string           `json:"id" yaml:"id"`
-	WebhookURL *string          `json:"webhook_url" yaml:"webhook_url"`
-	Settings   ProviderSettings `json:"settings" yaml:"settings"`
+	ID         string           `json:"id"`
+	WebhookURL *string          `json:"webhook_url"`
+	Settings   ProviderSettings `json:"settings"`
 }
 
 // UnmarshalJSON decodes the Provider, choosing the type of the Settings from the ID.
@@ -14,7 +14,7 @@ func (p *Provider) UnmarshalJSON(data []byte) error {
 	type provider Provider
 	var v struct {
 		provider
-		Settings json.RawMessage `json:"settings" yaml:"settings"`
+		Settings json.RawMessage `json:"settings"`
 	}
 
 	err := json.Unmarshal(data, &v)
@@ -53,59 +53,59 @@ type ProviderSettings interface {
 
 // BitbucketSettings are settings for pipelines building from Bitbucket repositories.
 type BitbucketSettings struct {
-	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty" yaml:"build_pull_requests,omitempty"`
-	BuildBranches                           *bool   `json:"build_branches,omitempty" yaml:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty" yaml:"pull_request_branch_filter_enabled,omitempty"`
-	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty" yaml:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty" yaml:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildTags                               *bool   `json:"build_tags,omitempty" yaml:"build_tags,omitempty"`
-	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty" yaml:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty" yaml:"publish_commit_status_per_step,omitempty"`
+	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
+	BuildBranches                           *bool   `json:"build_branches,omitempty"`
+	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildTags                               *bool   `json:"build_tags,omitempty"`
+	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
 
 	// Read-only
-	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
+	Repository *string `json:"repository,omitempty"`
 }
 
 func (s *BitbucketSettings) isProviderSettings() {}
 
 // GitHubSettings are settings for pipelines building from GitHub repositories.
 type GitHubSettings struct {
-	TriggerMode                             *string `json:"trigger_mode,omitempty" yaml:"trigger_mode,omitempty"`
-	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty" yaml:"build_pull_requests,omitempty"`
-	BuildBranches                           *bool   `json:"build_branches,omitempty" yaml:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty" yaml:"pull_request_branch_filter_enabled,omitempty"`
-	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty" yaml:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty" yaml:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildPullRequestForks                   *bool   `json:"build_pull_request_forks,omitempty" yaml:"build_pull_request_forks,omitempty"`
-	PrefixPullRequestForkBranchNames        *bool   `json:"prefix_pull_request_fork_branch_names,omitempty" yaml:"prefix_pull_request_fork_branch_names,omitempty"`
-	BuildTags                               *bool   `json:"build_tags,omitempty" yaml:"build_tags,omitempty"`
-	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty" yaml:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty" yaml:"publish_commit_status_per_step,omitempty"`
-	FilterEnabled                           *bool   `json:"filter_enabled,omitempty" yaml:"filter_enabled,omitempty"`
-	FilterCondition                         *string `json:"filter_condition,omitempty" yaml:"filter_condition,omitempty"`
-	SeparatePullRequestStatuses             *bool   `json:"separate_pull_request_statuses,omitempty" yaml:"separate_pull_request_statuses,omitempty"`
-	PublishBlockedAsPending                 *bool   `json:"publish_blocked_as_pending,omitempty" yaml:"publish_blocked_as_pending,omitempty"`
+	TriggerMode                             *string `json:"trigger_mode,omitempty"`
+	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
+	BuildBranches                           *bool   `json:"build_branches,omitempty"`
+	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildPullRequestForks                   *bool   `json:"build_pull_request_forks,omitempty"`
+	PrefixPullRequestForkBranchNames        *bool   `json:"prefix_pull_request_fork_branch_names,omitempty"`
+	BuildTags                               *bool   `json:"build_tags,omitempty"`
+	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
+	FilterEnabled                           *bool   `json:"filter_enabled,omitempty"`
+	FilterCondition                         *string `json:"filter_condition,omitempty"`
+	SeparatePullRequestStatuses             *bool   `json:"separate_pull_request_statuses,omitempty"`
+	PublishBlockedAsPending                 *bool   `json:"publish_blocked_as_pending,omitempty"`
 
 	// Read-only
-	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
+	Repository *string `json:"repository,omitempty"`
 }
 
 func (s *GitHubSettings) isProviderSettings() {}
 
 // GitHubEnterpriseSettings are settings for pipelines building from GitHub Enterprise repositories.
 type GitHubEnterpriseSettings struct {
-	TriggerMode                             *string `json:"trigger_mode,omitempty" yaml:"trigger_mode,omitempty"`
-	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty" yaml:"build_pull_requests,omitempty"`
-	BuildBranches                           *bool   `json:"build_branches,omitempty" yaml:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty" yaml:"pull_request_branch_filter_enabled,omitempty"`
-	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty" yaml:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty" yaml:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildTags                               *bool   `json:"build_tags,omitempty" yaml:"build_tags,omitempty"`
-	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty" yaml:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty" yaml:"publish_commit_status_per_step,omitempty"`
+	TriggerMode                             *string `json:"trigger_mode,omitempty"`
+	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
+	BuildBranches                           *bool   `json:"build_branches,omitempty"`
+	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildTags                               *bool   `json:"build_tags,omitempty"`
+	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
 
 	// Read-only
-	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
+	Repository *string `json:"repository,omitempty"`
 }
 
 func (s *GitHubEnterpriseSettings) isProviderSettings() {}
@@ -113,7 +113,7 @@ func (s *GitHubEnterpriseSettings) isProviderSettings() {}
 // GitLabSettings are settings for pipelines building from GitLab repositories.
 type GitLabSettings struct {
 	// Read-only
-	Repository *string `json:"repository,omitempty" yaml:"repository,omitempty"`
+	Repository *string `json:"repository,omitempty"`
 }
 
 func (s *GitLabSettings) isProviderSettings() {}

--- a/buildkite/teams.go
+++ b/buildkite/teams.go
@@ -18,14 +18,14 @@ type TeamsService struct {
 
 // Team represents a buildkite team.
 type Team struct {
-	ID          *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	Name        *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	Slug        *string    `json:"slug,omitempty" yaml:"slug,omitempty"`
-	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
-	Privacy     *string    `json:"privacy,omitempty" yaml:"privacy,omitempty"`
-	Default     *bool      `json:"default,omitempty" yaml:"default,omitempty"`
-	CreatedAt   *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	CreatedBy   *User      `json:"created_by,omitempty" yaml:"created_by,omitempty"`
+	ID          *string    `json:"id,omitempty"`
+	Name        *string    `json:"name,omitempty"`
+	Slug        *string    `json:"slug,omitempty"`
+	Description *string    `json:"description,omitempty"`
+	Privacy     *string    `json:"privacy,omitempty"`
+	Default     *bool      `json:"default,omitempty"`
+	CreatedAt   *Timestamp `json:"created_at,omitempty"`
+	CreatedBy   *User      `json:"created_by,omitempty"`
 }
 
 // TeamsListOptions specifies the optional parameters to the

--- a/buildkite/test_runs.go
+++ b/buildkite/test_runs.go
@@ -14,12 +14,12 @@ type TestRunsService struct {
 }
 
 type TestRun struct {
-	ID        *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	URL       *string    `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL    *string    `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	Branch    *string    `json:"branch,omitempty" yaml:"branch,omitempty"`
-	CommitSHA *string    `json:"commit_sha,omitempty" yaml:"commit_sha,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ID        *string    `json:"id,omitempty"`
+	URL       *string    `json:"url,omitempty"`
+	WebURL    *string    `json:"web_url,omitempty"`
+	Branch    *string    `json:"branch,omitempty"`
+	CommitSHA *string    `json:"commit_sha,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
 type TestRunsListOptions struct {

--- a/buildkite/test_suites.go
+++ b/buildkite/test_suites.go
@@ -15,20 +15,20 @@ type TestSuitesService struct {
 }
 
 type TestSuiteCreate struct {
-	Name          string   `json:"name" yaml:"name"`
-	DefaultBranch string   `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
-	ShowAPIToken  bool     `json:"show_api_token,omitempty" yaml:"show_api_token,omitempty"`
-	TeamUUIDs     []string `json:"team_ids,omitempty" yaml:"team_ids,omitempty"`
+	Name          string   `json:"name"`
+	DefaultBranch string   `json:"default_branch,omitempty"`
+	ShowAPIToken  bool     `json:"show_api_token,omitempty"`
+	TeamUUIDs     []string `json:"team_ids,omitempty"`
 }
 
 type TestSuite struct {
-	ID            *string `json:"id,omitempty" yaml:"id,omitempty"`
-	GraphQLID     *string `json:"graphql_id,omitempty" yaml:"graphql_id,omitempty"`
-	Slug          *string `json:"slug,omitempty" yaml:"slug,omitempty"`
-	Name          *string `json:"name,omitempty" yaml:"name,omitempty"`
-	URL           *string `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL        *string `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	DefaultBranch *string `json:"default_branch,omitempty" yaml:"default_branch,omitempty"`
+	ID            *string `json:"id,omitempty"`
+	GraphQLID     *string `json:"graphql_id,omitempty"`
+	Slug          *string `json:"slug,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	URL           *string `json:"url,omitempty"`
+	WebURL        *string `json:"web_url,omitempty"`
+	DefaultBranch *string `json:"default_branch,omitempty"`
 }
 
 type TestSuiteListOptions struct {

--- a/buildkite/tests.go
+++ b/buildkite/tests.go
@@ -14,13 +14,13 @@ type TestsService struct {
 }
 
 type Test struct {
-	ID       *string `json:"id,omitempty" yaml:"id,omitempty"`
-	URL      *string `json:"url,omitempty" yaml:"url,omitempty"`
-	WebURL   *string `json:"web_url,omitempty" yaml:"web_url,omitempty"`
-	Scope    *string `json:"scope,omitempty" yaml:"scope,omitempty"`
-	Name     *string `json:"name,omitempty" yaml:"name,omitempty"`
-	Location *string `json:"location,omitempty" yaml:"location,omitempty"`
-	FileName *string `json:"file_name,omitempty" yaml:"file_name,omitempty"`
+	ID       *string `json:"id,omitempty"`
+	URL      *string `json:"url,omitempty"`
+	WebURL   *string `json:"web_url,omitempty"`
+	Scope    *string `json:"scope,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Location *string `json:"location,omitempty"`
+	FileName *string `json:"file_name,omitempty"`
 }
 
 func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (*Test, *Response, error) {

--- a/buildkite/user.go
+++ b/buildkite/user.go
@@ -15,10 +15,10 @@ type UserService struct {
 
 // User represents a buildkite user.
 type User struct {
-	ID        *string    `json:"id,omitempty" yaml:"id,omitempty"`
-	Name      *string    `json:"name,omitempty" yaml:"name,omitempty"`
-	Email     *string    `json:"email,omitempty" yaml:"email,omitempty"`
-	CreatedAt *Timestamp `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	ID        *string    `json:"id,omitempty"`
+	Name      *string    `json:"name,omitempty"`
+	Email     *string    `json:"email,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
 // Get the current user.


### PR DESCRIPTION
Buildkite does not output any API responses in YAML, nor (in general) does it accept them. There are exceptions to the acceptance side of that, but within this library, they'll either be passed as JSON (a subset of YAML), or passed as raw text.

This removes the ability for external users to make calls like
```Go
bytes, err := yaml.Marshal(Agent{/* ... */})
```
(or more accurately; it'll remove the ability for those calls to work as they currently do - names of keys will not be properly cased and yaml library semantics like `inline` and `omitempty` will not function)

**This is a breaking change.**