### PR TITLE
Remove pointer arguments where they're not needed

### DIFF
--- a/buildkite/access_tokens.go
+++ b/buildkite/access_tokens.go
@@ -10,29 +10,24 @@ type AccessTokensService struct {
 }
 
 type AccessToken struct {
-	UUID   *string   `json:"uuid,omitempty"`
-	Scopes *[]string `json:"scopes,omitempty"`
+	UUID   string   `json:"uuid,omitempty"`
+	Scopes []string `json:"scopes,omitempty"`
 }
 
 // Get gets the current token which was used to authenticate the request
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/access-token
-func (ats *AccessTokensService) Get(ctx context.Context) (*AccessToken, *Response, error) {
-
-	var u string
-
-	u = fmt.Sprintf("v2/access-token")
-
+func (ats *AccessTokensService) Get(ctx context.Context) (AccessToken, *Response, error) {
+	u := fmt.Sprintf("v2/access-token")
 	req, err := ats.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return AccessToken{}, nil, err
 	}
 
-	accessToken := new(AccessToken)
-
-	resp, err := ats.client.Do(req, accessToken)
+	var accessToken AccessToken
+	resp, err := ats.client.Do(req, &accessToken)
 	if err != nil {
-		return nil, resp, err
+		return AccessToken{}, resp, err
 	}
 
 	return accessToken, resp, nil
@@ -42,11 +37,7 @@ func (ats *AccessTokensService) Get(ctx context.Context) (*AccessToken, *Respons
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/access-token
 func (ats *AccessTokensService) Revoke(ctx context.Context) (*Response, error) {
-
-	var u string
-
-	u = fmt.Sprintf("v2/access-token")
-
+	u := fmt.Sprintf("v2/access-token")
 	req, err := ats.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/buildkite/access_tokens_test.go
+++ b/buildkite/access_tokens_test.go
@@ -25,9 +25,9 @@ func TestAccessTokensService_Get(t *testing.T) {
 		t.Errorf("AccessTokens.Get returned error: %v", err)
 	}
 
-	want := &AccessToken{
-		UUID:   String("b63254c0-3271-4a98-8270-7cfbd6c2f14e"),
-		Scopes: &[]string{"read_build"},
+	want := AccessToken{
+		UUID:   "b63254c0-3271-4a98-8270-7cfbd6c2f14e",
+		Scopes: []string{"read_build"},
 	}
 	if diff := cmp.Diff(ats, want); diff != "" {
 		t.Errorf("AccessTokens.Get diff: (-got +want)\n%s", diff)

--- a/buildkite/agents.go
+++ b/buildkite/agents.go
@@ -15,17 +15,17 @@ type AgentsService struct {
 
 // Agent represents a buildkite build agent.
 type Agent struct {
-	ID                *string    `json:"id,omitempty"`
-	GraphQLID         *string    `json:"graphql_id,omitempty"`
-	URL               *string    `json:"url,omitempty"`
-	WebURL            *string    `json:"web_url,omitempty"`
-	Name              *string    `json:"name,omitempty"`
-	ConnectedState    *string    `json:"connection_state,omitempty"`
-	AgentToken        *string    `json:"access_token,omitempty"`
-	Hostname          *string    `json:"hostname,omitempty"`
-	IPAddress         *string    `json:"ip_address,omitempty"`
-	UserAgent         *string    `json:"user_agent,omitempty"`
-	Version           *string    `json:"version,omitempty"`
+	ID                string     `json:"id,omitempty"`
+	GraphQLID         string     `json:"graphql_id,omitempty"`
+	URL               string     `json:"url,omitempty"`
+	WebURL            string     `json:"web_url,omitempty"`
+	Name              string     `json:"name,omitempty"`
+	ConnectedState    string     `json:"connection_state,omitempty"`
+	AgentToken        string     `json:"access_token,omitempty"`
+	Hostname          string     `json:"hostname,omitempty"`
+	IPAddress         string     `json:"ip_address,omitempty"`
+	UserAgent         string     `json:"user_agent,omitempty"`
+	Version           string     `json:"version,omitempty"`
 	CreatedAt         *Timestamp `json:"created_at,omitempty"`
 	LastJobFinishedAt *Timestamp `json:"last_job_finished_at,omitempty"`
 	Priority          *int       `json:"priority,omitempty"`
@@ -56,10 +56,7 @@ type AgentListOptions struct {
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#list-agents
 func (as *AgentsService) List(ctx context.Context, org string, opt *AgentListOptions) ([]Agent, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/agents", org)
-
+	u := fmt.Sprintf("v2/organizations/%s/agents", org)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -70,31 +67,29 @@ func (as *AgentsService) List(ctx context.Context, org string, opt *AgentListOpt
 		return nil, nil, err
 	}
 
-	agents := new([]Agent)
-	resp, err := as.client.Do(req, agents)
+	var agents []Agent
+	resp, err := as.client.Do(req, &agents)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *agents, resp, err
+	return agents, resp, err
 }
 
 // Get fetches an agent.
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#get-an-agent
-func (as *AgentsService) Get(ctx context.Context, org string, id string) (*Agent, *Response, error) {
-
+func (as *AgentsService) Get(ctx context.Context, org string, id string) (Agent, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/agents/%s", org, id)
-
 	req, err := as.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return Agent{}, nil, err
 	}
 
-	agent := new(Agent)
-	resp, err := as.client.Do(req, agent)
+	var agent Agent
+	resp, err := as.client.Do(req, &agent)
 	if err != nil {
-		return nil, resp, err
+		return Agent{}, resp, err
 	}
 
 	return agent, resp, err
@@ -103,21 +98,17 @@ func (as *AgentsService) Get(ctx context.Context, org string, id string) (*Agent
 // Create a new buildkite agent.
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#create-an-agent
-func (as *AgentsService) Create(ctx context.Context, org string, agent *Agent) (*Agent, *Response, error) {
-
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/agents", org)
-
+func (as *AgentsService) Create(ctx context.Context, org string, agent Agent) (Agent, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/agents", org)
 	req, err := as.client.NewRequest(ctx, "POST", u, agent)
 	if err != nil {
-		return nil, nil, err
+		return Agent{}, nil, err
 	}
 
-	a := new(Agent)
-	resp, err := as.client.Do(req, a)
+	var a Agent
+	resp, err := as.client.Do(req, &a)
 	if err != nil {
-		return nil, resp, err
+		return Agent{}, resp, err
 	}
 
 	return a, resp, err
@@ -127,9 +118,7 @@ func (as *AgentsService) Create(ctx context.Context, org string, agent *Agent) (
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#delete-an-agent
 func (as *AgentsService) Delete(ctx context.Context, org string, id string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/agents/%s", org, id)
-
 	req, err := as.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -142,13 +131,11 @@ func (as *AgentsService) Delete(ctx context.Context, org string, id string) (*Re
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/agents#stop-an-agent
 func (as *AgentsService) Stop(ctx context.Context, org string, id string, force bool) (*Response, error) {
-
-	u := fmt.Sprintf("v2/organizations/%s/agents/%s/stop", org, id)
-
 	var body = struct {
 		Force bool `json:"force"`
 	}{force}
 
+	u := fmt.Sprintf("v2/organizations/%s/agents/%s/stop", org, id)
 	req, err := as.client.NewRequest(ctx, "PUT", u, body)
 	if err != nil {
 		return nil, err

--- a/buildkite/agents_test.go
+++ b/buildkite/agents_test.go
@@ -28,9 +28,9 @@ func TestAgentsService_List(t *testing.T) {
 		t.Errorf("Agents.List returned error: %v", err)
 	}
 
-	want := []Agent{{ID: String("123")}, {ID: String("1234")}}
+	want := []Agent{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(agents, want); diff != "" {
-		t.Errorf("Agents.List diff: (-got +want)\n%s", diff)
+		t.Errorf("Agents.List: diff: (-got +want)\n%s", diff)
 	}
 }
 
@@ -50,9 +50,9 @@ func TestAgentsService_Get(t *testing.T) {
 		t.Errorf("Agents.Get returned error: %v", err)
 	}
 
-	want := &Agent{ID: String("123")}
+	want := Agent{ID: "123"}
 	if diff := cmp.Diff(agent, want); diff != "" {
-		t.Errorf("Agents.Get diff: (-got +want)\n%s", diff)
+		t.Errorf("Agents.List(): diff: (-got +want)\n%s", diff)
 	}
 }
 
@@ -62,10 +62,10 @@ func TestAgentsService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &Agent{Name: String("new_agent_bob")}
+	input := Agent{Name: "new_agent_bob"}
 
 	server.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
-		v := new(Agent)
+		var v Agent
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -82,11 +82,10 @@ func TestAgentsService_Create(t *testing.T) {
 		t.Errorf("Agents.Create returned error: %v", err)
 	}
 
-	want := &Agent{ID: String("123")}
+	want := Agent{ID: "123"}
 	if diff := cmp.Diff(agent, want); diff != "" {
-		t.Errorf("Agents.Create diff: (-got +want)\n%s", diff)
+		t.Errorf("Agents.Create() diff: (-got +want)\n%s", diff)
 	}
-
 }
 
 func TestAgentsService_Delete(t *testing.T) {

--- a/buildkite/annotations.go
+++ b/buildkite/annotations.go
@@ -15,19 +15,19 @@ type AnnotationsService struct {
 
 // Annotation represents an annotation which has been stored from a build
 type Annotation struct {
-	ID        *string    `json:"id,omitempty"`
-	Context   *string    `json:"context,omitempty"`
-	Style     *string    `json:"style,omitempty"`
-	BodyHTML  *string    `json:"body_html,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	Context   string     `json:"context,omitempty"`
+	Style     string     `json:"style,omitempty"`
+	BodyHTML  string     `json:"body_html,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
 }
 
 type AnnotationCreate struct {
-	Body    *string `json:"body,omitempty"`
-	Context *string `json:"context,omitempty"`
-	Style   *string `json:"style,omitempty"`
-	Append  *bool   `json:"append,omitempty"`
+	Body    string `json:"body,omitempty"`
+	Context string `json:"context,omitempty"`
+	Style   string `json:"style,omitempty"`
+	Append  bool   `json:"append,omitempty"`
 }
 
 // AnnotationListOptions specifies the optional parameters to the
@@ -40,9 +40,7 @@ type AnnotationListOptions struct {
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/annotations#list-annotations-for-a-build
 func (as *AnnotationsService) ListByBuild(ctx context.Context, org string, pipeline string, build string, opt *AnnotationListOptions) ([]Annotation, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/annotations", org, pipeline, build)
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/annotations", org, pipeline, build)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -53,30 +51,26 @@ func (as *AnnotationsService) ListByBuild(ctx context.Context, org string, pipel
 		return nil, nil, err
 	}
 
-	annotations := new([]Annotation)
-	resp, err := as.client.Do(req, annotations)
+	var annotations []Annotation
+	resp, err := as.client.Do(req, &annotations)
 	if err != nil {
 		return nil, resp, err
 	}
-	return *annotations, resp, err
+	return annotations, resp, err
 }
 
-func (as *AnnotationsService) Create(ctx context.Context, org, pipeline, build string, ac *AnnotationCreate) (*Annotation, *Response, error) {
-
+func (as *AnnotationsService) Create(ctx context.Context, org, pipeline, build string, ac AnnotationCreate) (Annotation, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/annotations", org, pipeline, build)
-
 	req, err := as.client.NewRequest(ctx, "POST", u, ac)
-
 	if err != nil {
-		return nil, nil, err
+		return Annotation{}, nil, err
 	}
 
-	annotation := new(Annotation)
-
-	resp, err := as.client.Do(req, annotation)
+	var annotation Annotation
+	resp, err := as.client.Do(req, &annotation)
 
 	if err != nil {
-		return nil, resp, err
+		return Annotation{}, resp, err
 	}
 
 	return annotation, resp, err

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -44,18 +44,18 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 
 	want := []Annotation{
 		{
-			ID:        String("de0d4ab5-6360-467a-a34b-e5ef5db5320d"),
-			Context:   String("default"),
-			Style:     String("info"),
-			BodyHTML:  String("<h1>My Markdown Heading</h1>\n<img src=\"artifact://indy.png\" alt=\"Belongs in a museum\" height=250 />"),
+			ID:        "de0d4ab5-6360-467a-a34b-e5ef5db5320d",
+			Context:   "default",
+			Style:     "info",
+			BodyHTML:  "<h1>My Markdown Heading</h1>\n<img src=\"artifact://indy.png\" alt=\"Belongs in a museum\" height=250 />",
 			CreatedAt: NewTimestamp(time.Date(2019, 4, 9, 18, 7, 15, 775000000, time.UTC)),
 			UpdatedAt: NewTimestamp(time.Date(2019, 8, 6, 20, 58, 49, 396000000, time.UTC)),
 		},
 		{
-			ID:        String("5b3ceff6-78cb-4fe9-88ae-51be5f145977"),
-			Context:   String("coverage"),
-			Style:     String("info"),
-			BodyHTML:  String("Read the <a href=\"artifact://coverage/index.html\">uploaded coverage report</a>"),
+			ID:        "5b3ceff6-78cb-4fe9-88ae-51be5f145977",
+			Context:   "coverage",
+			Style:     "info",
+			BodyHTML:  "Read the <a href=\"artifact://coverage/index.html\">uploaded coverage report</a>",
 			CreatedAt: NewTimestamp(time.Date(2019, 4, 9, 18, 7, 16, 320000000, time.UTC)),
 			UpdatedAt: NewTimestamp(time.Date(2019, 4, 9, 18, 7, 16, 320000000, time.UTC)),
 		},
@@ -71,15 +71,15 @@ func TestAnnotationsService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &AnnotationCreate{
-		Style:   String("info"),
-		Context: String("default"),
-		Body:    String("<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>"),
-		Append:  Bool(false),
+	input := AnnotationCreate{
+		Style:   "info",
+		Context: "default",
+		Body:    "<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>",
+		Append:  false,
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline/builds/10/annotations", func(w http.ResponseWriter, r *http.Request) {
-		v := new(AnnotationCreate)
+		var v AnnotationCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -101,7 +101,6 @@ func TestAnnotationsService_Create(t *testing.T) {
 	})
 
 	annotation, _, err := client.Annotations.Create(context.Background(), "my-great-org", "my-great-pipeline", "10", input)
-
 	if err != nil {
 		t.Errorf("TestAnnotations.Create returned error: %v", err)
 	}
@@ -109,11 +108,11 @@ func TestAnnotationsService_Create(t *testing.T) {
 	annotationCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-21T08:50:05.824Z"))
 	annotationUpatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-21T08:50:05.824Z"))
 
-	want := &Annotation{
-		ID:        String("68aef727-f754-48e1-aad8-5f5da8a9960c"),
-		Context:   String("default"),
-		Style:     String("info"),
-		BodyHTML:  String("<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>"),
+	want := Annotation{
+		ID:        "68aef727-f754-48e1-aad8-5f5da8a9960c",
+		Context:   "default",
+		Style:     "info",
+		BodyHTML:  "<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>",
 		CreatedAt: NewTimestamp(annotationCreatedAt),
 		UpdatedAt: NewTimestamp(annotationUpatedAt),
 	}

--- a/buildkite/artifacts.go
+++ b/buildkite/artifacts.go
@@ -16,19 +16,19 @@ type ArtifactsService struct {
 
 // Artifact represents an artifact which has been stored from a build
 type Artifact struct {
-	ID           *string `json:"id,omitempty"`
-	JobID        *string `json:"job_id,omitempty"`
-	URL          *string `json:"url,omitempty"`
-	DownloadURL  *string `json:"download_url,omitempty"`
-	State        *string `json:"state,omitempty"`
-	Path         *string `json:"path,omitempty"`
-	Dirname      *string `json:"dirname,omitempty"`
-	Filename     *string `json:"filename,omitempty"`
-	MimeType     *string `json:"mime_type,omitempty"`
-	FileSize     *int64  `json:"file_size,omitempty"`
-	GlobPath     *string `json:"glob_path,omitempty"`
-	OriginalPath *string `json:"original_path,omitempty"`
-	SHA1         *string `json:"sha1sum,omitempty"`
+	ID           string `json:"id,omitempty"`
+	JobID        string `json:"job_id,omitempty"`
+	URL          string `json:"url,omitempty"`
+	DownloadURL  string `json:"download_url,omitempty"`
+	State        string `json:"state,omitempty"`
+	Path         string `json:"path,omitempty"`
+	Dirname      string `json:"dirname,omitempty"`
+	Filename     string `json:"filename,omitempty"`
+	MimeType     string `json:"mime_type,omitempty"`
+	FileSize     int64  `json:"file_size,omitempty"`
+	GlobPath     string `json:"glob_path,omitempty"`
+	OriginalPath string `json:"original_path,omitempty"`
+	SHA1         string `json:"sha1sum,omitempty"`
 }
 
 // ArtifactListOptions specifies the optional parameters to the
@@ -41,9 +41,7 @@ type ArtifactListOptions struct {
 //
 // buildkite API docs: https://buildkite.com/docs/api/artifacts#list-artifacts-for-a-build
 func (as *ArtifactsService) ListByBuild(ctx context.Context, org string, pipeline string, build string, opt *ArtifactListOptions) ([]Artifact, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/artifacts", org, pipeline, build)
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/artifacts", org, pipeline, build)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -54,21 +52,19 @@ func (as *ArtifactsService) ListByBuild(ctx context.Context, org string, pipelin
 		return nil, nil, err
 	}
 
-	artifacts := new([]Artifact)
-	resp, err := as.client.Do(req, artifacts)
+	var artifacts []Artifact
+	resp, err := as.client.Do(req, &artifacts)
 	if err != nil {
 		return nil, resp, err
 	}
-	return *artifacts, resp, err
+	return artifacts, resp, err
 }
 
 // ListByJob gets artifacts for a specific build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/artifacts#list-artifacts-for-a-job
 func (as *ArtifactsService) ListByJob(ctx context.Context, org string, pipeline string, build string, job string, opt *ArtifactListOptions) ([]Artifact, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/artifacts", org, pipeline, build, job)
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/artifacts", org, pipeline, build, job)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -79,12 +75,12 @@ func (as *ArtifactsService) ListByJob(ctx context.Context, org string, pipeline 
 		return nil, nil, err
 	}
 
-	artifacts := new([]Artifact)
-	resp, err := as.client.Do(req, artifacts)
+	var artifacts []Artifact
+	resp, err := as.client.Do(req, &artifacts)
 	if err != nil {
 		return nil, resp, err
 	}
-	return *artifacts, resp, err
+	return artifacts, resp, err
 }
 
 // DownloadArtifactByURL gets artifacts for a specific build

--- a/buildkite/buildkite.go
+++ b/buildkite/buildkite.go
@@ -441,29 +441,6 @@ func addOptions(s string, opt interface{}) (string, error) {
 	return u.String(), nil
 }
 
-// Int is a helper routine that allocates a new int value
-// to store v and returns a pointer to it, but unlike Int
-// its argument value is an int.
-func Int(v int) *int {
-	p := new(int)
-	*p = v
-	return p
-}
-
-// String is a helper routine that allocates a new string value
-// to store v and returns a pointer to it.
-func String(v string) *string {
-	p := new(string)
-	*p = v
-	return p
-}
-
-func Bool(v bool) *bool {
-	p := new(bool)
-	*p = v
-	return p
-}
-
 // ListOptions specifies the optional parameters to various List methods that
 // support pagination.
 type ListOptions struct {

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -102,7 +102,7 @@ func TestNewClient(t *testing.T) {
 func TestNewRequest(t *testing.T) {
 	c := NewClient(nil)
 	inURL, outURL := "/foo", DefaultBaseURL+"foo"
-	inBody := &User{ID: String("123"), Name: String("Jane Doe"), Email: String("jane@doe.com")}
+	inBody := User{ID: "123", Name: "Jane Doe", Email: "jane@doe.com"}
 	outBody := `{"id":"123","name":"Jane Doe","email":"jane@doe.com"}` + "\n"
 
 	req, _ := c.NewRequest(context.Background(), "GET", inURL, inBody)

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -91,7 +91,7 @@ type Build struct {
 	Source      string                 `json:"source,omitempty"`
 
 	// jobs run during the build
-	Jobs []*Job `json:"jobs,omitempty"`
+	Jobs []Job `json:"jobs,omitempty"`
 
 	// the pipeline this build is associated with
 	Pipeline *Pipeline `json:"pipeline,omitempty"`

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -57,38 +57,38 @@ type RebuiltFrom struct {
 
 // PullRequest represents a Github PR
 type PullRequest struct {
-	ID         *string `json:"id,omitempty"`
-	Base       *string `json:"base,omitempty"`
-	Repository *string `json:"repository,omitempty"`
+	ID         string `json:"id,omitempty"`
+	Base       string `json:"base,omitempty"`
+	Repository string `json:"repository,omitempty"`
 }
 
 type TriggeredFrom struct {
-	BuildID           *string `json:"build_id,omitempty"`
-	BuildNumber       *int    `json:"build_number,omitempty"`
-	BuildPipelineSlug *string `json:"build_pipeline_slug,omitempty"`
+	BuildID           string `json:"build_id,omitempty"`
+	BuildNumber       int    `json:"build_number,omitempty"`
+	BuildPipelineSlug string `json:"build_pipeline_slug,omitempty"`
 }
 
 // Build represents a build which has run in buildkite
 type Build struct {
-	ID          *string                `json:"id,omitempty"`
-	GraphQLID   *string                `json:"graphql_id,omitempty"`
-	URL         *string                `json:"url,omitempty"`
-	WebURL      *string                `json:"web_url,omitempty"`
-	Number      *int                   `json:"number,omitempty"`
-	State       *string                `json:"state,omitempty"`
-	Blocked     *bool                  `json:"blocked,omitempty"`
-	Message     *string                `json:"message,omitempty"`
-	Commit      *string                `json:"commit,omitempty"`
-	Branch      *string                `json:"branch,omitempty"`
-	Author      *Author                `json:"author,omitempty"`
+	ID          string                 `json:"id,omitempty"`
+	GraphQLID   string                 `json:"graphql_id,omitempty"`
+	URL         string                 `json:"url,omitempty"`
+	WebURL      string                 `json:"web_url,omitempty"`
+	Number      int                    `json:"number,omitempty"`
+	State       string                 `json:"state,omitempty"`
+	Blocked     bool                   `json:"blocked,omitempty"`
+	Message     string                 `json:"message,omitempty"`
+	Commit      string                 `json:"commit,omitempty"`
+	Branch      string                 `json:"branch,omitempty"`
+	Author      Author                 `json:"author,omitempty"`
 	Env         map[string]interface{} `json:"env,omitempty"`
 	CreatedAt   *Timestamp             `json:"created_at,omitempty"`
 	ScheduledAt *Timestamp             `json:"scheduled_at,omitempty"`
 	StartedAt   *Timestamp             `json:"started_at,omitempty"`
 	FinishedAt  *Timestamp             `json:"finished_at,omitempty"`
 	MetaData    map[string]string      `json:"meta_data,omitempty"`
-	Creator     *Creator               `json:"creator,omitempty"`
-	Source      *string                `json:"source,omitempty"`
+	Creator     Creator                `json:"creator,omitempty"`
+	Source      string                 `json:"source,omitempty"`
 
 	// jobs run during the build
 	Jobs []*Job `json:"jobs,omitempty"`
@@ -159,35 +159,36 @@ type BuildsListOptions struct {
 // Cancel - Trigger a cancel for the target build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/builds#cancel-a-build
-func (bs *BuildsService) Cancel(ctx context.Context, org, pipeline, build string) (*Build, error) {
+func (bs *BuildsService) Cancel(ctx context.Context, org, pipeline, build string) (Build, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/cancel", org, pipeline, build)
 	req, err := bs.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
-		return nil, err
+		return Build{}, err
 	}
-	result := Build{}
+
+	var result Build
 	_, err = bs.client.Do(req, &result)
 	if err != nil {
-		return nil, err
+		return Build{}, err
 	}
-	return &result, nil
+
+	return result, nil
 }
 
 // Create - Create a pipeline
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#create-a-build
-func (bs *BuildsService) Create(ctx context.Context, org string, pipeline string, b *CreateBuild) (*Build, *Response, error) {
+func (bs *BuildsService) Create(ctx context.Context, org string, pipeline string, b CreateBuild) (Build, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds", org, pipeline)
-
 	req, err := bs.client.NewRequest(ctx, "POST", u, b)
 	if err != nil {
-		return nil, nil, err
+		return Build{}, nil, err
 	}
 
-	build := new(Build)
+	var build Build
 	resp, err := bs.client.Do(req, build)
 	if err != nil {
-		return nil, resp, err
+		return Build{}, resp, err
 	}
 
 	return build, resp, err
@@ -196,23 +197,23 @@ func (bs *BuildsService) Create(ctx context.Context, org string, pipeline string
 // Get fetches a build.
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#get-a-build
-func (bs *BuildsService) Get(ctx context.Context, org string, pipeline string, id string, opt *BuildsListOptions) (*Build, *Response, error) {
+func (bs *BuildsService) Get(ctx context.Context, org string, pipeline string, id string, opt *BuildsListOptions) (Build, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s", org, pipeline, id)
 
 	u, err := addOptions(u, opt)
 	if err != nil {
-		return nil, nil, err
+		return Build{}, nil, err
 	}
 
 	req, err := bs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return Build{}, nil, err
 	}
 
-	build := new(Build)
-	resp, err := bs.client.Do(req, build)
+	var build Build
+	resp, err := bs.client.Do(req, &build)
 	if err != nil {
-		return nil, resp, err
+		return Build{}, resp, err
 	}
 
 	return build, resp, err
@@ -222,10 +223,7 @@ func (bs *BuildsService) Get(ctx context.Context, org string, pipeline string, i
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#list-all-builds
 func (bs *BuildsService) List(ctx context.Context, opt *BuildsListOptions) ([]Build, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/builds")
-
+	u := fmt.Sprintf("v2/builds")
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -236,23 +234,20 @@ func (bs *BuildsService) List(ctx context.Context, opt *BuildsListOptions) ([]Bu
 		return nil, nil, err
 	}
 
-	orgs := new([]Build)
-	resp, err := bs.client.Do(req, orgs)
+	var builds []Build
+	resp, err := bs.client.Do(req, &builds)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *orgs, resp, err
+	return builds, resp, err
 }
 
 // ListByOrg lists the builds within the specified orginisation.
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#list-builds-for-an-organization
 func (bs *BuildsService) ListByOrg(ctx context.Context, org string, opt *BuildsListOptions) ([]Build, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/builds", org)
-
+	u := fmt.Sprintf("v2/organizations/%s/builds", org)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -263,23 +258,20 @@ func (bs *BuildsService) ListByOrg(ctx context.Context, org string, opt *BuildsL
 		return nil, nil, err
 	}
 
-	orgs := new([]Build)
-	resp, err := bs.client.Do(req, orgs)
+	var builds []Build
+	resp, err := bs.client.Do(req, &builds)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *orgs, resp, err
+	return builds, resp, err
 }
 
 // ListByPipeline lists the builds for a pipeline within the specified originisation.
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#list-builds-for-a-pipeline
 func (bs *BuildsService) ListByPipeline(ctx context.Context, org string, pipeline string, opt *BuildsListOptions) ([]Build, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds", org, pipeline)
-
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds", org, pipeline)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -290,28 +282,30 @@ func (bs *BuildsService) ListByPipeline(ctx context.Context, org string, pipelin
 		return nil, nil, err
 	}
 
-	orgs := new([]Build)
-	resp, err := bs.client.Do(req, orgs)
+	var builds []Build
+	resp, err := bs.client.Do(req, &builds)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *orgs, resp, err
+	return builds, resp, err
 }
 
 // Rebuild triggers a rebuild for the target build
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/builds#rebuild-a-build
-func (bs *BuildsService) Rebuild(ctx context.Context, org, pipeline, build string) (*Build, error) {
+func (bs *BuildsService) Rebuild(ctx context.Context, org, pipeline, build string) (Build, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/rebuild", org, pipeline, build)
 	req, err := bs.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
-		return nil, err
+		return Build{}, err
 	}
-	result := Build{}
+
+	var result Build
 	_, err = bs.client.Do(req, &result)
 	if err != nil {
-		return nil, err
+		return Build{}, err
 	}
-	return &result, nil
+
+	return result, nil
 }

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -30,7 +30,7 @@ func TestBuildsService_Cancel(t *testing.T) {
 		t.Errorf("Cancel returned error: %v", err)
 	}
 
-	want := &Build{ID: String("1"), State: String("cancelled")}
+	want := Build{ID: "1", State: "cancelled"}
 	if diff := cmp.Diff(build, want); diff != "" {
 		t.Errorf("Cancel diff: (-got +want)\n%s", diff)
 	}
@@ -52,7 +52,7 @@ func TestBuildsService_List(t *testing.T) {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
 
-	want := []Build{{ID: String("123")}, {ID: String("1234")}}
+	want := []Build{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(builds, want); diff != "" {
 		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
 	}
@@ -83,7 +83,7 @@ func TestBuildsService_Get(t *testing.T) {
 			t.Errorf("Builds.Get (expected id) returned error: %v", err)
 		}
 
-		want := &Build{ID: String(buildNumber)}
+		want := Build{ID: buildNumber}
 		if diff := cmp.Diff(build, want); diff != "" {
 			t.Errorf("Builds.Get (expected id) diff: (-got +want)\n%s", diff)
 		}
@@ -110,7 +110,7 @@ func TestBuildsService_Get(t *testing.T) {
 			t.Errorf("Builds.Get (group key) returned error: %v", err)
 		}
 
-		want := &Build{ID: String(buildNumber), Jobs: []*Job{{GroupKey: &expectedGroup}}}
+		want := Build{ID: buildNumber, Jobs: []*Job{{GroupKey: &expectedGroup}}}
 		if diff := cmp.Diff(build, want); diff != "" {
 			t.Errorf("Builds.Get (group key) diff: (-got +want)\n%s", diff)
 		}
@@ -141,7 +141,7 @@ func TestBuildsService_Get(t *testing.T) {
 			t.Errorf("Builds.Get (manual job) returned error: %v", err)
 		}
 
-		want := &Build{ID: String(buildNumber), Jobs: []*Job{{Type: &jobType, UnblockedAt: NewTimestamp(parsedTime)}}}
+		want := Build{ID: buildNumber, Jobs: []*Job{{Type: &jobType, UnblockedAt: NewTimestamp(parsedTime)}}}
 		if diff := cmp.Diff(build, want); diff != "" {
 			t.Errorf("Builds.Get (manual job) diff: (-got +want)\n%s", diff)
 		}
@@ -172,7 +172,7 @@ func TestBuildsService_List_by_status(t *testing.T) {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
 
-	want := []Build{{ID: String("123")}, {ID: String("1234")}}
+	want := []Build{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(builds, want); diff != "" {
 		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
 	}
@@ -203,7 +203,7 @@ func TestBuildsService_List_by_multiple_status(t *testing.T) {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
 
-	want := []Build{{ID: String("123")}, {ID: String("1234")}}
+	want := []Build{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(builds, want); diff != "" {
 		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
 	}
@@ -238,7 +238,7 @@ func TestBuildsService_List_by_created_date(t *testing.T) {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
 
-	want := []Build{{ID: String("123")}}
+	want := []Build{{ID: "123"}}
 	if diff := cmp.Diff(builds, want); diff != "" {
 		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
 	}
@@ -260,7 +260,7 @@ func TestBuildsService_ListByOrg(t *testing.T) {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
 
-	want := []Build{{ID: String("123")}, {ID: String("1234")}}
+	want := []Build{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(builds, want); diff != "" {
 		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
 	}
@@ -291,7 +291,7 @@ func TestBuildsService_ListByOrg_branch_commit(t *testing.T) {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
 
-	want := []Build{{ID: String("123")}, {ID: String("1234")}}
+	want := []Build{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(builds, want); diff != "" {
 		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
 	}
@@ -320,7 +320,7 @@ func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
 
-	want := []Build{{ID: String("123")}, {ID: String("1234")}}
+	want := []Build{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(builds, want); diff != "" {
 		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
 	}
@@ -342,7 +342,7 @@ func TestBuildsService_ListByPipeline(t *testing.T) {
 		t.Errorf("Builds.List returned error: %v", err)
 	}
 
-	want := []Build{{ID: String("123")}, {ID: String("1234")}}
+	want := []Build{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(builds, want); diff != "" {
 		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
 	}

--- a/buildkite/builds_test.go
+++ b/buildkite/builds_test.go
@@ -110,7 +110,7 @@ func TestBuildsService_Get(t *testing.T) {
 			t.Errorf("Builds.Get (group key) returned error: %v", err)
 		}
 
-		want := Build{ID: buildNumber, Jobs: []*Job{{GroupKey: &expectedGroup}}}
+		want := Build{ID: buildNumber, Jobs: []Job{{GroupKey: expectedGroup}}}
 		if diff := cmp.Diff(build, want); diff != "" {
 			t.Errorf("Builds.Get (group key) diff: (-got +want)\n%s", diff)
 		}
@@ -141,7 +141,7 @@ func TestBuildsService_Get(t *testing.T) {
 			t.Errorf("Builds.Get (manual job) returned error: %v", err)
 		}
 
-		want := Build{ID: buildNumber, Jobs: []*Job{{Type: &jobType, UnblockedAt: NewTimestamp(parsedTime)}}}
+		want := Build{ID: buildNumber, Jobs: []Job{{Type: jobType, UnblockedAt: NewTimestamp(parsedTime)}}}
 		if diff := cmp.Diff(build, want); diff != "" {
 			t.Errorf("Builds.Get (manual job) diff: (-got +want)\n%s", diff)
 		}

--- a/buildkite/cluster_queues.go
+++ b/buildkite/cluster_queues.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -15,32 +14,32 @@ type ClusterQueuesService struct {
 }
 
 type ClusterQueue struct {
-	ID                 *string         `json:"id,omitempty"`
-	GraphQLID          *string         `json:"graphql_id,omitempty"`
-	Key                *string         `json:"key,omitempty"`
-	Description        *string         `json:"description,omitempty"`
-	URL                *string         `json:"url,omitempty"`
-	WebURL             *string         `json:"web_url,omitempty"`
-	ClusterURL         *string         `json:"cluster_url,omitempty"`
-	DispatchPaused     *bool           `json:"dispatch_paused,omitempty"`
+	ID                 string          `json:"id,omitempty"`
+	GraphQLID          string          `json:"graphql_id,omitempty"`
+	Key                string          `json:"key,omitempty"`
+	Description        string          `json:"description,omitempty"`
+	URL                string          `json:"url,omitempty"`
+	WebURL             string          `json:"web_url,omitempty"`
+	ClusterURL         string          `json:"cluster_url,omitempty"`
+	DispatchPaused     bool            `json:"dispatch_paused,omitempty"`
 	DispatchPausedBy   *ClusterCreator `json:"dispatch_paused_by,omitempty"`
 	DispatchPausedAt   *Timestamp      `json:"dispatch_paused_at,omitempty"`
 	DispatchPausedNote *string         `json:"dispatch_paused_note,omitempty"`
 	CreatedAt          *Timestamp      `json:"created_at,omitempty"`
-	CreatedBy          *ClusterCreator `json:"created_by,omitempty"`
+	CreatedBy          ClusterCreator  `json:"created_by,omitempty"`
 }
 
 type ClusterQueueCreate struct {
-	Key         *string `json:"key,omitempty"`
-	Description *string `json:"description,omitempty"`
+	Key         string `json:"key,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type ClusterQueueUpdate struct {
-	Description *string `json:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 type ClusterQueuePause struct {
-	Note *string `json:"dispatch_paused_note,omitempty"`
+	Note string `json:"dispatch_paused_note,omitempty"`
 }
 
 type ClusterQueuesListOptions struct {
@@ -48,94 +47,67 @@ type ClusterQueuesListOptions struct {
 }
 
 func (cqs *ClusterQueuesService) List(ctx context.Context, org, clusterID string, opt *ClusterQueuesListOptions) ([]ClusterQueue, *Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues", org, clusterID)
-
 	u, err := addOptions(u, opt)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req, err := cqs.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	queues := new([]ClusterQueue)
-
-	resp, err := cqs.client.Do(req, queues)
-
+	var queues []ClusterQueue
+	resp, err := cqs.client.Do(req, &queues)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *queues, resp, err
+	return queues, resp, err
 }
 
-func (cqs *ClusterQueuesService) Get(ctx context.Context, org, clusterID, queueID string) (*ClusterQueue, *Response, error) {
-
+func (cqs *ClusterQueuesService) Get(ctx context.Context, org, clusterID, queueID string) (ClusterQueue, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s", org, clusterID, queueID)
-
 	req, err := cqs.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
-		return nil, nil, err
+		return ClusterQueue{}, nil, err
 	}
 
-	queue := new(ClusterQueue)
-
-	resp, err := cqs.client.Do(req, queue)
-
+	var queue ClusterQueue
+	resp, err := cqs.client.Do(req, &queue)
 	if err != nil {
-		return nil, resp, err
+		return ClusterQueue{}, resp, err
 	}
 
 	return queue, resp, err
 }
 
-func (cqs *ClusterQueuesService) Create(ctx context.Context, org, clusterID string, qc *ClusterQueueCreate) (*ClusterQueue, *Response, error) {
-
-	if qc == nil {
-		return nil, nil, errors.New("ClusterQueueCreate struct instance must not be nil")
-	}
-
+func (cqs *ClusterQueuesService) Create(ctx context.Context, org, clusterID string, qc ClusterQueueCreate) (ClusterQueue, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues", org, clusterID)
-
 	req, err := cqs.client.NewRequest(ctx, "POST", u, qc)
-
 	if err != nil {
-		return nil, nil, err
+		return ClusterQueue{}, nil, err
 	}
 
-	queue := new(ClusterQueue)
-
-	resp, err := cqs.client.Do(req, queue)
+	var queue ClusterQueue
+	resp, err := cqs.client.Do(req, &queue)
 
 	if err != nil {
-		return nil, resp, err
+		return ClusterQueue{}, resp, err
 	}
 
 	return queue, resp, err
 }
 
-func (cqs *ClusterQueuesService) Update(ctx context.Context, org, clusterID, queueID string, qu *ClusterQueueUpdate) (*Response, error) {
-
-	if qu == nil {
-		return nil, errors.New("ClusterQueueUpdate struct instance must not be nil")
-	}
-
+func (cqs *ClusterQueuesService) Update(ctx context.Context, org, clusterID, queueID string, qu ClusterQueueUpdate) (*Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s", org, clusterID, queueID)
-
 	req, err := cqs.client.NewRequest(ctx, "PATCH", u, qu)
-
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := cqs.client.Do(req, qu)
-
+	resp, err := cqs.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -144,11 +116,8 @@ func (cqs *ClusterQueuesService) Update(ctx context.Context, org, clusterID, que
 }
 
 func (cqs *ClusterQueuesService) Delete(ctx context.Context, org, clusterID, queueID string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s", org, clusterID, queueID)
-
 	req, err := cqs.client.NewRequest(ctx, "DELETE", u, nil)
-
 	if err != nil {
 		return nil, err
 	}
@@ -156,16 +125,9 @@ func (cqs *ClusterQueuesService) Delete(ctx context.Context, org, clusterID, que
 	return cqs.client.Do(req, nil)
 }
 
-func (cqs *ClusterQueuesService) Pause(ctx context.Context, org, clusterID, queueID string, qp *ClusterQueuePause) (*Response, error) {
-
-	if qp == nil {
-		return nil, errors.New("ClusterQueuePause struct instance must not be nil")
-	}
-
+func (cqs *ClusterQueuesService) Pause(ctx context.Context, org, clusterID, queueID string, qp ClusterQueuePause) (*Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s/pause_dispatch", org, clusterID, queueID)
-
 	req, err := cqs.client.NewRequest(ctx, "POST", u, qp)
-
 	if err != nil {
 		return nil, err
 	}
@@ -174,11 +136,8 @@ func (cqs *ClusterQueuesService) Pause(ctx context.Context, org, clusterID, queu
 }
 
 func (cqs *ClusterQueuesService) Resume(ctx context.Context, org, clusterID, queueID string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s/resume_dispatch", org, clusterID, queueID)
-
 	req, err := cqs.client.NewRequest(ctx, "POST", u, nil)
-
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/cluster_queues.go
+++ b/buildkite/cluster_queues.go
@@ -24,7 +24,7 @@ type ClusterQueue struct {
 	DispatchPaused     bool            `json:"dispatch_paused,omitempty"`
 	DispatchPausedBy   *ClusterCreator `json:"dispatch_paused_by,omitempty"`
 	DispatchPausedAt   *Timestamp      `json:"dispatch_paused_at,omitempty"`
-	DispatchPausedNote *string         `json:"dispatch_paused_note,omitempty"`
+	DispatchPausedNote string          `json:"dispatch_paused_note,omitempty"`
 	CreatedAt          *Timestamp      `json:"created_at,omitempty"`
 	CreatedBy          ClusterCreator  `json:"created_by,omitempty"`
 }
@@ -100,19 +100,20 @@ func (cqs *ClusterQueuesService) Create(ctx context.Context, org, clusterID stri
 	return queue, resp, err
 }
 
-func (cqs *ClusterQueuesService) Update(ctx context.Context, org, clusterID, queueID string, qu ClusterQueueUpdate) (*Response, error) {
+func (cqs *ClusterQueuesService) Update(ctx context.Context, org, clusterID, queueID string, qu ClusterQueueUpdate) (ClusterQueue, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s", org, clusterID, queueID)
 	req, err := cqs.client.NewRequest(ctx, "PATCH", u, qu)
 	if err != nil {
-		return nil, err
+		return ClusterQueue{}, nil, err
 	}
 
-	resp, err := cqs.client.Do(req, nil)
+	var cq ClusterQueue
+	resp, err := cqs.client.Do(req, &cq)
 	if err != nil {
-		return resp, err
+		return ClusterQueue{}, resp, err
 	}
 
-	return resp, err
+	return cq, resp, err
 }
 
 func (cqs *ClusterQueuesService) Delete(ctx context.Context, org, clusterID, queueID string) (*Response, error) {
@@ -125,14 +126,20 @@ func (cqs *ClusterQueuesService) Delete(ctx context.Context, org, clusterID, que
 	return cqs.client.Do(req, nil)
 }
 
-func (cqs *ClusterQueuesService) Pause(ctx context.Context, org, clusterID, queueID string, qp ClusterQueuePause) (*Response, error) {
+func (cqs *ClusterQueuesService) Pause(ctx context.Context, org, clusterID, queueID string, qp ClusterQueuePause) (ClusterQueue, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/queues/%s/pause_dispatch", org, clusterID, queueID)
 	req, err := cqs.client.NewRequest(ctx, "POST", u, qp)
 	if err != nil {
-		return nil, err
+		return ClusterQueue{}, nil, err
 	}
 
-	return cqs.client.Do(req, nil)
+	var cq ClusterQueue
+	resp, err := cqs.client.Do(req, &cq)
+	if err != nil {
+		return ClusterQueue{}, resp, err
+	}
+
+	return cq, resp, err
 }
 
 func (cqs *ClusterQueuesService) Resume(ctx context.Context, org, clusterID, queueID string) (*Response, error) {

--- a/buildkite/cluster_queues_test.go
+++ b/buildkite/cluster_queues_test.go
@@ -84,38 +84,38 @@ func TestClusterQueuesService_List(t *testing.T) {
 	devQueuePausedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-25T08:53:05.824Z"))
 	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
-	clusterCreator := &ClusterCreator{
-		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
-		GraphQLID: String("VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg=="),
-		Name:      String("Joe Smith"),
-		Email:     String("jsmith@example.com"),
-		AvatarURL: String("https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4"),
+	clusterCreator := ClusterCreator{
+		ID:        "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+		GraphQLID: "VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg==",
+		Name:      "Joe Smith",
+		Email:     "jsmith@example.com",
+		AvatarURL: "https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4",
 		CreatedAt: NewTimestamp(userCreatedAt),
 	}
 
 	want := []ClusterQueue{
 		{
-			ID:             String("da3b950b-5761-4940-900d-d9d88307c337"),
-			GraphQLID:      String("Q2x1c3RlclF1ZXVlLS0tZGEzYjk1MGItNTc2MS00OTQwLTkwMGQtZDlkODgzMDdjMzM3"),
-			Key:            String("default"),
-			Description:    String("Cluster's default queue"),
-			URL:            String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/da3b950b-5761-4940-900d-d9d88307c337"),
-			WebURL:         String("https://buildkite.com/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/da3b950b-5761-4940-900d-d9d88307c337"),
-			ClusterURL:     String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57"),
-			DispatchPaused: Bool(false),
+			ID:             "da3b950b-5761-4940-900d-d9d88307c337",
+			GraphQLID:      "Q2x1c3RlclF1ZXVlLS0tZGEzYjk1MGItNTc2MS00OTQwLTkwMGQtZDlkODgzMDdjMzM3",
+			Key:            "default",
+			Description:    "Cluster's default queue",
+			URL:            "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/da3b950b-5761-4940-900d-d9d88307c337",
+			WebURL:         "https://buildkite.com/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/da3b950b-5761-4940-900d-d9d88307c337",
+			ClusterURL:     "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57",
+			DispatchPaused: false,
 			CreatedAt:      NewTimestamp(defaultQueueCreatedAt),
 			CreatedBy:      clusterCreator,
 		},
 		{
-			ID:                 String("46718bb6-3b2a-48da-9dcb-922c6b7ba140"),
-			GraphQLID:          String("Q2x1c3RlclF1ZXVlLS0tNDY3MThiYjYtM2IyYS00OGRhLTlkY2ItOTIyYzZiN2JhMTQw"),
-			Key:                String("development"),
-			Description:        String("Development queue"),
-			URL:                String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140"),
-			WebURL:             String("https://buildkite.com/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140"),
-			ClusterURL:         String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57"),
-			DispatchPaused:     Bool(true),
-			DispatchPausedBy:   clusterCreator,
+			ID:                 "46718bb6-3b2a-48da-9dcb-922c6b7ba140",
+			GraphQLID:          "Q2x1c3RlclF1ZXVlLS0tNDY3MThiYjYtM2IyYS00OGRhLTlkY2ItOTIyYzZiN2JhMTQw",
+			Key:                "development",
+			Description:        "Development queue",
+			URL:                "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140",
+			WebURL:             "https://buildkite.com/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140",
+			ClusterURL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57",
+			DispatchPaused:     true,
+			DispatchPausedBy:   &clusterCreator,
 			DispatchPausedAt:   NewTimestamp(devQueuePausedAt),
 			DispatchPausedNote: String("Weekend queue pause"),
 			CreatedAt:          NewTimestamp(devQueueClusterCreatedAt),
@@ -179,25 +179,25 @@ func TestClusterQueuesService_Get(t *testing.T) {
 	devQueuePausedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-25T08:53:05.824Z"))
 	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
-	clusterCreator := &ClusterCreator{
-		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
-		GraphQLID: String("VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg=="),
-		Name:      String("Joe Smith"),
-		Email:     String("jsmith@example.com"),
-		AvatarURL: String("https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4"),
+	clusterCreator := ClusterCreator{
+		ID:        "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+		GraphQLID: "VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg==",
+		Name:      "Joe Smith",
+		Email:     "jsmith@example.com",
+		AvatarURL: "https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4",
 		CreatedAt: NewTimestamp(userCreatedAt),
 	}
 
-	want := &ClusterQueue{
-		ID:                 String("46718bb6-3b2a-48da-9dcb-922c6b7ba140"),
-		GraphQLID:          String("Q2x1c3RlclF1ZXVlLS0tNDY3MThiYjYtM2IyYS00OGRhLTlkY2ItOTIyYzZiN2JhMTQw"),
-		Key:                String("development"),
-		Description:        String("Development queue"),
-		URL:                String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140"),
-		WebURL:             String("https://buildkite.com/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140"),
-		ClusterURL:         String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57"),
-		DispatchPaused:     Bool(true),
-		DispatchPausedBy:   clusterCreator,
+	want := ClusterQueue{
+		ID:                 "46718bb6-3b2a-48da-9dcb-922c6b7ba140",
+		GraphQLID:          "Q2x1c3RlclF1ZXVlLS0tNDY3MThiYjYtM2IyYS00OGRhLTlkY2ItOTIyYzZiN2JhMTQw",
+		Key:                "development",
+		Description:        "Development queue",
+		URL:                "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140",
+		WebURL:             "https://buildkite.com/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/46718bb6-3b2a-48da-9dcb-922c6b7ba140",
+		ClusterURL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57",
+		DispatchPaused:     true,
+		DispatchPausedBy:   &clusterCreator,
 		DispatchPausedAt:   NewTimestamp(devQueuePausedAt),
 		DispatchPausedNote: String("Weekend queue pause"),
 		CreatedAt:          NewTimestamp(devQueueClusterCreatedAt),
@@ -215,13 +215,13 @@ func TestClusterQueuesService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &ClusterQueueCreate{
-		Key:         String("development1"),
-		Description: String("Development 1 queue"),
+	input := ClusterQueueCreate{
+		Key:         "development1",
+		Description: "Development 1 queue",
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterQueueCreate)
+		var v ClusterQueueCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -244,9 +244,9 @@ func TestClusterQueuesService_Create(t *testing.T) {
 		t.Errorf("TestClusterQueues.Create returned error: %v", err)
 	}
 
-	want := &ClusterQueue{
-		Key:         String("development1"),
-		Description: String("Development 1 queue"),
+	want := ClusterQueue{
+		Key:         "development1",
+		Description: "Development 1 queue",
 	}
 
 	if diff := cmp.Diff(queue, want); diff != "" {
@@ -260,13 +260,13 @@ func TestClusterQueuesService_Update(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &ClusterQueueCreate{
-		Key:         String("development1"),
-		Description: String("Development 1 queue"),
+	input := ClusterQueueCreate{
+		Key:         "development1",
+		Description: "Development 1 queue",
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterQueueCreate)
+		var v ClusterQueueCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -291,10 +291,10 @@ func TestClusterQueuesService_Update(t *testing.T) {
 	}
 
 	// Lets update the description of the cluster queue
-	queue.Description = String("Development 1 Team queue")
+	queue.Description = "Development 1 Team queue"
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterQueueUpdate)
+		var v ClusterQueueUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "PATCH")
@@ -309,19 +309,19 @@ func TestClusterQueuesService_Update(t *testing.T) {
 	})
 
 	queueUpdate := ClusterQueueUpdate{
-		Description: String("Development 1 Team queue"),
+		Description: "Development 1 Team queue",
 	}
 
-	_, err = client.ClusterQueues.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "1374ffd0-c5ed-49a5-aebe-67ce906e68ca", &queueUpdate)
+	_, err = client.ClusterQueues.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "1374ffd0-c5ed-49a5-aebe-67ce906e68ca", queueUpdate)
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Update returned error: %v", err)
 	}
 
-	want := &ClusterQueue{
-		ID:          String("1374ffd0-c5ed-49a5-aebe-67ce906e68ca"),
-		Key:         String("development1"),
-		Description: String("Development 1 Team queue"),
+	want := ClusterQueue{
+		ID:          "1374ffd0-c5ed-49a5-aebe-67ce906e68ca",
+		Key:         "development1",
+		Description: "Development 1 Team queue",
 	}
 
 	if diff := cmp.Diff(queue, want); diff != "" {
@@ -352,13 +352,13 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &ClusterQueueCreate{
-		Key:         String("development1"),
-		Description: String("Development 1 Team queue"),
+	input := ClusterQueueCreate{
+		Key:         "development1",
+		Description: "Development 1 Team queue",
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterQueueCreate)
+		var v ClusterQueueCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -402,19 +402,19 @@ func TestClusterQueuesService_Pause(t *testing.T) {
 	})
 
 	queuePause := ClusterQueuePause{
-		Note: String("Pausing dispatch for the weekend"),
+		Note: "Pausing dispatch for the weekend",
 	}
 
-	_, err = client.ClusterQueues.Pause(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "5cadac07-51dd-4e12-bea3-d91be4655c2f", &queuePause)
+	_, err = client.ClusterQueues.Pause(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "5cadac07-51dd-4e12-bea3-d91be4655c2f", queuePause)
 
 	if err != nil {
 		t.Errorf("TestClusterQueues.Pause returned error: %v", err)
 	}
 
-	want := &ClusterQueue{
-		ID:                 String("5cadac07-51dd-4e12-bea3-d91be4655c2f"),
-		Key:                String("development1"),
-		Description:        String("Development 1 Team queue"),
+	want := ClusterQueue{
+		ID:                 "5cadac07-51dd-4e12-bea3-d91be4655c2f",
+		Key:                "development1",
+		Description:        "Development 1 Team queue",
 		DispatchPausedNote: String("Pausing dispatch for the weekend"),
 	}
 

--- a/buildkite/cluster_tokens.go
+++ b/buildkite/cluster_tokens.go
@@ -87,19 +87,20 @@ func (cts *ClusterTokensService) Create(ctx context.Context, org, clusterID stri
 	return token, resp, err
 }
 
-func (cts *ClusterTokensService) Update(ctx context.Context, org, clusterID, tokenID string, ctc ClusterTokenCreateUpdate) (*Response, error) {
+func (cts *ClusterTokensService) Update(ctx context.Context, org, clusterID, tokenID string, ctc ClusterTokenCreateUpdate) (ClusterToken, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens/%s", org, clusterID, tokenID)
 	req, err := cts.client.NewRequest(ctx, "PATCH", u, ctc)
 	if err != nil {
-		return nil, err
+		return ClusterToken{}, nil, err
 	}
 
-	resp, err := cts.client.Do(req, nil)
+	var ct ClusterToken
+	resp, err := cts.client.Do(req, &ct)
 	if err != nil {
-		return resp, err
+		return ClusterToken{}, resp, err
 	}
 
-	return resp, err
+	return ct, resp, err
 }
 
 func (cts *ClusterTokensService) Delete(ctx context.Context, org, clusterID, tokenID string) (*Response, error) {

--- a/buildkite/cluster_tokens.go
+++ b/buildkite/cluster_tokens.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -15,20 +14,20 @@ type ClusterTokensService struct {
 }
 
 type ClusterToken struct {
-	ID                 *string         `json:"id,omitempty"`
-	GraphQLID          *string         `json:"graphql_id,omitempty"`
-	Description        *string         `json:"description,omitempty"`
-	AllowedIPAddresses *string         `json:"allowed_ip_addresses,omitempty"`
-	URL                *string         `json:"url,omitempty"`
-	ClusterURL         *string         `json:"cluster_url,omitempty"`
-	CreatedAt          *Timestamp      `json:"created_at,omitempty"`
-	CreatedBy          *ClusterCreator `json:"created_by,omitempty"`
-	Token              *string         `json:"token,omitempty"`
+	ID                 string         `json:"id,omitempty"`
+	GraphQLID          string         `json:"graphql_id,omitempty"`
+	Description        string         `json:"description,omitempty"`
+	AllowedIPAddresses string         `json:"allowed_ip_addresses,omitempty"`
+	URL                string         `json:"url,omitempty"`
+	ClusterURL         string         `json:"cluster_url,omitempty"`
+	CreatedAt          *Timestamp     `json:"created_at,omitempty"`
+	CreatedBy          ClusterCreator `json:"created_by,omitempty"`
+	Token              string         `json:"token,omitempty"`
 }
 
 type ClusterTokenCreateUpdate struct {
-	Description        *string `json:"description,omitempty"`
-	AllowedIPAddresses *string `json:"allowed_ip_addresses,omitempty"`
+	Description        string `json:"description,omitempty"`
+	AllowedIPAddresses string `json:"allowed_ip_addresses,omitempty"`
 }
 
 type ClusterTokensListOptions struct {
@@ -36,94 +35,66 @@ type ClusterTokensListOptions struct {
 }
 
 func (cts *ClusterTokensService) List(ctx context.Context, org, clusterID string, opt *ClusterTokensListOptions) ([]ClusterToken, *Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens", org, clusterID)
-
 	u, err := addOptions(u, opt)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req, err := cts.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	tokens := new([]ClusterToken)
-
-	resp, err := cts.client.Do(req, tokens)
-
+	var tokens []ClusterToken
+	resp, err := cts.client.Do(req, &tokens)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *tokens, resp, err
+	return tokens, resp, err
 }
 
-func (cts *ClusterTokensService) Get(ctx context.Context, org, clusterID, tokenID string) (*ClusterToken, *Response, error) {
-
+func (cts *ClusterTokensService) Get(ctx context.Context, org, clusterID, tokenID string) (ClusterToken, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens/%s", org, clusterID, tokenID)
-
 	req, err := cts.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
-		return nil, nil, err
+		return ClusterToken{}, nil, err
 	}
 
-	token := new(ClusterToken)
-
-	resp, err := cts.client.Do(req, token)
-
+	var token ClusterToken
+	resp, err := cts.client.Do(req, &token)
 	if err != nil {
-		return nil, resp, err
+		return ClusterToken{}, resp, err
 	}
 
 	return token, resp, err
 }
 
-func (cts *ClusterTokensService) Create(ctx context.Context, org, clusterID string, ctc *ClusterTokenCreateUpdate) (*ClusterToken, *Response, error) {
-
-	if ctc == nil {
-		return nil, nil, errors.New("ClusterTokenCreateUpdate struct instance must not be nil")
-	}
-
+func (cts *ClusterTokensService) Create(ctx context.Context, org, clusterID string, ctc ClusterTokenCreateUpdate) (ClusterToken, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens", org, clusterID)
-
 	req, err := cts.client.NewRequest(ctx, "POST", u, ctc)
-
 	if err != nil {
-		return nil, nil, err
+		return ClusterToken{}, nil, err
 	}
 
-	token := new(ClusterToken)
-
-	resp, err := cts.client.Do(req, token)
-
+	var token ClusterToken
+	resp, err := cts.client.Do(req, &token)
 	if err != nil {
-		return nil, resp, err
+		return ClusterToken{}, resp, err
 	}
 
 	return token, resp, err
 }
 
-func (cts *ClusterTokensService) Update(ctx context.Context, org, clusterID, tokenID string, ctc *ClusterTokenCreateUpdate) (*Response, error) {
-
-	if ctc == nil {
-		return nil, errors.New("ClusterTokenCreateUpdate struct instance must not be nil")
-	}
-
+func (cts *ClusterTokensService) Update(ctx context.Context, org, clusterID, tokenID string, ctc ClusterTokenCreateUpdate) (*Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens/%s", org, clusterID, tokenID)
-
 	req, err := cts.client.NewRequest(ctx, "PATCH", u, ctc)
-
 	if err != nil {
 		return nil, err
 	}
 
-	resp, err := cts.client.Do(req, ctc)
-
+	resp, err := cts.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -132,11 +103,8 @@ func (cts *ClusterTokensService) Update(ctx context.Context, org, clusterID, tok
 }
 
 func (cts *ClusterTokensService) Delete(ctx context.Context, org, clusterID, tokenID string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens/%s", org, clusterID, tokenID)
-
 	req, err := cts.client.NewRequest(ctx, "DELETE", u, nil)
-
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -68,32 +68,32 @@ func TestClusterTokensService_List(t *testing.T) {
 	testTokenCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-06-07T08:05:00.755Z"))
 	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
-	clusterCreator := &ClusterCreator{
-		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
-		GraphQLID: String("VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg=="),
-		Name:      String("Joe Smith"),
-		Email:     String("jsmith@example.com"),
-		AvatarURL: String("https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4"),
+	clusterCreator := ClusterCreator{
+		ID:        "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+		GraphQLID: "VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg==",
+		Name:      "Joe Smith",
+		Email:     "jsmith@example.com",
+		AvatarURL: "https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4",
 		CreatedAt: NewTimestamp(userCreatedAt),
 	}
 
 	want := []ClusterToken{
 		{
-			ID:                 String("38e8fdb0-52bf-4e73-ad82-ce93cfbaa724"),
-			GraphQLID:          String("Q2x1c3RlclRva2VuLS0tMzhlOGZkYjAtNTJiZi00ZTczLWFkODItY2U5M2NmYmFhNzI0"),
-			Description:        String("Development cluster token"),
-			URL:                String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724"),
-			ClusterURL:         String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57"),
+			ID:                 "38e8fdb0-52bf-4e73-ad82-ce93cfbaa724",
+			GraphQLID:          "Q2x1c3RlclRva2VuLS0tMzhlOGZkYjAtNTJiZi00ZTczLWFkODItY2U5M2NmYmFhNzI0",
+			Description:        "Development cluster token",
+			URL:                "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724",
+			ClusterURL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57",
 			CreatedAt:          NewTimestamp(developmentTokenCreatedAt),
 			CreatedBy:          clusterCreator,
-			AllowedIPAddresses: String("99.26.83.126/24 220.189.137.145/32"),
+			AllowedIPAddresses: "99.26.83.126/24 220.189.137.145/32",
 		},
 		{
-			ID:          String("218baae1-3e70-44f4-9d52-2e578536693e"),
-			GraphQLID:   String("Q2x1c3RlclRva2VuLS0tMjE4YmFhZTEtM2U3MC00NGY0LTlkNTItMmU1Nzg1MzY2OTNl"),
-			Description: String("Test cluster token"),
-			URL:         String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/218baae1-3e70-44f4-9d52-2e578536693e"),
-			ClusterURL:  String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57"),
+			ID:          "218baae1-3e70-44f4-9d52-2e578536693e",
+			GraphQLID:   "Q2x1c3RlclRva2VuLS0tMjE4YmFhZTEtM2U3MC00NGY0LTlkNTItMmU1Nzg1MzY2OTNl",
+			Description: "Test cluster token",
+			URL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/218baae1-3e70-44f4-9d52-2e578536693e",
+			ClusterURL:  "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57",
 			CreatedAt:   NewTimestamp(testTokenCreatedAt),
 			CreatedBy:   clusterCreator,
 		},
@@ -134,7 +134,6 @@ func TestClusterTokensService_Get(t *testing.T) {
 	})
 
 	token, _, err := client.ClusterTokens.Get(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "38e8fdb0-52bf-4e73-ad82-ce93cfbaa724")
-
 	if err != nil {
 		t.Errorf("TestClusterTokens.Get returned error: %v", err)
 	}
@@ -142,24 +141,24 @@ func TestClusterTokensService_Get(t *testing.T) {
 	developmentTokenCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-06-07T08:01:02.951Z"))
 	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
-	clusterCreator := &ClusterCreator{
-		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
-		GraphQLID: String("VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg=="),
-		Name:      String("Joe Smith"),
-		Email:     String("jsmith@example.com"),
-		AvatarURL: String("https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4"),
+	clusterCreator := ClusterCreator{
+		ID:        "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+		GraphQLID: "VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg==",
+		Name:      "Joe Smith",
+		Email:     "jsmith@example.com",
+		AvatarURL: "https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4",
 		CreatedAt: NewTimestamp(userCreatedAt),
 	}
 
-	want := &ClusterToken{
-		ID:                 String("38e8fdb0-52bf-4e73-ad82-ce93cfbaa724"),
-		GraphQLID:          String("Q2x1c3RlclRva2VuLS0tMzhlOGZkYjAtNTJiZi00ZTczLWFkODItY2U5M2NmYmFhNzI0"),
-		Description:        String("Development cluster token"),
-		URL:                String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724"),
-		ClusterURL:         String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57"),
+	want := ClusterToken{
+		ID:                 "38e8fdb0-52bf-4e73-ad82-ce93cfbaa724",
+		GraphQLID:          "Q2x1c3RlclRva2VuLS0tMzhlOGZkYjAtNTJiZi00ZTczLWFkODItY2U5M2NmYmFhNzI0",
+		Description:        "Development cluster token",
+		URL:                "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/38e8fdb0-52bf-4e73-ad82-ce93cfbaa724",
+		ClusterURL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57",
 		CreatedAt:          NewTimestamp(developmentTokenCreatedAt),
 		CreatedBy:          clusterCreator,
-		AllowedIPAddresses: String("99.26.83.126/24 220.189.137.145/32"),
+		AllowedIPAddresses: "99.26.83.126/24 220.189.137.145/32",
 	}
 
 	if diff := cmp.Diff(token, want); diff != "" {
@@ -173,12 +172,10 @@ func TestClusterTokensService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &ClusterTokenCreateUpdate{
-		Description: String("Development 2 cluster token"),
-	}
+	input := ClusterTokenCreateUpdate{Description: "Development 2 cluster token"}
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterTokenCreateUpdate)
+		var v ClusterTokenCreateUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -200,10 +197,7 @@ func TestClusterTokensService_Create(t *testing.T) {
 		t.Errorf("TestClusterTokens.Create returned error: %v", err)
 	}
 
-	want := &ClusterToken{
-		Description: String("Development 2 cluster token"),
-	}
-
+	want := ClusterToken{Description: "Development 2 cluster token"}
 	if diff := cmp.Diff(token, want); diff != "" {
 		t.Errorf("TestClusterTokens.Create diff: (-got +want)\n%s", diff)
 	}
@@ -215,12 +209,10 @@ func TestClusterTokensService_Update(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &ClusterTokenCreateUpdate{
-		Description: String("Development 1 Fleet Token"),
-	}
+	input := ClusterTokenCreateUpdate{Description: "Development 1 Fleet Token"}
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterTokenCreateUpdate)
+		var v ClusterTokenCreateUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -238,16 +230,15 @@ func TestClusterTokensService_Update(t *testing.T) {
 	})
 
 	token, _, err := client.ClusterTokens.Create(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
-
 	if err != nil {
 		t.Errorf("TestClusterTokens.Update returned error: %v", err)
 	}
 
 	// Lets update the description of the cluster token
-	token.Description = String("Development 1 agent token")
+	token.Description = "Development 1 agent token"
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterTokenCreateUpdate)
+		var v ClusterTokenCreateUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "PATCH")
@@ -260,19 +251,16 @@ func TestClusterTokensService_Update(t *testing.T) {
 			}`)
 	})
 
-	tokenUpdate := ClusterTokenCreateUpdate{
-		Description: String("Development 1 agent token"),
-	}
+	tokenUpdate := ClusterTokenCreateUpdate{Description: "Development 1 agent token"}
 
-	_, err = client.ClusterTokens.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054", &tokenUpdate)
-
+	_, err = client.ClusterTokens.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054", tokenUpdate)
 	if err != nil {
 		t.Errorf("TestClusterTokens.Update returned error: %v", err)
 	}
 
-	want := &ClusterToken{
-		ID:          String("9cb33339-1c4a-4020-9aeb-3319b2e1f054"),
-		Description: String("Development 1 agent token"),
+	want := ClusterToken{
+		ID:          "9cb33339-1c4a-4020-9aeb-3319b2e1f054",
+		Description: "Development 1 agent token",
 	}
 
 	if diff := cmp.Diff(token, want); diff != "" {
@@ -291,7 +279,6 @@ func TestClusterTokensService_Delete(t *testing.T) {
 	})
 
 	_, err := client.ClusterTokens.Delete(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054")
-
 	if err != nil {
 		t.Errorf("TestClusterTokens.Delete returned error: %v", err)
 	}

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -209,34 +209,6 @@ func TestClusterTokensService_Update(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := ClusterTokenCreateUpdate{Description: "Development 1 Fleet Token"}
-
-	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
-		var v ClusterTokenCreateUpdate
-		json.NewDecoder(r.Body).Decode(&v)
-
-		testMethod(t, r, "POST")
-
-		if diff := cmp.Diff(v, input); diff != "" {
-			t.Errorf("Request body diff: (-got +want)\n%s", diff)
-		}
-
-		fmt.Fprint(w,
-			`
-			{
-				"id": "9cb33339-1c4a-4020-9aeb-3319b2e1f054",
-				"description": "Development 1 agent-fleet token"
-			}`)
-	})
-
-	token, _, err := client.ClusterTokens.Create(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", input)
-	if err != nil {
-		t.Errorf("TestClusterTokens.Update returned error: %v", err)
-	}
-
-	// Lets update the description of the cluster token
-	token.Description = "Development 1 agent token"
-
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
 		var v ClusterTokenCreateUpdate
 		json.NewDecoder(r.Body).Decode(&v)
@@ -253,7 +225,7 @@ func TestClusterTokensService_Update(t *testing.T) {
 
 	tokenUpdate := ClusterTokenCreateUpdate{Description: "Development 1 agent token"}
 
-	_, err = client.ClusterTokens.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054", tokenUpdate)
+	got, _, err := client.ClusterTokens.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054", tokenUpdate)
 	if err != nil {
 		t.Errorf("TestClusterTokens.Update returned error: %v", err)
 	}
@@ -263,7 +235,7 @@ func TestClusterTokensService_Update(t *testing.T) {
 		Description: "Development 1 agent token",
 	}
 
-	if diff := cmp.Diff(token, want); diff != "" {
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("TestClusterTokens.Update diff: (-got +want)\n%s", diff)
 	}
 }

--- a/buildkite/clusters.go
+++ b/buildkite/clusters.go
@@ -109,19 +109,20 @@ func (cs *ClustersService) Create(ctx context.Context, org string, cc ClusterCre
 	return cluster, resp, err
 }
 
-func (cs *ClustersService) Update(ctx context.Context, org, id string, cu ClusterUpdate) (*Response, error) {
+func (cs *ClustersService) Update(ctx context.Context, org, id string, cu ClusterUpdate) (Cluster, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s", org, id)
 	req, err := cs.client.NewRequest(ctx, "PATCH", u, cu)
 	if err != nil {
-		return nil, nil
+		return Cluster{}, nil, nil
 	}
 
-	resp, err := cs.client.Do(req, nil)
+	var cluster Cluster
+	resp, err := cs.client.Do(req, &cluster)
 	if err != nil {
-		return resp, err
+		return Cluster{}, resp, err
 	}
 
-	return resp, err
+	return cluster, resp, err
 }
 
 func (cs *ClustersService) Delete(ctx context.Context, org, id string) (*Response, error) {

--- a/buildkite/clusters.go
+++ b/buildkite/clusters.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -15,138 +14,109 @@ type ClustersService struct {
 }
 
 type ClusterCreate struct {
-	Name        string  `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Emoji       *string `json:"emoji,omitempty"`
-	Color       *string `json:"color,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Emoji       string `json:"emoji,omitempty"`
+	Color       string `json:"color,omitempty"`
 }
 
 type ClusterUpdate struct {
-	Name           *string `json:"name,omitempty"`
-	Description    *string `json:"description,omitempty"`
-	Emoji          *string `json:"emoji,omitempty"`
-	Color          *string `json:"color,omitempty"`
-	DefaultQueueID *string `json:"default_queue_id,omitempty"`
+	Name           string `json:"name,omitempty"`
+	Description    string `json:"description,omitempty"`
+	Emoji          string `json:"emoji,omitempty"`
+	Color          string `json:"color,omitempty"`
+	DefaultQueueID string `json:"default_queue_id,omitempty"`
 }
 
 type Cluster struct {
-	ID              *string         `json:"id,omitempty"`
-	GraphQLID       *string         `json:"graphql_id,omitempty"`
-	DefaultQueueID  *string         `json:"default_queue_id,omitempty"`
-	Name            *string         `json:"name,omitempty"`
-	Description     *string         `json:"description,omitempty"`
-	Emoji           *string         `json:"emoji,omitempty"`
-	Color           *string         `json:"color,omitempty"`
-	URL             *string         `json:"url,omitempty"`
-	WebURL          *string         `json:"web_url,omitempty"`
-	QueuesURL       *string         `json:"queues_url,omitempty"`
-	DefaultQueueURL *string         `json:"default_queue_url,omitempty"`
-	CreatedAt       *Timestamp      `json:"created_at,omitempty"`
-	CreatedBy       *ClusterCreator `json:"created_by,omitempty"`
+	ID              string         `json:"id,omitempty"`
+	GraphQLID       string         `json:"graphql_id,omitempty"`
+	DefaultQueueID  string         `json:"default_queue_id,omitempty"`
+	Name            string         `json:"name,omitempty"`
+	Description     string         `json:"description,omitempty"`
+	Emoji           string         `json:"emoji,omitempty"`
+	Color           string         `json:"color,omitempty"`
+	URL             string         `json:"url,omitempty"`
+	WebURL          string         `json:"web_url,omitempty"`
+	QueuesURL       string         `json:"queues_url,omitempty"`
+	DefaultQueueURL string         `json:"default_queue_url,omitempty"`
+	CreatedAt       *Timestamp     `json:"created_at,omitempty"`
+	CreatedBy       ClusterCreator `json:"created_by,omitempty"`
 }
 
 type ClusterCreator struct {
-	ID        *string    `json:"id,omitempty"`
-	GraphQLID *string    `json:"graphql_id,omitempty"`
-	Name      *string    `json:"name,omitempty"`
-	Email     *string    `json:"email,omitempty"`
-	AvatarURL *string    `json:"avatar_url,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	GraphQLID string     `json:"graphql_id,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	Email     string     `json:"email,omitempty"`
+	AvatarURL string     `json:"avatar_url,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
-type ClustersListOptions struct {
-	ListOptions
-}
+type ClustersListOptions struct{ ListOptions }
 
 func (cs *ClustersService) List(ctx context.Context, org string, opt *ClustersListOptions) ([]Cluster, *Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/clusters", org)
-
 	u, err := addOptions(u, opt)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req, err := cs.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	clusters := new([]Cluster)
-
-	resp, err := cs.client.Do(req, clusters)
-
+	var clusters []Cluster
+	resp, err := cs.client.Do(req, &clusters)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *clusters, resp, err
+	return clusters, resp, err
 }
 
-func (cs *ClustersService) Get(ctx context.Context, org, id string) (*Cluster, *Response, error) {
-
+func (cs *ClustersService) Get(ctx context.Context, org, id string) (Cluster, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s", org, id)
-
 	req, err := cs.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
-		return nil, nil, err
+		return Cluster{}, nil, err
 	}
 
-	cluster := new(Cluster)
-
-	resp, err := cs.client.Do(req, cluster)
+	var cluster Cluster
+	resp, err := cs.client.Do(req, &cluster)
 
 	if err != nil {
-		return nil, resp, err
+		return Cluster{}, resp, err
 	}
 
 	return cluster, resp, err
 }
 
-func (cs *ClustersService) Create(ctx context.Context, org string, cc *ClusterCreate) (*Cluster, *Response, error) {
-
-	if cc == nil {
-		return nil, nil, errors.New("ClusterCreate struct instance must not be nil")
-	}
-
+func (cs *ClustersService) Create(ctx context.Context, org string, cc ClusterCreate) (Cluster, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters", org)
-
 	req, err := cs.client.NewRequest(ctx, "POST", u, cc)
-
 	if err != nil {
-		return nil, nil, err
+		return Cluster{}, nil, err
 	}
 
-	cluster := new(Cluster)
-
-	resp, err := cs.client.Do(req, cluster)
-
+	var cluster Cluster
+	resp, err := cs.client.Do(req, &cluster)
 	if err != nil {
-		return nil, resp, err
+		return Cluster{}, resp, err
 	}
 
 	return cluster, resp, err
 }
 
-func (cs *ClustersService) Update(ctx context.Context, org, id string, cu *ClusterUpdate) (*Response, error) {
-
-	if cu == nil {
-		return nil, errors.New("ClusterUpdate struct instance must not be nil")
-	}
-
+func (cs *ClustersService) Update(ctx context.Context, org, id string, cu ClusterUpdate) (*Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s", org, id)
-
 	req, err := cs.client.NewRequest(ctx, "PATCH", u, cu)
-
 	if err != nil {
 		return nil, nil
 	}
 
-	resp, err := cs.client.Do(req, cu)
-
+	resp, err := cs.client.Do(req, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -155,11 +125,8 @@ func (cs *ClustersService) Update(ctx context.Context, org, id string, cu *Clust
 }
 
 func (cs *ClustersService) Delete(ctx context.Context, org, id string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s", org, id)
-
 	req, err := cs.client.NewRequest(ctx, "DELETE", u, nil)
-
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -243,43 +243,11 @@ func TestClustersService_Update(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := ClusterCreate{
-		Name:        "Testing Cluster",
-		Description: "A cluster for testing",
-		Emoji:       ":construction:",
-		Color:       "E5F185",
-	}
+	orgSlug := "my-great-org"
+	clusterID := "a32cbe81-82b2-45f7-bd97-66f1ac2c0cc1"
 
-	server.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
-		var v ClusterCreate
-		json.NewDecoder(r.Body).Decode(&v)
-
-		testMethod(t, r, "POST")
-
-		if diff := cmp.Diff(v, input); diff != "" {
-			t.Errorf("$3 diff: (-got +want)\n%s", diff)
-		}
-
-		fmt.Fprint(w,
-			`
-			{
-				"id": "a32cbe81-82b2-45f7-bd97-66f1ac2c0cc1",
-				"name" : "Testing Cluster",
-				"description": "A cluster for testing",
-				"emoji": ":construction:",
-				"color": "E5F185"
-			}`)
-	})
-
-	cluster, _, err := client.Clusters.Create(context.Background(), "my-great-org", input)
-	if err != nil {
-		t.Errorf("TestClusters.Create returned error: %v", err)
-	}
-
-	// Lets update the description of the cluster
-	cluster.Description = "A test cluster"
-
-	server.HandleFunc("/v2/organizations/my-great-org/clusters/a32cbe81-82b2-45f7-bd97-66f1ac2c0cc1", func(w http.ResponseWriter, r *http.Request) {
+	clustersPutEndpoint := fmt.Sprintf("/v2/organizations/%s/clusters/%s", orgSlug, clusterID)
+	server.HandleFunc(clustersPutEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		var v ClusterUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
@@ -297,7 +265,7 @@ func TestClustersService_Update(t *testing.T) {
 	})
 
 	clusterUpdate := ClusterUpdate{Description: "A test cluster"}
-	_, err = client.Clusters.Update(context.Background(), "my-great-org", cluster.ID, clusterUpdate)
+	cluster, _, err := client.Clusters.Update(context.Background(), orgSlug, clusterID, clusterUpdate)
 	if err != nil {
 		t.Errorf("TestClusters.Update returned error: %v", err)
 	}

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -75,39 +75,39 @@ func TestClustersService_List(t *testing.T) {
 	prodClusterCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-09-04T04:25:55.751Z"))
 	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
-	clusterCreator := &ClusterCreator{
-		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
-		GraphQLID: String("VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg=="),
-		Name:      String("Joe Smith"),
-		Email:     String("jsmith@example.com"),
-		AvatarURL: String("https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4"),
+	clusterCreator := ClusterCreator{
+		ID:        "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+		GraphQLID: "VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg==",
+		Name:      "Joe Smith",
+		Email:     "jsmith@example.com",
+		AvatarURL: "https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4",
 		CreatedAt: NewTimestamp(userCreatedAt),
 	}
 
 	want := []Cluster{
 		{
-			ID:          String("528000d8-4ee1-4479-8af1-032b143185f0"),
-			GraphQLID:   String("Q2x1c3Rlci0tLTUyODAwMGQ4LTRlZTEtNDQ3OS04YWYxLTAzMmIxNDMxODVmMA=="),
-			Name:        String("Development Cluster"),
-			Description: String("A cluster for development pipelines"),
-			Emoji:       String(":toolbox:"),
-			Color:       String("#A9CCE3"),
-			URL:         String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0"),
-			WebURL:      String("https://buildkite.com/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0"),
-			QueuesURL:   String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0/queues"),
+			ID:          "528000d8-4ee1-4479-8af1-032b143185f0",
+			GraphQLID:   "Q2x1c3Rlci0tLTUyODAwMGQ4LTRlZTEtNDQ3OS04YWYxLTAzMmIxNDMxODVmMA==",
+			Name:        "Development Cluster",
+			Description: "A cluster for development pipelines",
+			Emoji:       ":toolbox:",
+			Color:       "#A9CCE3",
+			URL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
+			WebURL:      "https://buildkite.com/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
+			QueuesURL:   "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0/queues",
 			CreatedAt:   NewTimestamp(devClusterCreatedAt),
 			CreatedBy:   clusterCreator,
 		},
 		{
-			ID:          String("3edcecdb-5191-44f1-a5ae-370083c8f92e"),
-			GraphQLID:   String("Q2x1c3Rlci0tLTNlZGNlY2RiLTUxOTEtNDRmMS1hNWFlLTM3MDA4M2M4ZjkyZQ=="),
-			Name:        String("Production Cluster"),
-			Description: String("A cluster for production pipelines"),
-			Emoji:       String(":toolbox:"),
-			Color:       String("#B9E3A9"),
-			URL:         String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e"),
-			WebURL:      String("https://buildkite.com/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e"),
-			QueuesURL:   String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e/queues"),
+			ID:          "3edcecdb-5191-44f1-a5ae-370083c8f92e",
+			GraphQLID:   "Q2x1c3Rlci0tLTNlZGNlY2RiLTUxOTEtNDRmMS1hNWFlLTM3MDA4M2M4ZjkyZQ==",
+			Name:        "Production Cluster",
+			Description: "A cluster for production pipelines",
+			Emoji:       ":toolbox:",
+			Color:       "#B9E3A9",
+			URL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e",
+			WebURL:      "https://buildkite.com/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e",
+			QueuesURL:   "https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e/queues",
 			CreatedAt:   NewTimestamp(prodClusterCreatedAt),
 			CreatedBy:   clusterCreator,
 		},
@@ -159,25 +159,25 @@ func TestClustersService_Get(t *testing.T) {
 	devClusterCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-09-01T04:27:11.392Z"))
 	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
-	clusterCreator := &ClusterCreator{
-		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
-		GraphQLID: String("VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg=="),
-		Name:      String("Joe Smith"),
-		Email:     String("jsmith@example.com"),
-		AvatarURL: String("https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4"),
+	clusterCreator := ClusterCreator{
+		ID:        "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+		GraphQLID: "VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg==",
+		Name:      "Joe Smith",
+		Email:     "jsmith@example.com",
+		AvatarURL: "https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4",
 		CreatedAt: NewTimestamp(userCreatedAt),
 	}
 
-	want := &Cluster{
-		ID:          String("528000d8-4ee1-4479-8af1-032b143185f0"),
-		GraphQLID:   String("Q2x1c3Rlci0tLTUyODAwMGQ4LTRlZTEtNDQ3OS04YWYxLTAzMmIxNDMxODVmMA=="),
-		Name:        String("Development Cluster"),
-		Description: String("A cluster for development pipelines"),
-		Emoji:       String(":toolbox:"),
-		Color:       String("#A9CCE3"),
-		URL:         String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0"),
-		WebURL:      String("https://buildkite.com/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0"),
-		QueuesURL:   String("https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0/queues"),
+	want := Cluster{
+		ID:          "528000d8-4ee1-4479-8af1-032b143185f0",
+		GraphQLID:   "Q2x1c3Rlci0tLTUyODAwMGQ4LTRlZTEtNDQ3OS04YWYxLTAzMmIxNDMxODVmMA==",
+		Name:        "Development Cluster",
+		Description: "A cluster for development pipelines",
+		Emoji:       ":toolbox:",
+		Color:       "#A9CCE3",
+		URL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
+		WebURL:      "https://buildkite.com/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
+		QueuesURL:   "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0/queues",
 		CreatedAt:   NewTimestamp(devClusterCreatedAt),
 		CreatedBy:   clusterCreator,
 	}
@@ -193,21 +193,21 @@ func TestClustersService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &ClusterCreate{
+	input := ClusterCreate{
 		Name:        "Testing Cluster",
-		Description: String("A cluster for testing"),
-		Emoji:       String(":construction:"),
-		Color:       String("E5F185"),
+		Description: "A cluster for testing",
+		Emoji:       ":construction:",
+		Color:       "E5F185",
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterCreate)
+		var v ClusterCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
 
 		if diff := cmp.Diff(v, input); diff != "" {
-			t.Errorf("Request body diff: (-got +want)\n%s", diff)
+			t.Errorf("$3 diff: (-got +want)\n%s", diff)
 		}
 
 		fmt.Fprint(w,
@@ -221,16 +221,15 @@ func TestClustersService_Create(t *testing.T) {
 	})
 
 	cluster, _, err := client.Clusters.Create(context.Background(), "my-great-org", input)
-
 	if err != nil {
 		t.Errorf("TestClusters.Create returned error: %v", err)
 	}
 
-	want := &Cluster{
-		Name:        String("Testing Cluster"),
-		Description: String("A cluster for testing"),
-		Emoji:       String(":construction:"),
-		Color:       String("E5F185"),
+	want := Cluster{
+		Name:        "Testing Cluster",
+		Description: "A cluster for testing",
+		Emoji:       ":construction:",
+		Color:       "E5F185",
 	}
 
 	if diff := cmp.Diff(cluster, want); diff != "" {
@@ -244,21 +243,21 @@ func TestClustersService_Update(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &ClusterCreate{
+	input := ClusterCreate{
 		Name:        "Testing Cluster",
-		Description: String("A cluster for testing"),
-		Emoji:       String(":construction:"),
-		Color:       String("E5F185"),
+		Description: "A cluster for testing",
+		Emoji:       ":construction:",
+		Color:       "E5F185",
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterCreate)
+		var v ClusterCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
 
 		if diff := cmp.Diff(v, input); diff != "" {
-			t.Errorf("Request body diff: (-got +want)\n%s", diff)
+			t.Errorf("$3 diff: (-got +want)\n%s", diff)
 		}
 
 		fmt.Fprint(w,
@@ -273,16 +272,15 @@ func TestClustersService_Update(t *testing.T) {
 	})
 
 	cluster, _, err := client.Clusters.Create(context.Background(), "my-great-org", input)
-
 	if err != nil {
 		t.Errorf("TestClusters.Create returned error: %v", err)
 	}
 
 	// Lets update the description of the cluster
-	cluster.Description = String("A test cluster")
+	cluster.Description = "A test cluster"
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/a32cbe81-82b2-45f7-bd97-66f1ac2c0cc1", func(w http.ResponseWriter, r *http.Request) {
-		v := new(ClusterUpdate)
+		var v ClusterUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "PATCH")
@@ -298,28 +296,23 @@ func TestClustersService_Update(t *testing.T) {
 			}`)
 	})
 
-	clusterUpdate := ClusterUpdate{
-		Description: String("A test cluster"),
-	}
-
-	_, err = client.Clusters.Update(context.Background(), "my-great-org", *cluster.ID, &clusterUpdate)
-
+	clusterUpdate := ClusterUpdate{Description: "A test cluster"}
+	_, err = client.Clusters.Update(context.Background(), "my-great-org", cluster.ID, clusterUpdate)
 	if err != nil {
 		t.Errorf("TestClusters.Update returned error: %v", err)
 	}
 
-	want := &Cluster{
-		ID:          String("a32cbe81-82b2-45f7-bd97-66f1ac2c0cc1"),
-		Name:        String("Testing Cluster"),
-		Description: String("A test cluster"),
-		Emoji:       String(":construction:"),
-		Color:       String("E5F185"),
+	want := Cluster{
+		ID:          "a32cbe81-82b2-45f7-bd97-66f1ac2c0cc1",
+		Name:        "Testing Cluster",
+		Description: "A test cluster",
+		Emoji:       ":construction:",
+		Color:       "E5F185",
 	}
 
 	if diff := cmp.Diff(cluster, want); diff != "" {
 		t.Errorf("TestClusters.Update diff: (-got +want)\n%s", diff)
 	}
-
 }
 
 func TestClustersService_Delete(t *testing.T) {
@@ -333,7 +326,6 @@ func TestClustersService_Delete(t *testing.T) {
 	})
 
 	_, err := client.Clusters.Delete(context.Background(), "my-great-org", "7d2aa9b5-bf2a-4ce0-b9d7-90d3d9b8942c")
-
 	if err != nil {
 		t.Errorf("TestClusters.Delete returned error: %v", err)
 	}

--- a/buildkite/flaky_tests.go
+++ b/buildkite/flaky_tests.go
@@ -14,43 +14,35 @@ type FlakyTestsService struct {
 }
 
 type FlakyTest struct {
-	ID                   *string    `json:"id,omitempty"`
-	WebURL               *string    `json:"web_url,omitempty"`
-	Scope                *string    `json:"scope,omitempty"`
-	Name                 *string    `json:"name,omitempty"`
-	Location             *string    `json:"location,omitempty"`
-	FileName             *string    `json:"file_name,omitempty"`
-	Instances            *int       `json:"instances,omitempty"`
+	ID                   string     `json:"id,omitempty"`
+	WebURL               string     `json:"web_url,omitempty"`
+	Scope                string     `json:"scope,omitempty"`
+	Name                 string     `json:"name,omitempty"`
+	Location             string     `json:"location,omitempty"`
+	FileName             string     `json:"file_name,omitempty"`
+	Instances            int        `json:"instances,omitempty"`
 	MostRecentInstanceAt *Timestamp `json:"most_recent_instance_at,omitempty"`
 }
 
-type FlakyTestsListOptions struct {
-	ListOptions
-}
+type FlakyTestsListOptions struct{ ListOptions }
 
 func (fts *FlakyTestsService) List(ctx context.Context, org, slug string, opt *FlakyTestsListOptions) ([]FlakyTest, *Response, error) {
-
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/flaky-tests", org, slug)
-
 	u, err := addOptions(u, opt)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req, err := fts.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	flakyTests := new([]FlakyTest)
-
-	resp, err := fts.client.Do(req, flakyTests)
-
+	var flakyTests []FlakyTest
+	resp, err := fts.client.Do(req, &flakyTests)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *flakyTests, resp, err
+	return flakyTests, resp, err
 }

--- a/buildkite/flaky_tests_test.go
+++ b/buildkite/flaky_tests_test.go
@@ -45,7 +45,6 @@ func TestFlakyTestsService_List(t *testing.T) {
 	})
 
 	flakyTests, _, err := client.FlakyTests.List(context.Background(), "my-great-org", "suite-example", nil)
-
 	if err != nil {
 		t.Errorf("TestSuites.List returned error: %v", err)
 	}
@@ -54,29 +53,25 @@ func TestFlakyTestsService_List(t *testing.T) {
 	parsedTime1 := must(time.Parse(BuildKiteDateFormat, "2023-05-19T20:00:02.223Z"))
 	parsedTime2 := must(time.Parse(BuildKiteDateFormat, "2023-07-10T13:14:03.214Z"))
 
-	if err != nil {
-		t.Errorf("TestSuites.List time.Parse error: %v", err)
-	}
-
 	want := []FlakyTest{
 		{
-			ID:                   String("a915535c-a8f1-4e1a-bd6a-a5589e09f349"),
-			WebURL:               String("https://buildkite.com/organizations/my_great_org/analytics/suites/suite-example/tests/a915535c-a8f1-4e1a-bd6a-a5589e09f349"),
-			Scope:                String("User#email"),
-			Name:                 String("TestExample1_Create"),
-			Location:             String("./spec/models/text_example.rb:55"),
-			FileName:             String("./spec/models/text_example.rb"),
-			Instances:            Int(1),
+			ID:                   "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+			WebURL:               "https://buildkite.com/organizations/my_great_org/analytics/suites/suite-example/tests/a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+			Scope:                "User#email",
+			Name:                 "TestExample1_Create",
+			Location:             "./spec/models/text_example.rb:55",
+			FileName:             "./spec/models/text_example.rb",
+			Instances:            1,
 			MostRecentInstanceAt: NewTimestamp(parsedTime1),
 		},
 		{
-			ID:                   String("01867216-8478-7fde-a55a-0300f88bb49b"),
-			WebURL:               String("https://buildkite.com/organizations/my_great_org/analytics/suites/suite-example/tests/01867216-8478-7fde-a55a-0300f88bb49b"),
-			Scope:                String("User#email"),
-			Name:                 String("TestExample1_Delete"),
-			Location:             String("./spec/models/text_example.rb:102"),
-			FileName:             String("./spec/models/text_example.rb"),
-			Instances:            Int(2),
+			ID:                   "01867216-8478-7fde-a55a-0300f88bb49b",
+			WebURL:               "https://buildkite.com/organizations/my_great_org/analytics/suites/suite-example/tests/01867216-8478-7fde-a55a-0300f88bb49b",
+			Scope:                "User#email",
+			Name:                 "TestExample1_Delete",
+			Location:             "./spec/models/text_example.rb:102",
+			FileName:             "./spec/models/text_example.rb",
+			Instances:            2,
 			MostRecentInstanceAt: NewTimestamp(parsedTime2),
 		},
 	}

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -15,20 +15,20 @@ type JobsService struct {
 
 // Job represents a job run during a build in buildkite
 type Job struct {
-	ID                 *string         `json:"id,omitempty"`
-	GraphQLID          *string         `json:"graphql_id,omitempty"`
-	Type               *string         `json:"type,omitempty"`
-	Name               *string         `json:"name,omitempty"`
-	Label              *string         `json:"label,omitempty"`
-	StepKey            *string         `json:"step_key,omitempty"`
-	GroupKey           *string         `json:"group_key,omitempty"`
-	State              *string         `json:"state,omitempty"`
-	LogsURL            *string         `json:"logs_url,omitempty"`
-	RawLogsURL         *string         `json:"raw_log_url,omitempty"`
-	Command            *string         `json:"command,omitempty"`
+	ID                 string          `json:"id,omitempty"`
+	GraphQLID          string          `json:"graphql_id,omitempty"`
+	Type               string          `json:"type,omitempty"`
+	Name               string          `json:"name,omitempty"`
+	Label              string          `json:"label,omitempty"`
+	StepKey            string          `json:"step_key,omitempty"`
+	GroupKey           string          `json:"group_key,omitempty"`
+	State              string          `json:"state,omitempty"`
+	LogsURL            string          `json:"logs_url,omitempty"`
+	RawLogsURL         string          `json:"raw_log_url,omitempty"`
+	Command            string          `json:"command,omitempty"`
 	ExitStatus         *int            `json:"exit_status,omitempty"`
-	ArtifactPaths      *string         `json:"artifact_paths,omitempty"`
-	ArtifactsURL       *string         `json:"artifacts_url,omitempty"`
+	ArtifactPaths      string          `json:"artifact_paths,omitempty"`
+	ArtifactsURL       string          `json:"artifacts_url,omitempty"`
 	CreatedAt          *Timestamp      `json:"created_at,omitempty"`
 	ScheduledAt        *Timestamp      `json:"scheduled_at,omitempty"`
 	RunnableAt         *Timestamp      `json:"runnable_at,omitempty"`
@@ -42,15 +42,15 @@ type Job struct {
 	RetriedInJobID     string          `json:"retried_in_job_id,omitempty"`
 	RetriesCount       int             `json:"retries_count,omitempty"`
 	RetrySource        *JobRetrySource `json:"retry_source,omitempty"`
-	RetryType          *string         `json:"retry_type,omitempty"`
+	RetryType          string          `json:"retry_type,omitempty"`
 	SoftFailed         bool            `json:"soft_failed,omitempty"`
 	UnblockedBy        *UnblockedBy    `json:"unblocked_by,omitempty"`
-	Unblockable        *bool           `json:"unblockable,omitempty"`
-	UnblockURL         *string         `json:"unblock_url,omitempty"`
+	Unblockable        bool            `json:"unblockable,omitempty"`
+	UnblockURL         string          `json:"unblock_url,omitempty"`
 	ParallelGroupIndex *int            `json:"parallel_group_index,omitempty"`
 	ParallelGroupTotal *int            `json:"parallel_group_total,omitempty"`
-	ClusterID          *string         `json:"cluster_id,omitempty"`
-	ClusterQueueID     *string         `json:"cluster_queue_id,omitempty"`
+	ClusterID          string          `json:"cluster_id,omitempty"`
+	ClusterQueueID     string          `json:"cluster_queue_id,omitempty"`
 	TriggeredBuild     *TriggeredBuild `json:"triggered_build,omitempty"`
 	Priority           *JobPriority    `json:"priority"`
 }
@@ -63,11 +63,11 @@ type JobRetrySource struct {
 
 // UnblockedBy represents the unblocked status of a job, when present
 type UnblockedBy struct {
-	ID        string    `json:"id,omitempty"`
-	Name      string    `json:"name,omitempty"`
-	Email     string    `json:"email,omitempty"`
-	AvatarURL string    `json:"avatar_url,omitempty"`
-	CreatedAt Timestamp `json:"created_at,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	Email     string     `json:"email,omitempty"`
+	AvatarURL string     `json:"avatar_url,omitempty"`
+	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
 // JobUnblockOptions specifies the optional parameters to UnblockJob
@@ -77,40 +77,37 @@ type JobUnblockOptions struct {
 
 // JobLog represents a job log output
 type JobLog struct {
-	URL         *string `json:"url"`
-	Content     *string `json:"content"`
-	Size        *int    `json:"size"`
+	URL         string  `json:"url"`
+	Content     string  `json:"content"`
+	Size        int     `json:"size"`
 	HeaderTimes []int64 `json:"header_times"`
 }
 
 // JobEnvs represent job environments output
 type JobEnvs struct {
-	EnvironmentVariables *map[string]string `json:"env,string"`
+	EnvironmentVariables map[string]string `json:"env,string"`
 }
 
 type TriggeredBuild struct {
-	ID     *string `json:"id,omitempty"`
-	Number *int    `json:"number,omitempty"`
-	URL    *string `json:"url,omitempty"`
-	WebURL *string `json:"web_url,omitempty"`
+	ID     string `json:"id,omitempty"`
+	Number int    `json:"number,omitempty"`
+	URL    string `json:"url,omitempty"`
+	WebURL string `json:"web_url,omitempty"`
 }
 
 // JobPriority represents the priority of the job
 type JobPriority struct {
-	Number *int `json:"number,omitempty"`
+	Number int `json:"number,omitempty"`
 }
 
 // UnblockJob - unblock a job
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#unblock-a-job
-func (js *JobsService) UnblockJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string, opt *JobUnblockOptions) (*Job, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/unblock", org, pipeline, buildNumber, jobID)
-
+func (js *JobsService) UnblockJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string, opt *JobUnblockOptions) (Job, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/unblock", org, pipeline, buildNumber, jobID)
 	u, err := addOptions(u, opt)
 	if err != nil {
-		return nil, nil, err
+		return Job{}, nil, err
 	}
 
 	if opt == nil {
@@ -119,13 +116,13 @@ func (js *JobsService) UnblockJob(ctx context.Context, org string, pipeline stri
 
 	req, err := js.client.NewRequest(ctx, "PUT", u, opt)
 	if err != nil {
-		return nil, nil, err
+		return Job{}, nil, err
 	}
 
-	job := new(Job)
-	resp, err := js.client.Do(req, job)
+	var job Job
+	resp, err := js.client.Do(req, &job)
 	if err != nil {
-		return nil, resp, err
+		return Job{}, resp, err
 	}
 
 	return job, resp, err
@@ -134,20 +131,17 @@ func (js *JobsService) UnblockJob(ctx context.Context, org string, pipeline stri
 // RetryJob - retry a job
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#retry-a-job
-func (js *JobsService) RetryJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (*Job, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/retry", org, pipeline, buildNumber, jobID)
-
+func (js *JobsService) RetryJob(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (Job, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/retry", org, pipeline, buildNumber, jobID)
 	req, err := js.client.NewRequest(ctx, "PUT", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return Job{}, nil, err
 	}
 
-	job := new(Job)
-	resp, err := js.client.Do(req, job)
+	var job Job
+	resp, err := js.client.Do(req, &job)
 	if err != nil {
-		return nil, resp, err
+		return Job{}, resp, err
 	}
 
 	return job, resp, err
@@ -156,21 +150,19 @@ func (js *JobsService) RetryJob(ctx context.Context, org string, pipeline string
 // GetJobLog - get a job’s log output
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-log-output
-func (js *JobsService) GetJobLog(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (*JobLog, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/log", org, pipeline, buildNumber, jobID)
+func (js *JobsService) GetJobLog(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (JobLog, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/log", org, pipeline, buildNumber, jobID)
 	req, err := js.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return JobLog{}, nil, err
 	}
 
 	req.Header.Set("Accept", "application/json")
 
-	jobLog := new(JobLog)
-	resp, err := js.client.Do(req, jobLog)
+	var jobLog JobLog
+	resp, err := js.client.Do(req, &jobLog)
 	if err != nil {
-		return nil, resp, err
+		return JobLog{}, resp, err
 	}
 
 	return jobLog, resp, err
@@ -179,21 +171,19 @@ func (js *JobsService) GetJobLog(ctx context.Context, org string, pipeline strin
 // GetJobEnvironmentVariables - get a job’s environment variables
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-environment-variables
-func (js *JobsService) GetJobEnvironmentVariables(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (*JobEnvs, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/env", org, pipeline, buildNumber, jobID)
+func (js *JobsService) GetJobEnvironmentVariables(ctx context.Context, org string, pipeline string, buildNumber string, jobID string) (JobEnvs, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/env", org, pipeline, buildNumber, jobID)
 	req, err := js.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return JobEnvs{}, nil, err
 	}
 
 	req.Header.Set("Accept", "application/json")
 
-	jobEnvs := new(JobEnvs)
-	resp, err := js.client.Do(req, jobEnvs)
+	var jobEnvs JobEnvs
+	resp, err := js.client.Do(req, &jobEnvs)
 	if err != nil {
-		return nil, resp, err
+		return JobEnvs{}, resp, err
 	}
 
 	return jobEnvs, resp, err

--- a/buildkite/jobs_test.go
+++ b/buildkite/jobs_test.go
@@ -29,7 +29,7 @@ func TestJobsService_UnblockJob(t *testing.T) {
 		t.Errorf("UnblockJob returned error: %v", err)
 	}
 
-	want := &Job{ID: String("awesome-job-id"), State: String("unblocked")}
+	want := Job{ID: "awesome-job-id", State: "unblocked"}
 	if diff := cmp.Diff(job, want); diff != "" {
 		t.Errorf("UnblockJob diff: (-got +want)\n%s", diff)
 	}
@@ -56,7 +56,7 @@ func TestJobsService_RetryJob(t *testing.T) {
 		t.Errorf("RetryJob returned error: %v", err)
 	}
 
-	want := &Job{ID: String("awesome-job-id"), State: String("scheduled"), Retried: bool(true), RetriesCount: int(1)}
+	want := Job{ID: "awesome-job-id", State: "scheduled", Retried: true, RetriesCount: 1}
 	if diff := cmp.Diff(job, want); diff != "" {
 		t.Errorf("RetryJob diff: (-got +want)\n%s", diff)
 	}
@@ -83,10 +83,10 @@ func TestJobsService_GetJobLog(t *testing.T) {
 		t.Errorf("GetJobLog returned error: %v", err)
 	}
 
-	want := &JobLog{
-		URL:         String("https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sub-keith/builds/awesome-build/jobs/awesome-job-id/log"),
-		Content:     String("This is the job's log output"),
-		Size:        Int(28),
+	want := JobLog{
+		URL:         "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sub-keith/builds/awesome-build/jobs/awesome-job-id/log",
+		Content:     "This is the job's log output",
+		Size:        28,
 		HeaderTimes: []int64{1563337899810051000, 1563337899811015000, 1563337905336878000, 1563337906589603000, 156333791038291900},
 	}
 	if diff := cmp.Diff(job, want); diff != "" {
@@ -124,16 +124,16 @@ func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
 		"BUILDKITE_BUILD_CREATOR_EMAIL":   "keith@buildkite.com",
 		"BUILDKITE_AGENT_META_DATA_LOCAL": "true",
 	}
+
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/15/jobs/awesome-job-id/env", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		body := map[string]map[string]string{
-			"env": envVars,
-		}
-		jsonString, err := json.Marshal(body)
+		body := map[string]map[string]string{"env": envVars}
+		bytes, err := json.Marshal(body)
 		if err != nil {
-			t.Errorf("Cast map into string returned error: %v", err)
+			t.Errorf("json.Marshal(body) returned error: %v", err)
 		}
-		fmt.Fprintf(w, `%s`, jsonString)
+
+		fmt.Fprint(w, string(bytes))
 	})
 
 	jobEnvVars, _, err := client.Jobs.GetJobEnvironmentVariables(context.Background(), "my-great-org", "sup-keith", "15", "awesome-job-id")
@@ -141,9 +141,7 @@ func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
 		t.Errorf("GetJobEnvironmentVariables returned error: %v", err)
 	}
 
-	want := &JobEnvs{
-		EnvironmentVariables: &envVars,
-	}
+	want := JobEnvs{EnvironmentVariables: envVars}
 	if diff := cmp.Diff(jobEnvVars, want); diff != "" {
 		t.Errorf("GetJobLog diff: (-got +want)\n%s", diff)
 	}

--- a/buildkite/misc.go
+++ b/buildkite/misc.go
@@ -7,35 +7,31 @@ import (
 
 // Emoji emoji, what else can you say?
 type Emoji struct {
-	Name *string `json:"name,omitempty"`
-	URL  *string `json:"url,omitempty"`
+	Name string `json:"name,omitempty"`
+	URL  string `json:"url,omitempty"`
 }
 
 // ListEmojis list all the emojis for a given account, including custom emojis and aliases.
 //
 // buildkite API docs: https://buildkite.com/docs/api/emojis
 func (c *Client) ListEmojis(ctx context.Context, org string) ([]Emoji, *Response, error) {
-
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/emojis", org)
-
+	u := fmt.Sprintf("v2/organizations/%s/emojis", org)
 	req, err := c.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	emoji := new([]Emoji)
-	resp, err := c.Do(req, emoji)
+	var emoji []Emoji
+	resp, err := c.Do(req, &emoji)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *emoji, resp, nil
+	return emoji, resp, nil
 }
 
 // Token an oauth access token for the buildkite service
 type Token struct {
-	AccessToken *string `json:"access_token,omitempty"`
-	Type        *string `json:"token_type,omitempty"`
+	AccessToken string `json:"access_token,omitempty"`
+	Type        string `json:"token_type,omitempty"`
 }

--- a/buildkite/misc_test.go
+++ b/buildkite/misc_test.go
@@ -25,8 +25,8 @@ func TestListEmojis(t *testing.T) {
 		t.Errorf("ListEmojis returned error: %v", err)
 	}
 
-	want := []Emoji{{Name: String("rocket"), URL: String("https://a.buildboxassets.com/assets/emoji2/unicode/1f680.png?v2")}}
-	if diff := cmp.Diff(want, emoji); diff != "" {
-		t.Errorf("ListEmojis diff: (-got +want)\n%s", diff)
+	want := []Emoji{{Name: "rocket", URL: "https://a.buildboxassets.com/assets/emoji2/unicode/1f680.png?v2"}}
+	if diff := cmp.Diff(emoji, want); diff != "" {
+		t.Errorf("ListEmojis diff: (-got +want): \n%s", diff)
 	}
 }

--- a/buildkite/organizations.go
+++ b/buildkite/organizations.go
@@ -15,33 +15,28 @@ type OrganizationsService struct {
 
 // Organization represents a buildkite organization.
 type Organization struct {
-	ID           *string    `json:"id,omitempty"`
-	GraphQLID    *string    `json:"graphql_id,omitempty"`
-	URL          *string    `json:"url,omitempty"`
-	WebURL       *string    `json:"web_url,omitempty"`
-	Name         *string    `json:"name,omitempty"`
-	Slug         *string    `json:"slug,omitempty"`
-	Repository   *string    `json:"repository,omitempty"`
-	PipelinesURL *string    `json:"pipelines_url,omitempty"`
-	EmojisURL    *string    `json:"emojis_url,omitempty"`
-	AgentsURL    *string    `json:"agents_url,omitempty"`
+	ID           string     `json:"id,omitempty"`
+	GraphQLID    string     `json:"graphql_id,omitempty"`
+	URL          string     `json:"url,omitempty"`
+	WebURL       string     `json:"web_url,omitempty"`
+	Name         string     `json:"name,omitempty"`
+	Slug         string     `json:"slug,omitempty"`
+	Repository   string     `json:"repository,omitempty"`
+	PipelinesURL string     `json:"pipelines_url,omitempty"`
+	EmojisURL    string     `json:"emojis_url,omitempty"`
+	AgentsURL    string     `json:"agents_url,omitempty"`
 	CreatedAt    *Timestamp `json:"created_at,omitempty"`
 }
 
 // OrganizationListOptions specifies the optional parameters to the
 // OrganizationsService.List method.
-type OrganizationListOptions struct {
-	ListOptions
-}
+type OrganizationListOptions struct{ ListOptions }
 
 // List the organizations for the current user.
 //
 // buildkite API docs: https://buildkite.com/docs/api/organizations#list-organizations
 func (os *OrganizationsService) List(ctx context.Context, opt *OrganizationListOptions) ([]Organization, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations")
-
+	u := fmt.Sprintf("v2/organizations")
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -52,31 +47,29 @@ func (os *OrganizationsService) List(ctx context.Context, opt *OrganizationListO
 		return nil, nil, err
 	}
 
-	orgs := new([]Organization)
-	resp, err := os.client.Do(req, orgs)
+	var orgs []Organization
+	resp, err := os.client.Do(req, &orgs)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *orgs, resp, err
+	return orgs, resp, err
 }
 
 // Get fetches an organization
 //
 // buildkite API docs: https://buildkite.com/docs/api/organizations#get-an-organization
-func (os *OrganizationsService) Get(ctx context.Context, slug string) (*Organization, *Response, error) {
-
+func (os *OrganizationsService) Get(ctx context.Context, slug string) (Organization, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s", slug)
-
 	req, err := os.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return Organization{}, nil, err
 	}
 
-	organization := new(Organization)
-	resp, err := os.client.Do(req, organization)
+	var organization Organization
+	resp, err := os.client.Do(req, &organization)
 	if err != nil {
-		return nil, resp, err
+		return Organization{}, resp, err
 	}
 
 	return organization, resp, err

--- a/buildkite/organizations_test.go
+++ b/buildkite/organizations_test.go
@@ -25,7 +25,7 @@ func TestOrganizationsService_List(t *testing.T) {
 		t.Errorf("Organizations.List returned error: %v", err)
 	}
 
-	want := []Organization{{ID: String("123")}, {ID: String("1234")}}
+	want := []Organization{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(orgs, want); diff != "" {
 		t.Errorf("Organizations.List diff: (-got +want)\n%s", diff)
 	}
@@ -47,7 +47,7 @@ func TestOrganizationsService_Get(t *testing.T) {
 		t.Errorf("Organizations.Get returned error: %v", err)
 	}
 
-	want := &Organization{ID: String("123")}
+	want := Organization{ID: "123"}
 	if diff := cmp.Diff(org, want); diff != "" {
 		t.Errorf("Organizations.Get diff: (-got +want)\n%s", diff)
 	}

--- a/buildkite/packages_test.go
+++ b/buildkite/packages_test.go
@@ -103,10 +103,10 @@ func TestCreatePackage(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			mux, client, teardown := newMockServerAndClient(t)
+			server, client, teardown := newMockServerAndClient(t)
 			t.Cleanup(teardown)
 
-			mux.HandleFunc("/v2/packages/organizations/my-org/registries/my-registry/packages", func(w http.ResponseWriter, r *http.Request) {
+			server.HandleFunc("/v2/packages/organizations/my-org/registries/my-registry/packages", func(w http.ResponseWriter, r *http.Request) {
 				defer r.Body.Close()
 
 				testMethod(t, r, "POST")

--- a/buildkite/packages_test.go
+++ b/buildkite/packages_test.go
@@ -23,9 +23,9 @@ var (
 		WebURL:   "https://buildkite.com/my-org/my-registry/my-package",
 		Registry: registry,
 		Organization: Organization{
-			ID:   String(uuid.NewString()),
-			Slug: String("my-org"),
-			Name: String("My Org"),
+			ID:   "my-org",
+			Slug: "my-org",
+			Name: "My Org",
 		},
 	}
 )

--- a/buildkite/pipeline_templates.go
+++ b/buildkite/pipeline_templates.go
@@ -104,14 +104,20 @@ func (pts *PipelineTemplatesService) Create(ctx context.Context, org string, ptc
 	return template, resp, err
 }
 
-func (pts *PipelineTemplatesService) Update(ctx context.Context, org, templateUUID string, ptu PipelineTemplateCreateUpdate) (*Response, error) {
+func (pts *PipelineTemplatesService) Update(ctx context.Context, org, templateUUID string, ptu PipelineTemplateCreateUpdate) (PipelineTemplate, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates/%s", org, templateUUID)
 	req, err := pts.client.NewRequest(ctx, "PATCH", u, ptu)
 	if err != nil {
-		return nil, err
+		return PipelineTemplate{}, nil, err
 	}
 
-	return pts.client.Do(req, nil)
+	var template PipelineTemplate
+	resp, err := pts.client.Do(req, &template)
+	if err != nil {
+		return PipelineTemplate{}, resp, err
+	}
+
+	return template, resp, err
 }
 
 func (pts *PipelineTemplatesService) Delete(ctx context.Context, org, templateUUID string) (*Response, error) {

--- a/buildkite/pipeline_templates.go
+++ b/buildkite/pipeline_templates.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -15,33 +14,35 @@ type PipelineTemplatesService struct {
 }
 
 type PipelineTemplate struct {
-	UUID          *string                  `json:"uuid,omitempty"`
-	GraphQLID     *string                  `json:"graphql_id,omitempty"`
-	Name          *string                  `json:"name,omitempty"`
-	Description   *string                  `json:"description,omitempty"`
-	Configuration *string                  `json:"configuration,omitempty"`
-	Available     *bool                    `json:"available,omitempty"`
-	URL           *string                  `json:"url,omitempty"`
-	WebURL        *string                  `json:"web_url,omitempty"`
-	CreatedAt     *Timestamp               `json:"created_at,omitempty"`
-	CreatedBy     *PipelineTemplateCreator `json:"created_by,omitempty"`
-	UpdatedAt     *Timestamp               `json:"updated_at,omitempty"`
-	UpdatedBy     *PipelineTemplateCreator `json:"updated_by,omitempty"`
+	UUID          string `json:"uuid,omitempty"`
+	GraphQLID     string `json:"graphql_id,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Configuration string `json:"configuration,omitempty"`
+	Available     bool   `json:"available,omitempty"`
+	URL           string `json:"url,omitempty"`
+	WebURL        string `json:"web_url,omitempty"`
+
+	CreatedAt *Timestamp              `json:"created_at,omitempty"`
+	CreatedBy PipelineTemplateCreator `json:"created_by,omitempty"`
+
+	UpdatedAt *Timestamp              `json:"updated_at,omitempty"`
+	UpdatedBy PipelineTemplateCreator `json:"updated_by,omitempty"`
 }
 
 type PipelineTemplateCreateUpdate struct {
-	Name          *string `json:"name,omitempty"`
-	Configuration *string `json:"configuration,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	Available     *bool   `json:"available,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Configuration string `json:"configuration,omitempty"`
+	Description   string `json:"description,omitempty"`
+	Available     bool   `json:"available,omitempty"`
 }
 
 type PipelineTemplateCreator struct {
-	ID        *string    `json:"id,omitempty"`
-	GraphQLID *string    `json:"graphql_id,omitempty"`
-	Name      *string    `json:"name,omitempty"`
-	Email     *string    `json:"email,omitempty"`
-	AvatarURL *string    `json:"avatar_url,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	GraphQLID string     `json:"graphql_id,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	Email     string     `json:"email,omitempty"`
+	AvatarURL string     `json:"avatar_url,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
@@ -50,107 +51,72 @@ type PipelineTemplateListOptions struct {
 }
 
 func (pts *PipelineTemplatesService) List(ctx context.Context, org string, opt *PipelineTemplateListOptions) ([]PipelineTemplate, *Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates", org)
-
 	u, err := addOptions(u, opt)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req, err := pts.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	templates := new([]PipelineTemplate)
-
-	resp, err := pts.client.Do(req, templates)
+	var templates []PipelineTemplate
+	resp, err := pts.client.Do(req, &templates)
 
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *templates, resp, err
+	return templates, resp, err
 }
 
-func (pts *PipelineTemplatesService) Get(ctx context.Context, org, templateUUID string) (*PipelineTemplate, *Response, error) {
-
+func (pts *PipelineTemplatesService) Get(ctx context.Context, org, templateUUID string) (PipelineTemplate, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates/%s", org, templateUUID)
-
 	req, err := pts.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
-		return nil, nil, err
+		return PipelineTemplate{}, nil, err
 	}
 
-	template := new(PipelineTemplate)
-
-	resp, err := pts.client.Do(req, template)
-
+	var template PipelineTemplate
+	resp, err := pts.client.Do(req, &template)
 	if err != nil {
-		return nil, resp, err
+		return PipelineTemplate{}, resp, err
 	}
 
 	return template, resp, err
 }
 
-func (pts *PipelineTemplatesService) Create(ctx context.Context, org string, ptc *PipelineTemplateCreateUpdate) (*PipelineTemplate, *Response, error) {
-
-	if ptc == nil {
-		return nil, nil, errors.New("PipelineTemplateCreateUpdate struct instance must not be nil")
-	}
-
+func (pts *PipelineTemplatesService) Create(ctx context.Context, org string, ptc PipelineTemplateCreateUpdate) (PipelineTemplate, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates", org)
-
 	req, err := pts.client.NewRequest(ctx, "POST", u, ptc)
-
 	if err != nil {
-		return nil, nil, err
+		return PipelineTemplate{}, nil, err
 	}
 
-	template := new(PipelineTemplate)
-
-	resp, err := pts.client.Do(req, template)
-
+	var template PipelineTemplate
+	resp, err := pts.client.Do(req, &template)
 	if err != nil {
-		return nil, resp, err
+		return PipelineTemplate{}, resp, err
 	}
 
 	return template, resp, err
 }
 
-func (pts *PipelineTemplatesService) Update(ctx context.Context, org, templateUUID string, ptu *PipelineTemplateCreateUpdate) (*Response, error) {
-
-	if ptu == nil {
-		return nil, errors.New("PipelineTemplateCreateUpdate struct instance must not be nil")
-	}
-
+func (pts *PipelineTemplatesService) Update(ctx context.Context, org, templateUUID string, ptu PipelineTemplateCreateUpdate) (*Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates/%s", org, templateUUID)
-
 	req, err := pts.client.NewRequest(ctx, "PATCH", u, ptu)
-
 	if err != nil {
-		return nil, nil
+		return nil, err
 	}
 
-	resp, err := pts.client.Do(req, ptu)
-
-	if err != nil {
-		return resp, err
-	}
-
-	return resp, err
+	return pts.client.Do(req, nil)
 }
 
 func (pts *PipelineTemplatesService) Delete(ctx context.Context, org, templateUUID string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates/%s", org, templateUUID)
-
 	req, err := pts.client.NewRequest(ctx, "DELETE", u, nil)
-
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/pipeline_templates_test.go
+++ b/buildkite/pipeline_templates_test.go
@@ -91,43 +91,43 @@ func TestPipelineTemplatesService_List(t *testing.T) {
 	devTemplateCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-11T02:24:33.602Z"))
 	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
-	pipelineTemplateCreator := &PipelineTemplateCreator{
-		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
-		GraphQLID: String("VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg=="),
-		Name:      String("Joe Smith"),
-		Email:     String("jsmith@example.com"),
-		AvatarURL: String("https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4"),
+	pipelineTemplateCreator := PipelineTemplateCreator{
+		ID:        "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+		GraphQLID: "VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg==",
+		Name:      "Joe Smith",
+		Email:     "jsmith@example.com",
+		AvatarURL: "https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4",
 		CreatedAt: NewTimestamp(userCreatedAt),
 	}
 
 	want := []PipelineTemplate{
 		{
-			UUID:          String("90333dc7-b86a-4485-98c3-9419a5dbc52e"),
-			GraphQLID:     String("UGlwZWxpbmVUZW1wbG5lLS0tOTAzMzNkYzctYjg2YS00NDg1LTk4YzMtOTQxOWE1ZGJjNTJl=="),
-			Name:          String("Pipeline Upload Template"),
-			Description:   String("Pipeline template with basic YAML pipeline upload"),
-			Configuration: String("steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload\"\n"),
-			Available:     Bool(true),
+			UUID:          "90333dc7-b86a-4485-98c3-9419a5dbc52e",
+			GraphQLID:     "UGlwZWxpbmVUZW1wbG5lLS0tOTAzMzNkYzctYjg2YS00NDg1LTk4YzMtOTQxOWE1ZGJjNTJl==",
+			Name:          "Pipeline Upload Template",
+			Description:   "Pipeline template with basic YAML pipeline upload",
+			Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload\"\n",
+			Available:     true,
 			CreatedAt:     NewTimestamp(basicTemplateCreatedAt),
 			CreatedBy:     pipelineTemplateCreator,
 			UpdatedAt:     NewTimestamp(basicTemplateCreatedAt),
 			UpdatedBy:     pipelineTemplateCreator,
-			URL:           String("https://api.buildkite.com/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e"),
-			WebURL:        String("https://buildkite.com/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e"),
+			URL:           "https://api.buildkite.com/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e",
+			WebURL:        "https://buildkite.com/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e",
 		},
 		{
-			UUID:          String("6a25cc85-9fa2-4a00-b66c-bfe377bc5f78"),
-			GraphQLID:     String("UGlwZWxpbmVUZW1wbG5lLS0tNmEyNWNjODUtOWZhMi00YTAwLWI2NmMtYmZlMzc3YmM1Zjc4=="),
-			Name:          String("Pipeline-Dev Upload Template"),
-			Description:   String("Pipeline template uploading buildkite-dev.yml"),
-			Configuration: String("steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-dev.yml\"\n"),
-			Available:     Bool(true),
+			UUID:          "6a25cc85-9fa2-4a00-b66c-bfe377bc5f78",
+			GraphQLID:     "UGlwZWxpbmVUZW1wbG5lLS0tNmEyNWNjODUtOWZhMi00YTAwLWI2NmMtYmZlMzc3YmM1Zjc4==",
+			Name:          "Pipeline-Dev Upload Template",
+			Description:   "Pipeline template uploading buildkite-dev.yml",
+			Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-dev.yml\"\n",
+			Available:     true,
 			CreatedAt:     NewTimestamp(devTemplateCreatedAt),
 			CreatedBy:     pipelineTemplateCreator,
 			UpdatedAt:     NewTimestamp(devTemplateCreatedAt),
 			UpdatedBy:     pipelineTemplateCreator,
-			URL:           String("https://api.buildkite.com/v2/organizations/my-great-org/pipeline-templates/6a25cc85-9fa2-4a00-b66c-bfe377bc5f78"),
-			WebURL:        String("https://buildkite.com/organizations/my-great-org/pipeline-templates/6a25cc85-9fa2-4a00-b66c-bfe377bc5f78"),
+			URL:           "https://api.buildkite.com/v2/organizations/my-great-org/pipeline-templates/6a25cc85-9fa2-4a00-b66c-bfe377bc5f78",
+			WebURL:        "https://buildkite.com/organizations/my-great-org/pipeline-templates/6a25cc85-9fa2-4a00-b66c-bfe377bc5f78",
 		},
 	}
 
@@ -185,28 +185,28 @@ func TestPipelineTemplatesService_Get(t *testing.T) {
 	basicTemplateCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-08-11T01:22:05.650Z"))
 	userCreatedAt := must(time.Parse(BuildKiteDateFormat, "2023-02-20T03:00:05.824Z"))
 
-	pipelineTemplateCreator := &PipelineTemplateCreator{
-		ID:        String("7da07e25-0383-4aff-a7cf-14d1a9aa098f"),
-		GraphQLID: String("VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg=="),
-		Name:      String("Joe Smith"),
-		Email:     String("jsmith@example.com"),
-		AvatarURL: String("https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4"),
+	pipelineTemplateCreator := PipelineTemplateCreator{
+		ID:        "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+		GraphQLID: "VXNlci0tLTdkYTA3ZTI1LTAzODMtNGFmZi1hN2NmLTE0ZDFhOWFhMDk4Zg==",
+		Name:      "Joe Smith",
+		Email:     "jsmith@example.com",
+		AvatarURL: "https://www.gravatar.com/avatar/593nf93m405mf744n3kg9456jjph9grt4",
 		CreatedAt: NewTimestamp(userCreatedAt),
 	}
 
-	want := &PipelineTemplate{
-		UUID:          String("90333dc7-b86a-4485-98c3-9419a5dbc52e"),
-		GraphQLID:     String("UGlwZWxpbmVUZW1wbG5lLS0tOTAzMzNkYzctYjg2YS00NDg1LTk4YzMtOTQxOWE1ZGJjNTJl=="),
-		Name:          String("Pipeline Upload Template"),
-		Description:   String("Pipeline template with basic YAML pipeline upload"),
-		Configuration: String("steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload\"\n"),
-		Available:     Bool(true),
+	want := PipelineTemplate{
+		UUID:          "90333dc7-b86a-4485-98c3-9419a5dbc52e",
+		GraphQLID:     "UGlwZWxpbmVUZW1wbG5lLS0tOTAzMzNkYzctYjg2YS00NDg1LTk4YzMtOTQxOWE1ZGJjNTJl==",
+		Name:          "Pipeline Upload Template",
+		Description:   "Pipeline template with basic YAML pipeline upload",
+		Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload\"\n",
+		Available:     true,
 		CreatedAt:     NewTimestamp(basicTemplateCreatedAt),
 		CreatedBy:     pipelineTemplateCreator,
 		UpdatedAt:     NewTimestamp(basicTemplateCreatedAt),
 		UpdatedBy:     pipelineTemplateCreator,
-		URL:           String("https://api.buildkite.com/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e"),
-		WebURL:        String("https://buildkite.com/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e"),
+		URL:           "https://api.buildkite.com/v2/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e",
+		WebURL:        "https://buildkite.com/organizations/my-great-org/pipeline-templates/90333dc7-b86a-4485-98c3-9419a5dbc52e",
 	}
 
 	if diff := cmp.Diff(pipelineTemplate, want); diff != "" {
@@ -220,15 +220,15 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &PipelineTemplateCreateUpdate{
-		Name:          String("Production Pipeline uploader"),
-		Description:   String("Production pipeline upload template"),
-		Configuration: String("steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n"),
-		Available:     Bool(true),
+	input := PipelineTemplateCreateUpdate{
+		Name:          "Production Pipeline uploader",
+		Description:   "Production pipeline upload template",
+		Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n",
+		Available:     true,
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
-		v := new(PipelineTemplateCreateUpdate)
+		var v PipelineTemplateCreateUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -255,13 +255,13 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 		t.Errorf("TestPipelineTemplates.Create returned error: %v", err)
 	}
 
-	want := &PipelineTemplate{
-		UUID:          String("08ac0872-e3bd-41d2-b0f8-7822bb43ad41"),
-		GraphQLID:     String("UGlwZWxpbmVUZW1wbG5lLS0tMDhhYzA4NzItZTNiZC00MWQyLWIwZjgtNzgyMmJiNDNhZDQxIA=="),
-		Name:          String("Production Pipeline template"),
-		Description:   String("Production pipeline upload template"),
-		Configuration: String("steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n"),
-		Available:     Bool(true),
+	want := PipelineTemplate{
+		UUID:          "08ac0872-e3bd-41d2-b0f8-7822bb43ad41",
+		GraphQLID:     "UGlwZWxpbmVUZW1wbG5lLS0tMDhhYzA4NzItZTNiZC00MWQyLWIwZjgtNzgyMmJiNDNhZDQxIA==",
+		Name:          "Production Pipeline template",
+		Description:   "Production pipeline upload template",
+		Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n",
+		Available:     true,
 	}
 
 	if diff := cmp.Diff(pipelineTemplate, want); diff != "" {
@@ -275,15 +275,15 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &PipelineTemplateCreateUpdate{
-		Name:          String("Production Pipeline uploader"),
-		Description:   String("Production pipeline upload template"),
-		Configuration: String("steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n"),
-		Available:     Bool(true),
+	input := PipelineTemplateCreateUpdate{
+		Name:          "Production Pipeline uploader",
+		Description:   "Production pipeline upload template",
+		Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n",
+		Available:     true,
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
-		v := new(PipelineTemplateCreateUpdate)
+		var v PipelineTemplateCreateUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -311,10 +311,10 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 	}
 
 	// Lets update the description of the pipeline template
-	pipelineTemplate.Description = String("A pipeline template for uploading a production pipeline YAML (pipeline-production.yml)")
+	pipelineTemplate.Description = "A pipeline template for uploading a production pipeline YAML (pipeline-production.yml"
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", func(w http.ResponseWriter, r *http.Request) {
-		v := new(PipelineTemplateCreateUpdate)
+		var v PipelineTemplateCreateUpdate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "PATCH")
@@ -332,22 +332,22 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 	})
 
 	pipelineTemplateUpdate := PipelineTemplateCreateUpdate{
-		Description: String("A pipeline template for uploading a production pipeline YAML (pipeline-production.yml)"),
+		Description: "A pipeline template for uploading a production pipeline YAML (pipeline-production.yml",
 	}
 
-	_, err = client.PipelineTemplates.Update(context.Background(), "my-great-org", "b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", &pipelineTemplateUpdate)
+	_, err = client.PipelineTemplates.Update(context.Background(), "my-great-org", "b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", pipelineTemplateUpdate)
 
 	if err != nil {
 		t.Errorf("TestPipelineTemplates.Update returned error: %v", err)
 	}
 
-	want := &PipelineTemplate{
-		UUID:          String("b8c2e171-1c7d-47a4-a4d1-a20d691f51d0"),
-		GraphQLID:     String("UGlwZWxpbmVUZW1wbG5lLS0tYjhjMmUxNzEtMWM3ZC00N2E0LWE0ZDEtYTIwZDY5MWY1MWQw=="),
-		Name:          String("Production Pipeline template"),
-		Description:   String("A pipeline template for uploading a production pipeline YAML (pipeline-production.yml)"),
-		Configuration: String("steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n"),
-		Available:     Bool(true),
+	want := PipelineTemplate{
+		UUID:          "b8c2e171-1c7d-47a4-a4d1-a20d691f51d0",
+		GraphQLID:     "UGlwZWxpbmVUZW1wbG5lLS0tYjhjMmUxNzEtMWM3ZC00N2E0LWE0ZDEtYTIwZDY5MWY1MWQw==",
+		Name:          "Production Pipeline template",
+		Description:   "A pipeline template for uploading a production pipeline YAML (pipeline-production.yml",
+		Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n",
+		Available:     true,
 	}
 
 	if diff := cmp.Diff(pipelineTemplate, want); diff != "" {

--- a/buildkite/pipelines.go
+++ b/buildkite/pipelines.go
@@ -3,7 +3,6 @@ package buildkite
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 )
 
@@ -36,77 +35,77 @@ type CreatePipeline struct {
 	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty"`
 	TeamUuids                       []string          `json:"team_uuids,omitempty"`
 	ClusterID                       string            `json:"cluster_id,omitempty"`
-	Visibility                      *string           `json:"visibility,omitempty"`
+	Visibility                      string            `json:"visibility,omitempty"`
 	Tags                            []string          `json:"tags,omitempty"`
 }
 
 type UpdatePipeline struct {
 	// Either configuration needs to be specified as a yaml string or steps (based on what the pipeline uses)
-	Configuration string  `json:"configuration,omitempty"`
-	Steps         []*Step `json:"steps,omitempty"`
+	Configuration string `json:"configuration,omitempty"`
+	Steps         []Step `json:"steps,omitempty"`
 
-	Name                            *string          `json:"name,omitempty"`
-	Repository                      *string          `json:"repository,omitempty"`
-	DefaultBranch                   *string          `json:"default_branch,omitempty"`
-	Description                     *string          `json:"description,omitempty"`
+	Name                            string           `json:"name,omitempty"`
+	Repository                      string           `json:"repository,omitempty"`
+	DefaultBranch                   string           `json:"default_branch,omitempty"`
+	Description                     string           `json:"description,omitempty"`
 	ProviderSettings                ProviderSettings `json:"provider_settings,omitempty"`
-	BranchConfiguration             *string          `json:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          *bool            `json:"skip_queued_branch_builds,omitempty"`
-	SkipQueuedBranchBuildsFilter    *string          `json:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       *bool            `json:"cancel_running_branch_builds,omitempty"`
-	CancelRunningBranchBuildsFilter *string          `json:"cancel_running_branch_builds_filter,omitempty"`
-	ClusterID                       *string          `json:"cluster_id,omitempty"`
-	Visibility                      *string          `json:"visibility,omitempty"`
+	BranchConfiguration             string           `json:"branch_configuration,omitempty"`
+	SkipQueuedBranchBuilds          bool             `json:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuildsFilter    string           `json:"skip_queued_branch_builds_filter,omitempty"`
+	CancelRunningBranchBuilds       bool             `json:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuildsFilter string           `json:"cancel_running_branch_builds_filter,omitempty"`
+	ClusterID                       string           `json:"cluster_id,omitempty"`
+	Visibility                      string           `json:"visibility,omitempty"`
 	Tags                            []string         `json:"tags,omitempty"`
 }
 
 // Pipeline represents a buildkite pipeline.
 type Pipeline struct {
-	ID                              *string    `json:"id,omitempty"`
-	GraphQLID                       *string    `json:"graphql_id,omitempty"`
-	URL                             *string    `json:"url,omitempty"`
-	WebURL                          *string    `json:"web_url,omitempty"`
-	Name                            *string    `json:"name,omitempty"`
-	Slug                            *string    `json:"slug,omitempty"`
-	Repository                      *string    `json:"repository,omitempty"`
-	BuildsURL                       *string    `json:"builds_url,omitempty"`
-	BadgeURL                        *string    `json:"badge_url,omitempty"`
+	ID                              string     `json:"id,omitempty"`
+	GraphQLID                       string     `json:"graphql_id,omitempty"`
+	URL                             string     `json:"url,omitempty"`
+	WebURL                          string     `json:"web_url,omitempty"`
+	Name                            string     `json:"name,omitempty"`
+	Slug                            string     `json:"slug,omitempty"`
+	Repository                      string     `json:"repository,omitempty"`
+	BuildsURL                       string     `json:"builds_url,omitempty"`
+	BadgeURL                        string     `json:"badge_url,omitempty"`
 	CreatedAt                       *Timestamp `json:"created_at,omitempty"`
 	ArchivedAt                      *Timestamp `json:"archived_at,omitempty"`
-	DefaultBranch                   *string    `json:"default_branch,omitempty"`
-	Description                     *string    `json:"description,omitempty"`
-	BranchConfiguration             *string    `json:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          *bool      `json:"skip_queued_branch_builds,omitempty"`
-	SkipQueuedBranchBuildsFilter    *string    `json:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       *bool      `json:"cancel_running_branch_builds,omitempty"`
-	CancelRunningBranchBuildsFilter *string    `json:"cancel_running_branch_builds_filter,omitempty"`
-	ClusterID                       *string    `json:"cluster_id,omitempty"`
-	Visibility                      *string    `json:"visibility,omitempty"`
+	DefaultBranch                   string     `json:"default_branch,omitempty"`
+	Description                     string     `json:"description,omitempty"`
+	BranchConfiguration             string     `json:"branch_configuration,omitempty"`
+	SkipQueuedBranchBuilds          bool       `json:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuildsFilter    string     `json:"skip_queued_branch_builds_filter,omitempty"`
+	CancelRunningBranchBuilds       bool       `json:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuildsFilter string     `json:"cancel_running_branch_builds_filter,omitempty"`
+	ClusterID                       string     `json:"cluster_id,omitempty"`
+	Visibility                      string     `json:"visibility,omitempty"`
 	Tags                            []string   `json:"tags,omitempty"`
 
-	ScheduledBuildsCount *int `json:"scheduled_builds_count,omitempty"`
-	RunningBuildsCount   *int `json:"running_builds_count,omitempty"`
-	ScheduledJobsCount   *int `json:"scheduled_jobs_count,omitempty"`
-	RunningJobsCount     *int `json:"running_jobs_count,omitempty"`
-	WaitingJobsCount     *int `json:"waiting_jobs_count,omitempty"`
+	ScheduledBuildsCount int `json:"scheduled_builds_count,omitempty"`
+	RunningBuildsCount   int `json:"running_builds_count,omitempty"`
+	ScheduledJobsCount   int `json:"scheduled_jobs_count,omitempty"`
+	RunningJobsCount     int `json:"running_jobs_count,omitempty"`
+	WaitingJobsCount     int `json:"waiting_jobs_count,omitempty"`
 
 	// the provider of sources
-	Provider *Provider `json:"provider,omitempty"`
+	Provider Provider `json:"provider,omitempty"`
 
 	// build steps
-	Steps         []*Step                `json:"steps,omitempty"`
-	Configuration string                 `json:"configuration,omitempty"`
-	Env           map[string]interface{} `json:"env,omitempty"`
+	Steps         []Step         `json:"steps,omitempty"`
+	Configuration string         `json:"configuration,omitempty"`
+	Env           map[string]any `json:"env,omitempty"`
 }
 
 // Step represents a build step in buildkites build pipeline
 type Step struct {
-	Type                *string           `json:"type,omitempty"`
-	Name                *string           `json:"name,omitempty"`
-	Label               *string           `json:"label,omitempty"`
-	Command             *string           `json:"command,omitempty"`
-	ArtifactPaths       *string           `json:"artifact_paths,omitempty"`
-	BranchConfiguration *string           `json:"branch_configuration,omitempty"`
+	Type                string            `json:"type,omitempty"`
+	Name                string            `json:"name,omitempty"`
+	Label               string            `json:"label,omitempty"`
+	Command             string            `json:"command,omitempty"`
+	ArtifactPaths       string            `json:"artifact_paths,omitempty"`
+	BranchConfiguration string            `json:"branch_configuration,omitempty"`
 	Env                 map[string]string `json:"env,omitempty"`
 	TimeoutInMinutes    *int              `json:"timeout_in_minutes,omitempty"`
 	AgentQueryRules     []string          `json:"agent_query_rules,omitempty"`
@@ -147,25 +146,22 @@ type Plugin map[string]interface{}
 
 // PipelineListOptions specifies the optional parameters to the
 // PipelinesService.List method.
-type PipelineListOptions struct {
-	ListOptions
-}
+type PipelineListOptions struct{ ListOptions }
 
 // Create - Creates a pipeline for a given organisation.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#create-a-pipeline
-func (ps *PipelinesService) Create(ctx context.Context, org string, p *CreatePipeline) (*Pipeline, *Response, error) {
+func (ps *PipelinesService) Create(ctx context.Context, org string, p CreatePipeline) (Pipeline, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines", org)
-
 	req, err := ps.client.NewRequest(ctx, "POST", u, p)
 	if err != nil {
-		return nil, nil, err
+		return Pipeline{}, nil, err
 	}
 
-	pipeline := new(Pipeline)
-	resp, err := ps.client.Do(req, pipeline)
+	var pipeline Pipeline
+	resp, err := ps.client.Do(req, &pipeline)
 	if err != nil {
-		return nil, resp, err
+		return Pipeline{}, resp, err
 	}
 
 	return pipeline, resp, err
@@ -174,19 +170,17 @@ func (ps *PipelinesService) Create(ctx context.Context, org string, p *CreatePip
 // Get fetches a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#get-a-pipeline
-func (ps *PipelinesService) Get(ctx context.Context, org string, slug string) (*Pipeline, *Response, error) {
-
+func (ps *PipelinesService) Get(ctx context.Context, org string, slug string) (Pipeline, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
-
 	req, err := ps.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return Pipeline{}, nil, err
 	}
 
-	pipeline := new(Pipeline)
-	resp, err := ps.client.Do(req, pipeline)
+	var pipeline Pipeline
+	resp, err := ps.client.Do(req, &pipeline)
 	if err != nil {
-		return nil, resp, err
+		return Pipeline{}, resp, err
 	}
 
 	return pipeline, resp, err
@@ -196,10 +190,7 @@ func (ps *PipelinesService) Get(ctx context.Context, org string, slug string) (*
 //
 // buildkite API docs: https://buildkite.com/docs/api/pipelines#list-pipelines
 func (ps *PipelinesService) List(ctx context.Context, org string, opt *PipelineListOptions) ([]Pipeline, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/pipelines", org)
-
+	u := fmt.Sprintf("v2/organizations/%s/pipelines", org)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -210,22 +201,20 @@ func (ps *PipelinesService) List(ctx context.Context, org string, opt *PipelineL
 		return nil, nil, err
 	}
 
-	pipelines := new([]Pipeline)
-	resp, err := ps.client.Do(req, pipelines)
+	var pipelines []Pipeline
+	resp, err := ps.client.Do(req, &pipelines)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *pipelines, resp, err
+	return pipelines, resp, err
 }
 
 // Delete a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#delete-a-pipeline
-func (ps *PipelinesService) Delete(ctx context.Context, org string, slug string) (*Response, error) {
-
+func (ps *PipelinesService) Delete(ctx context.Context, org, slug string) (*Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
-
 	req, err := ps.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err
@@ -237,36 +226,27 @@ func (ps *PipelinesService) Delete(ctx context.Context, org string, slug string)
 // Update - Updates a pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/pipelines#update-a-pipeline
-func (ps *PipelinesService) Update(ctx context.Context, org string, p *Pipeline) (*Response, error) {
-	if p == nil {
-		return nil, errors.New("Pipeline must not be nil")
-	}
-
-	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, *p.Slug)
-
-	pu := generateUpdatePipelineInstance(*p)
-
-	req, err := ps.client.NewRequest(ctx, "PATCH", u, pu)
-
+func (ps *PipelinesService) Update(ctx context.Context, org, slug string, up UpdatePipeline) (Pipeline, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s", org, slug)
+	req, err := ps.client.NewRequest(ctx, "PATCH", u, up)
 	if err != nil {
-		return nil, err
+		return Pipeline{}, nil, err
 	}
 
-	resp, err := ps.client.Do(req, p)
+	var p Pipeline
+	resp, err := ps.client.Do(req, &p)
 	if err != nil {
-		return resp, err
+		return Pipeline{}, resp, err
 	}
 
-	return resp, err
+	return p, resp, err
 }
 
 // AddWebhook - Adds webhook in github for pipeline.
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipelines#add-a-webhook
 func (ps *PipelinesService) AddWebhook(ctx context.Context, org string, slug string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/webhook", org, slug)
-
 	req, err := ps.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -279,9 +259,7 @@ func (ps *PipelinesService) AddWebhook(ctx context.Context, org string, slug str
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipelines#archive-a-pipeline
 func (ps *PipelinesService) Archive(ctx context.Context, org string, slug string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/archive", org, slug)
-
 	req, err := ps.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -294,41 +272,11 @@ func (ps *PipelinesService) Archive(ctx context.Context, org string, slug string
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipelines#unarchive-a-pipeline
 func (ps *PipelinesService) Unarchive(ctx context.Context, org string, slug string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/unarchive", org, slug)
-
 	req, err := ps.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	return ps.client.Do(req, nil)
-}
-
-func generateUpdatePipelineInstance(p Pipeline) UpdatePipeline {
-
-	// Create a UpdatePipeline struct to use for updating
-	updatePipeline := UpdatePipeline{
-		Name:                            p.Name,
-		Repository:                      p.Repository,
-		DefaultBranch:                   p.DefaultBranch,
-		Description:                     p.Description,
-		BranchConfiguration:             p.BranchConfiguration,
-		SkipQueuedBranchBuilds:          p.SkipQueuedBranchBuilds,
-		SkipQueuedBranchBuildsFilter:    p.SkipQueuedBranchBuildsFilter,
-		CancelRunningBranchBuilds:       p.CancelRunningBranchBuilds,
-		CancelRunningBranchBuildsFilter: p.CancelRunningBranchBuildsFilter,
-		ClusterID:                       p.ClusterID,
-		Visibility:                      p.Visibility,
-		Configuration:                   p.Configuration,
-		Steps:                           p.Steps,
-		Tags:                            p.Tags,
-	}
-
-	// If Pipeline Provider has been defined, set ProviderSettings
-	if p.Provider != nil {
-		updatePipeline.ProviderSettings = p.Provider.Settings
-	}
-
-	return updatePipeline
 }

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -26,7 +26,7 @@ func TestPipelinesService_List(t *testing.T) {
 		t.Errorf("Pipelines.List returned error: %v", err)
 	}
 
-	want := []Pipeline{{ID: String("123")}, {ID: String("1234")}}
+	want := []Pipeline{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(pipelines, want); diff != "" {
 		t.Errorf("Pipelines.List diff: (-got +want)\n%s", diff)
 	}
@@ -38,13 +38,13 @@ func TestPipelinesService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &CreatePipeline{Name: *String("my-great-pipeline"),
-		Repository: *String("my-great-repo"),
+	input := CreatePipeline{Name: "my-great-pipeline",
+		Repository: "my-great-repo",
 		Steps: []Step{
 			{
-				Type:    String("script"),
-				Name:    String("Build :package"),
-				Command: String("script/release.sh"),
+				Type:    "script",
+				Name:    "Build :package",
+				Command: "script/release.sh",
 				Plugins: Plugins{
 					"my-org/docker#v3.3.0": {
 						"image":   "node",
@@ -53,7 +53,7 @@ func TestPipelinesService_Create(t *testing.T) {
 				},
 			},
 		},
-		DefaultBranch: *String("main"),
+		DefaultBranch: "main",
 		Tags: []string{
 			"well-tested",
 			"great-config",
@@ -61,7 +61,7 @@ func TestPipelinesService_Create(t *testing.T) {
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
-		v := new(CreatePipeline)
+		var v CreatePipeline
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -99,13 +99,14 @@ func TestPipelinesService_Create(t *testing.T) {
 		t.Errorf("Pipelines.Create returned error: %v", err)
 	}
 
-	want := &Pipeline{Name: String("my-great-pipeline"),
-		Repository: String("my-great-repo"),
-		Steps: []*Step{
+	want := Pipeline{
+		Name:       "my-great-pipeline",
+		Repository: "my-great-repo",
+		Steps: []Step{
 			{
-				Type:    String("script"),
-				Name:    String("Build :package:"),
-				Command: String("script/release.sh"),
+				Type:    "script",
+				Name:    "Build :package:",
+				Command: "script/release.sh",
 				Plugins: Plugins{
 					"my-org/docker#v3.3.0": {
 						"image":   "node",
@@ -114,7 +115,7 @@ func TestPipelinesService_Create(t *testing.T) {
 				},
 			},
 		},
-		DefaultBranch: String("main"),
+		DefaultBranch: "main",
 		Tags: []string{
 			"well-tested",
 			"great-config",
@@ -132,13 +133,13 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &CreatePipeline{Name: *String("my-great-pipeline"),
-		Repository:    *String("my-great-repo"),
-		Configuration: *String("steps:\n  - command: \"script/release.sh\"\n    label: \"Build :package:\""),
+	input := CreatePipeline{Name: "my-great-pipeline",
+		Repository:    "my-great-repo",
+		Configuration: "steps:\n  - command: \"script/release.sh\"\n    label: \"Build :package:\"",
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
-		v := new(CreatePipeline)
+		var v CreatePipeline
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -172,13 +173,14 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 		t.Errorf("Pipelines.Create returned error: %v", err)
 	}
 
-	want := &Pipeline{Name: String("my-great-pipeline"),
-		Repository: String("my-great-repo"),
-		Steps: []*Step{
+	want := Pipeline{
+		Name:       "my-great-pipeline",
+		Repository: "my-great-repo",
+		Steps: []Step{
 			{
-				Type:    String("script"),
-				Name:    String("Build :package:"),
-				Command: String("script/release.sh"),
+				Type:    "script",
+				Name:    "Build :package:",
+				Command: "script/release.sh",
 				Plugins: Plugins{
 					"my-org/docker#v3.3.0": {
 						"image":   "node",
@@ -187,7 +189,7 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 				},
 			},
 		},
-		Configuration: *String("steps:\n  - command: \"script/release.sh\"\n    label: \"Build :package:\""),
+		Configuration: "steps:\n  - command: \"script/release.sh\"\n    label: \"Build :package:\"",
 	}
 	if diff := cmp.Diff(pipeline, want); diff != "" {
 		t.Errorf("Pipelines.Create diff: (-got +want)\n%s", diff)
@@ -217,7 +219,7 @@ func TestPipelinesService_Get(t *testing.T) {
 		t.Errorf("Pipelines.Get returned error: %v", err)
 	}
 
-	want := &Pipeline{ID: String("123"), Slug: String("my-great-pipeline-slug")}
+	want := Pipeline{ID: "123", Slug: "my-great-pipeline-slug"}
 	if diff := cmp.Diff(pipeline, want); diff != "" {
 		t.Errorf("Pipelines.Get diff: (-got +want)\n%s", diff)
 	}
@@ -245,13 +247,13 @@ func TestPipelinesService_Update(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &CreatePipeline{Name: *String("my-great-pipeline"),
-		Repository: *String("my-great-repo"),
+	input := CreatePipeline{Name: "my-great-pipeline",
+		Repository: "my-great-repo",
 		Steps: []Step{
 			{
-				Type:    String("script"),
-				Name:    String("Build :package"),
-				Command: String("script/release.sh"),
+				Type:    "script",
+				Name:    "Build :package",
+				Command: "script/release.sh",
 				Plugins: Plugins{
 					"my-org/docker#v3.3.0": {
 						"image":   "node",
@@ -263,7 +265,7 @@ func TestPipelinesService_Update(t *testing.T) {
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
-		v := new(CreatePipeline)
+		var v CreatePipeline
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -292,16 +294,18 @@ func TestPipelinesService_Update(t *testing.T) {
 					}`)
 	})
 
-	pipeline, _, err := client.Pipelines.Create(context.Background(), "my-great-org", input)
+	_, _, err := client.Pipelines.Create(context.Background(), "my-great-org", input)
 	if err != nil {
 		t.Errorf("Pipelines.Create returned error: %v", err)
 	}
 
-	pipeline.Name = String("derp")
-
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-repo", func(w http.ResponseWriter, r *http.Request) {
-		v := new(CreatePipeline)
+		var v UpdatePipeline
 		json.NewDecoder(r.Body).Decode(&v)
+
+		if diff := cmp.Diff(v, UpdatePipeline{Name: "derp"}); diff != "" {
+			t.Errorf("Request body diff: (-got +want)\n%s", diff)
+		}
 
 		testMethod(t, r, "PATCH")
 
@@ -323,24 +327,23 @@ func TestPipelinesService_Update(t *testing.T) {
 						],
 						"slug": "my-great-repo",
             "visibility": "public",
-            "tags": [
-              "fresh-tag"
-            ]
+            "tags": ["fresh-tag"]
 					}`)
 	})
 
-	_, err = client.Pipelines.Update(context.Background(), "my-great-org", pipeline)
+	got, _, err := client.Pipelines.Update(context.Background(), "my-great-org", "my-great-repo", UpdatePipeline{Name: "derp"})
 	if err != nil {
 		t.Errorf("Pipelines.Update returned error: %v", err)
 	}
 
-	want := &Pipeline{Name: String("derp"),
-		Repository: String("my-great-repo"),
-		Steps: []*Step{
+	want := Pipeline{
+		Name:       "derp",
+		Repository: "my-great-repo",
+		Steps: []Step{
 			{
-				Type:    String("script"),
-				Name:    String("Build :package:"),
-				Command: String("script/release.sh"),
+				Type:    "script",
+				Name:    "Build :package:",
+				Command: "script/release.sh",
 				Plugins: Plugins{
 					"my-org/docker#v3.3.0": {
 						"image":   "node",
@@ -349,12 +352,12 @@ func TestPipelinesService_Update(t *testing.T) {
 				},
 			},
 		},
-		Slug:       String("my-great-repo"),
-		Visibility: String("public"),
+		Slug:       "my-great-repo",
+		Visibility: "public",
 		Tags:       []string{"fresh-tag"},
 	}
 
-	if diff := cmp.Diff(pipeline, want); diff != "" {
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Pipelines.Update diff: (-got +want)\n%s", diff)
 	}
 }

--- a/buildkite/providers.go
+++ b/buildkite/providers.go
@@ -5,7 +5,7 @@ import "encoding/json"
 // Provider represents a source code provider. It is read-only, but settings may be written using Pipeline.ProviderSettings.
 type Provider struct {
 	ID         string           `json:"id"`
-	WebhookURL *string          `json:"webhook_url"`
+	WebhookURL string           `json:"webhook_url"`
 	Settings   ProviderSettings `json:"settings"`
 }
 
@@ -53,59 +53,59 @@ type ProviderSettings interface {
 
 // BitbucketSettings are settings for pipelines building from Bitbucket repositories.
 type BitbucketSettings struct {
-	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
-	BuildBranches                           *bool   `json:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
-	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildTags                               *bool   `json:"build_tags,omitempty"`
-	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
+	BuildPullRequests                       bool   `json:"build_pull_requests,omitempty"`
+	BuildBranches                           bool   `json:"build_branches,omitempty"`
+	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    string `json:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildTags                               bool   `json:"build_tags,omitempty"`
+	PublishCommitStatus                     bool   `json:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step,omitempty"`
 
 	// Read-only
-	Repository *string `json:"repository,omitempty"`
+	Repository string `json:"repository,omitempty"`
 }
 
 func (s *BitbucketSettings) isProviderSettings() {}
 
 // GitHubSettings are settings for pipelines building from GitHub repositories.
 type GitHubSettings struct {
-	TriggerMode                             *string `json:"trigger_mode,omitempty"`
-	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
-	BuildBranches                           *bool   `json:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
-	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildPullRequestForks                   *bool   `json:"build_pull_request_forks,omitempty"`
-	PrefixPullRequestForkBranchNames        *bool   `json:"prefix_pull_request_fork_branch_names,omitempty"`
-	BuildTags                               *bool   `json:"build_tags,omitempty"`
-	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
-	FilterEnabled                           *bool   `json:"filter_enabled,omitempty"`
-	FilterCondition                         *string `json:"filter_condition,omitempty"`
-	SeparatePullRequestStatuses             *bool   `json:"separate_pull_request_statuses,omitempty"`
-	PublishBlockedAsPending                 *bool   `json:"publish_blocked_as_pending,omitempty"`
+	TriggerMode                             string `json:"trigger_mode,omitempty"`
+	BuildPullRequests                       bool   `json:"build_pull_requests,omitempty"`
+	BuildBranches                           bool   `json:"build_branches,omitempty"`
+	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    string `json:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildPullRequestForks                   bool   `json:"build_pull_request_forks,omitempty"`
+	PrefixPullRequestForkBranchNames        bool   `json:"prefix_pull_request_fork_branch_names,omitempty"`
+	BuildTags                               bool   `json:"build_tags,omitempty"`
+	PublishCommitStatus                     bool   `json:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step,omitempty"`
+	FilterEnabled                           bool   `json:"filter_enabled,omitempty"`
+	FilterCondition                         string `json:"filter_condition,omitempty"`
+	SeparatePullRequestStatuses             bool   `json:"separate_pull_request_statuses,omitempty"`
+	PublishBlockedAsPending                 bool   `json:"publish_blocked_as_pending,omitempty"`
 
 	// Read-only
-	Repository *string `json:"repository,omitempty"`
+	Repository string `json:"repository,omitempty"`
 }
 
 func (s *GitHubSettings) isProviderSettings() {}
 
 // GitHubEnterpriseSettings are settings for pipelines building from GitHub Enterprise repositories.
 type GitHubEnterpriseSettings struct {
-	TriggerMode                             *string `json:"trigger_mode,omitempty"`
-	BuildPullRequests                       *bool   `json:"build_pull_requests,omitempty"`
-	BuildBranches                           *bool   `json:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          *bool   `json:"pull_request_branch_filter_enabled,omitempty"`
-	PullRequestBranchFilterConfiguration    *string `json:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits *bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildTags                               *bool   `json:"build_tags,omitempty"`
-	PublishCommitStatus                     *bool   `json:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              *bool   `json:"publish_commit_status_per_step,omitempty"`
+	TriggerMode                             string `json:"trigger_mode,omitempty"`
+	BuildPullRequests                       bool   `json:"build_pull_requests,omitempty"`
+	BuildBranches                           bool   `json:"build_branches,omitempty"`
+	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	PullRequestBranchFilterConfiguration    string `json:"pull_request_branch_filter_configuration,omitempty"`
+	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
+	BuildTags                               bool   `json:"build_tags,omitempty"`
+	PublishCommitStatus                     bool   `json:"publish_commit_status,omitempty"`
+	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step,omitempty"`
 
 	// Read-only
-	Repository *string `json:"repository,omitempty"`
+	Repository string `json:"repository,omitempty"`
 }
 
 func (s *GitHubEnterpriseSettings) isProviderSettings() {}
@@ -113,7 +113,7 @@ func (s *GitHubEnterpriseSettings) isProviderSettings() {}
 // GitLabSettings are settings for pipelines building from GitLab repositories.
 type GitLabSettings struct {
 	// Read-only
-	Repository *string `json:"repository,omitempty"`
+	Repository string `json:"repository,omitempty"`
 }
 
 func (s *GitLabSettings) isProviderSettings() {}

--- a/buildkite/providers_test.go
+++ b/buildkite/providers_test.go
@@ -16,7 +16,7 @@ func TestUnmarshalBitbucketProvider(t *testing.T) {
 
 	want := Provider{
 		ID:       "bitbucket",
-		Settings: &BitbucketSettings{Repository: String("my-bitbucket-repo")},
+		Settings: &BitbucketSettings{Repository: "my-bitbucket-repo"},
 	}
 
 	if diff := cmp.Diff(provider, want); diff != "" {
@@ -33,7 +33,7 @@ func TestUnmarshalGitHubProvider(t *testing.T) {
 
 	want := Provider{
 		ID:       "github",
-		Settings: &GitHubSettings{Repository: String("my-github-repo")},
+		Settings: &GitHubSettings{Repository: "my-github-repo"},
 	}
 
 	if diff := cmp.Diff(provider, want); diff != "" {
@@ -50,7 +50,7 @@ func TestUnmarshalGitHubEnterpriseProvider(t *testing.T) {
 
 	want := Provider{
 		ID:       "github_enterprise",
-		Settings: &GitHubEnterpriseSettings{Repository: String("my-github-enterprise-repo")},
+		Settings: &GitHubEnterpriseSettings{Repository: "my-github-enterprise-repo"},
 	}
 
 	if diff := cmp.Diff(provider, want); diff != "" {
@@ -67,7 +67,7 @@ func TestUnmarshalGitLabProvider(t *testing.T) {
 
 	want := Provider{
 		ID:       "gitlab",
-		Settings: &GitLabSettings{Repository: String("my-gitlab-repo")},
+		Settings: &GitLabSettings{Repository: "my-gitlab-repo"},
 	}
 
 	if diff := cmp.Diff(provider, want); diff != "" {

--- a/buildkite/teams.go
+++ b/buildkite/teams.go
@@ -18,12 +18,12 @@ type TeamsService struct {
 
 // Team represents a buildkite team.
 type Team struct {
-	ID          *string    `json:"id,omitempty"`
-	Name        *string    `json:"name,omitempty"`
-	Slug        *string    `json:"slug,omitempty"`
-	Description *string    `json:"description,omitempty"`
-	Privacy     *string    `json:"privacy,omitempty"`
-	Default     *bool      `json:"default,omitempty"`
+	ID          string     `json:"id,omitempty"`
+	Name        string     `json:"name,omitempty"`
+	Slug        string     `json:"slug,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Privacy     string     `json:"privacy,omitempty"`
+	Default     bool       `json:"default,omitempty"`
 	CreatedAt   *Timestamp `json:"created_at,omitempty"`
 	CreatedBy   *User      `json:"created_by,omitempty"`
 }
@@ -39,10 +39,7 @@ type TeamsListOptions struct {
 //
 // buildkite API docs: https://buildkite.com/docs/api
 func (ts *TeamsService) List(ctx context.Context, org string, opt *TeamsListOptions) ([]Team, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/organizations/%s/teams", org)
-
+	u := fmt.Sprintf("v2/organizations/%s/teams", org)
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -53,11 +50,11 @@ func (ts *TeamsService) List(ctx context.Context, org string, opt *TeamsListOpti
 		return nil, nil, err
 	}
 
-	teams := new([]Team)
-	resp, err := ts.client.Do(req, teams)
+	var teams []Team
+	resp, err := ts.client.Do(req, &teams)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *teams, resp, err
+	return teams, resp, err
 }

--- a/buildkite/teams_test.go
+++ b/buildkite/teams_test.go
@@ -25,7 +25,7 @@ func TestTeamsService_List(t *testing.T) {
 		t.Errorf("Teams.List returned error: %v", err)
 	}
 
-	want := []Team{{ID: String("123")}, {ID: String("1234")}}
+	want := []Team{{ID: "123"}, {ID: "1234"}}
 	if diff := cmp.Diff(teams, want); diff != "" {
 		t.Errorf("Teams.List diff: (-got +want)\n%s", diff)
 	}
@@ -51,7 +51,7 @@ func TestTeamsService_ListForUser(t *testing.T) {
 		t.Errorf("Teams.List returned error: %v", err)
 	}
 
-	want := []Team{{ID: String("123")}}
+	want := []Team{{ID: "123"}}
 	if diff := cmp.Diff(teams, want); diff != "" {
 		t.Errorf("Teams.List diff: (-got +want)\n%s", diff)
 	}

--- a/buildkite/test_runs.go
+++ b/buildkite/test_runs.go
@@ -14,11 +14,11 @@ type TestRunsService struct {
 }
 
 type TestRun struct {
-	ID        *string    `json:"id,omitempty"`
-	URL       *string    `json:"url,omitempty"`
-	WebURL    *string    `json:"web_url,omitempty"`
-	Branch    *string    `json:"branch,omitempty"`
-	CommitSHA *string    `json:"commit_sha,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	URL       string     `json:"url,omitempty"`
+	WebURL    string     `json:"web_url,omitempty"`
+	Branch    string     `json:"branch,omitempty"`
+	CommitSHA string     `json:"commit_sha,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
@@ -27,48 +27,37 @@ type TestRunsListOptions struct {
 }
 
 func (trs *TestRunsService) List(ctx context.Context, org, slug string, opt *TestRunsListOptions) ([]TestRun, *Response, error) {
-
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/runs", org, slug)
-
 	u, err := addOptions(u, opt)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req, err := trs.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	testRuns := new([]TestRun)
-
-	resp, err := trs.client.Do(req, testRuns)
-
+	var testRuns []TestRun
+	resp, err := trs.client.Do(req, &testRuns)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *testRuns, resp, err
+	return testRuns, resp, err
 }
 
-func (trs *TestRunsService) Get(ctx context.Context, org, slug, runID string) (*TestRun, *Response, error) {
-
+func (trs *TestRunsService) Get(ctx context.Context, org, slug, runID string) (TestRun, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/runs/%s", org, slug, runID)
-
 	req, err := trs.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
-		return nil, nil, err
+		return TestRun{}, nil, err
 	}
 
-	testRun := new(TestRun)
-
-	resp, err := trs.client.Do(req, testRun)
-
+	var testRun TestRun
+	resp, err := trs.client.Do(req, &testRun)
 	if err != nil {
-		return nil, resp, err
+		return TestRun{}, resp, err
 	}
 
 	return testRun, resp, err

--- a/buildkite/test_runs_test.go
+++ b/buildkite/test_runs_test.go
@@ -56,19 +56,19 @@ func TestTestRunsService_List(t *testing.T) {
 
 	want := []TestRun{
 		{
-			ID:        String("3c90a8ad-8e86-4e78-87b4-acae5e808de4"),
-			URL:       String("https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4"),
-			WebURL:    String("https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4"),
-			Branch:    String("main"),
-			CommitSHA: String("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"),
+			ID:        "3c90a8ad-8e86-4e78-87b4-acae5e808de4",
+			URL:       "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4",
+			WebURL:    "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4",
+			Branch:    "main",
+			CommitSHA: "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
 			CreatedAt: NewTimestamp(parsedTime1),
 		},
 		{
-			ID:        String("70fe7e45-c9e4-446b-95e3-c50d61519b87"),
-			URL:       String("https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/runs/70fe7e45-c9e4-446b-95e3-c50d61519b87"),
-			WebURL:    String("https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/runs/70fe7e45-c9e4-446b-95e3-c50d61519b87"),
-			Branch:    String("main"),
-			CommitSHA: String("109f4b3c50d7b0df729d299bc6f8e9ef9066971f"),
+			ID:        "70fe7e45-c9e4-446b-95e3-c50d61519b87",
+			URL:       "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/runs/70fe7e45-c9e4-446b-95e3-c50d61519b87",
+			WebURL:    "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/runs/70fe7e45-c9e4-446b-95e3-c50d61519b87",
+			Branch:    "main",
+			CommitSHA: "109f4b3c50d7b0df729d299bc6f8e9ef9066971f",
 			CreatedAt: NewTimestamp(parsedTime2),
 		},
 	}
@@ -99,25 +99,22 @@ func TestTestRunsService_Get(t *testing.T) {
 	})
 
 	run, _, err := client.TestRuns.Get(context.Background(), "my-great-org", "suite-example", "3c90a8ad-8e86-4e78-87b4-acae5e808de4")
-
 	if err != nil {
 		t.Errorf("TestSuites.Get returned error: %v", err)
 	}
 
 	// Create Time instance from string in BuildKiteDateFormat friendly format
 	parsedTime, err := time.Parse(BuildKiteDateFormat, "2023-05-20T10:25:50.264Z")
-
 	if err != nil {
 		t.Errorf("TestSuites.Get time.Parse error: %v", err)
 	}
 
-	want := &TestRun{
-
-		ID:        String("3c90a8ad-8e86-4e78-87b4-acae5e808de4"),
-		URL:       String("https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4"),
-		WebURL:    String("https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4"),
-		Branch:    String("main"),
-		CommitSHA: String("a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"),
+	want := TestRun{
+		ID:        "3c90a8ad-8e86-4e78-87b4-acae5e808de4",
+		URL:       "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4",
+		WebURL:    "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4",
+		Branch:    "main",
+		CommitSHA: "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
 		CreatedAt: NewTimestamp(parsedTime),
 	}
 

--- a/buildkite/test_suites.go
+++ b/buildkite/test_suites.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"context"
-	"errors"
 	"fmt"
 )
 
@@ -22,116 +21,89 @@ type TestSuiteCreate struct {
 }
 
 type TestSuite struct {
-	ID            *string `json:"id,omitempty"`
-	GraphQLID     *string `json:"graphql_id,omitempty"`
-	Slug          *string `json:"slug,omitempty"`
-	Name          *string `json:"name,omitempty"`
-	URL           *string `json:"url,omitempty"`
-	WebURL        *string `json:"web_url,omitempty"`
-	DefaultBranch *string `json:"default_branch,omitempty"`
+	ID            string `json:"id,omitempty"`
+	GraphQLID     string `json:"graphql_id,omitempty"`
+	Slug          string `json:"slug,omitempty"`
+	Name          string `json:"name,omitempty"`
+	URL           string `json:"url,omitempty"`
+	WebURL        string `json:"web_url,omitempty"`
+	DefaultBranch string `json:"default_branch,omitempty"`
 }
 
-type TestSuiteListOptions struct {
-	ListOptions
-}
+type TestSuiteListOptions struct{ ListOptions }
 
 func (tss *TestSuitesService) List(ctx context.Context, org string, opt *TestSuiteListOptions) ([]TestSuite, *Response, error) {
-
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites", org)
-
 	u, err := addOptions(u, opt)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
 	req, err := tss.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
 		return nil, nil, err
 	}
 
-	testSuites := new([]TestSuite)
-
-	resp, err := tss.client.Do(req, testSuites)
-
+	var testSuites []TestSuite
+	resp, err := tss.client.Do(req, &testSuites)
 	if err != nil {
 		return nil, resp, err
 	}
 
-	return *testSuites, resp, err
+	return testSuites, resp, err
 }
 
-func (tss *TestSuitesService) Get(ctx context.Context, org, slug string) (*TestSuite, *Response, error) {
-
+func (tss *TestSuitesService) Get(ctx context.Context, org, slug string) (TestSuite, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, slug)
-
 	req, err := tss.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
-		return nil, nil, err
+		return TestSuite{}, nil, err
 	}
 
-	testSuite := new(TestSuite)
-
-	resp, err := tss.client.Do(req, testSuite)
-
+	var testSuite TestSuite
+	resp, err := tss.client.Do(req, &testSuite)
 	if err != nil {
-		return nil, resp, err
+		return TestSuite{}, resp, err
 	}
 
 	return testSuite, resp, err
 }
 
-func (tss *TestSuitesService) Create(ctx context.Context, org string, ts *TestSuiteCreate) (*TestSuite, *Response, error) {
-
+func (tss *TestSuitesService) Create(ctx context.Context, org string, ts TestSuiteCreate) (TestSuite, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites", org)
-
 	req, err := tss.client.NewRequest(ctx, "POST", u, ts)
-
 	if err != nil {
-		return nil, nil, err
+		return TestSuite{}, nil, err
 	}
 
-	testSuite := new(TestSuite)
-	resp, err := tss.client.Do(req, testSuite)
-
+	var testSuite TestSuite
+	resp, err := tss.client.Do(req, &testSuite)
 	if err != nil {
-		return nil, resp, err
+		return TestSuite{}, resp, err
 	}
 
 	return testSuite, resp, err
 }
 
-func (tss *TestSuitesService) Update(ctx context.Context, org string, ts *TestSuite) (*Response, error) {
-
-	if ts == nil {
-		return nil, errors.New("Test suite must not be nil")
-	}
-
-	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, *ts.Slug)
-
+func (tss *TestSuitesService) Update(ctx context.Context, org, slug string, ts TestSuite) (TestSuite, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, slug)
 	req, err := tss.client.NewRequest(ctx, "PATCH", u, ts)
-
 	if err != nil {
-		return nil, nil
+		return TestSuite{}, nil, nil
 	}
 
-	resp, err := tss.client.Do(req, ts)
-
+	var out TestSuite
+	resp, err := tss.client.Do(req, &out)
 	if err != nil {
-		return resp, err
+		return TestSuite{}, resp, err
 	}
 
-	return resp, err
+	return out, resp, err
 }
 
 func (tss *TestSuitesService) Delete(ctx context.Context, org, slug string) (*Response, error) {
-
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, slug)
-
 	req, err := tss.client.NewRequest(ctx, "DELETE", u, nil)
-
 	if err != nil {
 		return nil, err
 	}

--- a/buildkite/test_suites_test.go
+++ b/buildkite/test_suites_test.go
@@ -50,22 +50,22 @@ func TestTestSuitesService_List(t *testing.T) {
 
 	want := []TestSuite{
 		{
-			ID:            String("7c202aaa-3165-4811-9813-173c4c285463"),
-			GraphQLID:     String("N2MyMDJhYWEtMzE2NS00ODExLTk4MTMtMTczYzRjMjg1NDYz="),
-			Slug:          String("suite-1"),
-			Name:          String("suite-1"),
-			URL:           String("https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-1"),
-			WebURL:        String("https://buildkite.com/organizations/my-great-org/analytics/suites/suite-1"),
-			DefaultBranch: String("main"),
+			ID:            "7c202aaa-3165-4811-9813-173c4c285463",
+			GraphQLID:     "N2MyMDJhYWEtMzE2NS00ODExLTk4MTMtMTczYzRjMjg1NDYz=",
+			Slug:          "suite-1",
+			Name:          "suite-1",
+			URL:           "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-1",
+			WebURL:        "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-1",
+			DefaultBranch: "main",
 		},
 		{
-			ID:            String("38ed1d73-cea9-4aba-b223-def25e66ef51"),
-			GraphQLID:     String("MzhlZDFkNzMtY2VhOS00YWJhLWIyMjMtZGVmMjVlNjZlZjUx="),
-			Slug:          String("suite-2"),
-			Name:          String("suite-2"),
-			URL:           String("https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-2"),
-			WebURL:        String("https://buildkite.com/organizations/my-great-org/analytics/suites/suite-2"),
-			DefaultBranch: String("main"),
+			ID:            "38ed1d73-cea9-4aba-b223-def25e66ef51",
+			GraphQLID:     "MzhlZDFkNzMtY2VhOS00YWJhLWIyMjMtZGVmMjVlNjZlZjUx=",
+			Slug:          "suite-2",
+			Name:          "suite-2",
+			URL:           "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-2",
+			WebURL:        "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-2",
+			DefaultBranch: "main",
 		},
 	}
 	if diff := cmp.Diff(suites, want); diff != "" {
@@ -100,14 +100,14 @@ func TestTestSuitesService_Get(t *testing.T) {
 		t.Errorf("TestSuites.Get returned error: %v", err)
 	}
 
-	want := &TestSuite{
-		ID:            String("7c202aaa-3165-4811-9813-173c4c285463"),
-		GraphQLID:     String("N2MyMDJhYWEtMzE2NS00ODExLTk4MTMtMTczYzRjMjg1NDYz="),
-		Slug:          String("suite-1"),
-		Name:          String("suite-1"),
-		URL:           String("https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-1"),
-		WebURL:        String("https://buildkite.com/organizations/my-great-org/analytics/suites/suite-1"),
-		DefaultBranch: String("main"),
+	want := TestSuite{
+		ID:            "7c202aaa-3165-4811-9813-173c4c285463",
+		GraphQLID:     "N2MyMDJhYWEtMzE2NS00ODExLTk4MTMtMTczYzRjMjg1NDYz=",
+		Slug:          "suite-1",
+		Name:          "suite-1",
+		URL:           "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-1",
+		WebURL:        "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-1",
+		DefaultBranch: "main",
 	}
 
 	if diff := cmp.Diff(suite, want); diff != "" {
@@ -121,14 +121,14 @@ func TestTestSuitesService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &TestSuiteCreate{
+	input := TestSuiteCreate{
 		Name:          "Suite 3",
 		DefaultBranch: "main",
 		TeamUUIDs:     []string{"8369b300-fff0-4ef1-91de-010f72f4458d"},
 	}
 
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
-		v := new(TestSuiteCreate)
+		var v TestSuiteCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -152,9 +152,9 @@ func TestTestSuitesService_Create(t *testing.T) {
 		t.Errorf("TestSuites.Create returned error: %v", err)
 	}
 
-	want := &TestSuite{
-		Name:          String("Suite 3"),
-		DefaultBranch: String("main"),
+	want := TestSuite{
+		Name:          "Suite 3",
+		DefaultBranch: "main",
 	}
 
 	if diff := cmp.Diff(suite, want); diff != "" {
@@ -168,14 +168,14 @@ func TestTestSuitesService_Update(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := &TestSuiteCreate{
+	input := TestSuiteCreate{
 		Name:          "Suite 4",
 		DefaultBranch: "main",
 		TeamUUIDs:     []string{"818b0849-9718-4898-8de3-42d591a7fe26"},
 	}
 
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
-		v := new(TestSuiteCreate)
+		var v TestSuiteCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "POST")
@@ -195,16 +195,12 @@ func TestTestSuitesService_Update(t *testing.T) {
 	})
 
 	suite, _, err := client.TestSuites.Create(context.Background(), "my-great-org", input)
-
 	if err != nil {
 		t.Errorf("TestSuites.Create returned error: %v", err)
 	}
 
-	// Lets update the default branch to develop
-	suite.DefaultBranch = String("develop")
-
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-4", func(w http.ResponseWriter, r *http.Request) {
-		v := new(TestSuiteCreate)
+		var v TestSuiteCreate
 		json.NewDecoder(r.Body).Decode(&v)
 
 		testMethod(t, r, "PATCH")
@@ -219,19 +215,18 @@ func TestTestSuitesService_Update(t *testing.T) {
 			}`)
 	})
 
-	_, err = client.TestSuites.Update(context.Background(), "my-great-org", suite)
-
+	got, _, err := client.TestSuites.Update(context.Background(), "my-great-org", suite.Slug, TestSuite{DefaultBranch: "default"})
 	if err != nil {
 		t.Errorf("Pipelines.Update returned error: %v", err)
 	}
 
-	want := &TestSuite{
-		Name:          String("Suite 4"),
-		Slug:          String("suite-4"),
-		DefaultBranch: String("develop"),
+	want := TestSuite{
+		Name:          "Suite 4",
+		Slug:          "suite-4",
+		DefaultBranch: "develop",
 	}
 
-	if diff := cmp.Diff(suite, want); diff != "" {
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("TestSuites.Update diff: (-got +want)\n%s", diff)
 	}
 }

--- a/buildkite/tests.go
+++ b/buildkite/tests.go
@@ -14,32 +14,28 @@ type TestsService struct {
 }
 
 type Test struct {
-	ID       *string `json:"id,omitempty"`
-	URL      *string `json:"url,omitempty"`
-	WebURL   *string `json:"web_url,omitempty"`
-	Scope    *string `json:"scope,omitempty"`
-	Name     *string `json:"name,omitempty"`
-	Location *string `json:"location,omitempty"`
-	FileName *string `json:"file_name,omitempty"`
+	ID       string `json:"id,omitempty"`
+	URL      string `json:"url,omitempty"`
+	WebURL   string `json:"web_url,omitempty"`
+	Scope    string `json:"scope,omitempty"`
+	Name     string `json:"name,omitempty"`
+	Location string `json:"location,omitempty"`
+	FileName string `json:"file_name,omitempty"`
 }
 
-func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (*Test, *Response, error) {
-
+func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (Test, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/%s", org, slug, testID)
-
 	req, err := ts.client.NewRequest(ctx, "GET", u, nil)
-
 	if err != nil {
-		return nil, nil, err
+		return Test{}, nil, err
 	}
 
-	test := new(Test)
-
-	resp, err := ts.client.Do(req, test)
+	var t Test
+	resp, err := ts.client.Do(req, &t)
 
 	if err != nil {
-		return nil, resp, err
+		return Test{}, resp, err
 	}
 
-	return test, resp, err
+	return t, resp, err
 }

--- a/buildkite/tests_test.go
+++ b/buildkite/tests_test.go
@@ -30,23 +30,22 @@ func TestTestsService_Get(t *testing.T) {
 			}`)
 	})
 
-	test, _, err := client.Tests.Get(context.Background(), "my-great-org", "suite-example", "b3abe2e9-35c5-4905-85e1-8c9f2da3240f")
-
+	got, _, err := client.Tests.Get(context.Background(), "my-great-org", "suite-example", "b3abe2e9-35c5-4905-85e1-8c9f2da3240f")
 	if err != nil {
 		t.Errorf("TestSuites.Get returned error: %v", err)
 	}
 
-	want := &Test{
-		ID:       String("b3abe2e9-35c5-4905-85e1-8c9f2da3240f"),
-		URL:      String("https://api.buildkite.com/v2/analytics/organizations/my-great-org/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f"),
-		WebURL:   String("https://buildkite.com/organizations/my-great-org/analytics/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f"),
-		Name:     String("TestExample1_Create"),
-		Scope:    String("User#email"),
-		Location: String("./resources/test_example_test.go:123"),
-		FileName: String("./resources/test_example_test.go"),
+	want := Test{
+		ID:       "b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+		URL:      "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+		WebURL:   "https://buildkite.com/organizations/my-great-org/analytics/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+		Name:     "TestExample1_Create",
+		Scope:    "User#email",
+		Location: "./resources/test_example_test.go:123",
+		FileName: "./resources/test_example_test.go",
 	}
 
-	if diff := cmp.Diff(test, want); diff != "" {
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("TestsService.Get diff: (-got +want)\n%s", diff)
 	}
 }

--- a/buildkite/user.go
+++ b/buildkite/user.go
@@ -15,29 +15,26 @@ type UserService struct {
 
 // User represents a buildkite user.
 type User struct {
-	ID        *string    `json:"id,omitempty"`
-	Name      *string    `json:"name,omitempty"`
-	Email     *string    `json:"email,omitempty"`
+	ID        string     `json:"id,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	Email     string     `json:"email,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
 // Get the current user.
 //
 // buildkite API docs: https://buildkite.com/docs/api
-func (os *UserService) Get(ctx context.Context) (*User, *Response, error) {
-	var u string
-
-	u = fmt.Sprintf("v2/user")
-
-	req, err := os.client.NewRequest(ctx, "GET", u, nil)
+func (us *UserService) Get(ctx context.Context) (User, *Response, error) {
+	u := fmt.Sprintf("v2/user")
+	req, err := us.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, err
+		return User{}, nil, err
 	}
 
-	user := new(User)
-	resp, err := os.client.Do(req, user)
+	var user User
+	resp, err := us.client.Do(req, &user)
 	if err != nil {
-		return nil, resp, err
+		return User{}, resp, err
 	}
 
 	return user, resp, err

--- a/buildkite/user.go
+++ b/buildkite/user.go
@@ -21,10 +21,10 @@ type User struct {
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
-// Get the current user.
+// CurrentUser returns the user associated with the access token being used
 //
 // buildkite API docs: https://buildkite.com/docs/api
-func (us *UserService) Get(ctx context.Context) (User, *Response, error) {
+func (us *UserService) CurrentUser(ctx context.Context) (User, *Response, error) {
 	u := fmt.Sprintf("v2/user")
 	req, err := us.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {

--- a/buildkite/user_test.go
+++ b/buildkite/user_test.go
@@ -25,7 +25,7 @@ func TestUserService_Get(t *testing.T) {
 		t.Errorf("User.Get returned error: %v", err)
 	}
 
-	want := &User{ID: String("123"), Name: String("Jane Doe"), Email: String("jane@doe.com")}
+	want := User{ID: "123", Name: "Jane Doe", Email: "jane@doe.com"}
 	if diff := cmp.Diff(user, want); diff != "" {
 		t.Errorf("User.Get diff: (-got +want)\n%s", diff)
 	}

--- a/buildkite/user_test.go
+++ b/buildkite/user_test.go
@@ -20,7 +20,7 @@ func TestUserService_Get(t *testing.T) {
 		fmt.Fprint(w, `{"id":"123","name":"Jane Doe","email":"jane@doe.com"}`)
 	})
 
-	user, _, err := client.User.Get(context.Background())
+	user, _, err := client.User.CurrentUser(context.Background())
 	if err != nil {
 		t.Errorf("User.Get returned error: %v", err)
 	}

--- a/buildkite/webhook.go
+++ b/buildkite/webhook.go
@@ -57,7 +57,7 @@ func ParseWebHook(messageType string, payload []byte) (interface{}, error) {
 	}
 
 	event := Event{
-		Type:       &eventType,
+		Type:       eventType,
 		RawPayload: (*json.RawMessage)(&payload),
 	}
 	return event.ParsePayload()
@@ -143,7 +143,7 @@ func ValidatePayload(r *http.Request, secretKey []byte) (payload []byte, err err
 
 // Event represents a Buildkite webhook event
 type Event struct {
-	Type       *string          `json:"type"`
+	Type       string           `json:"type"`
 	RawPayload *json.RawMessage `json:"payload,omitempty"`
 }
 
@@ -157,7 +157,7 @@ type Event struct {
 //
 // Example usage:
 func (e *Event) ParsePayload() (payload interface{}, err error) {
-	switch *e.Type {
+	switch e.Type {
 	case "AgentConnectedEvent":
 		payload = &AgentConnectedEvent{}
 	case "AgentDisconnectedEvent":

--- a/buildkite/webhook_events.go
+++ b/buildkite/webhook_events.go
@@ -4,9 +4,9 @@ package buildkite
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/agent-events
 type AgentEvent struct {
-	Event  *string `json:"event"`
-	Agent  *Agent  `json:"agent"`
-	Sender *User   `json:"sender"`
+	Event  string `json:"event"`
+	Agent  Agent  `json:"agent"`
+	Sender User   `json:"sender"`
 }
 
 // AgentConnectedEvent is triggered when an agent has connected to the API
@@ -48,10 +48,10 @@ type AgentStoppingEvent struct {
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/build-events
 type BuildEvent struct {
-	Event    *string   `json:"event"`
-	Build    *Build    `json:"build"`
-	Pipeline *Pipeline `json:"pipeline"`
-	Sender   *User     `json:"sender"`
+	Event    string   `json:"event"`
+	Build    Build    `json:"build"`
+	Pipeline Pipeline `json:"pipeline"`
+	Sender   User     `json:"sender"`
 }
 
 // BuildFailingEvent is triggered when a build enters a failing state
@@ -86,11 +86,11 @@ type BuildScheduledEvent struct {
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/job-events
 type JobEvent struct {
-	Event    *string   `json:"event"`
-	Build    *Build    `json:"build"`
-	Job      *Job      `json:"job"`
-	Pipeline *Pipeline `json:"pipeline"`
-	Sender   *User     `json:"sender"`
+	Event    string   `json:"event"`
+	Build    Build    `json:"build"`
+	Job      Job      `json:"job"`
+	Pipeline Pipeline `json:"pipeline"`
+	Sender   User     `json:"sender"`
 }
 
 // JobActivatedEvent is triggered when a job is activated
@@ -125,7 +125,7 @@ type JobStartedEvent struct {
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/webhooks/ping-events
 type PingEvent struct {
-	Event        *string       `json:"event"`
-	Organization *Organization `json:"organization"`
-	Sender       *User         `json:"sender"`
+	Event        string       `json:"event"`
+	Organization Organization `json:"organization"`
+	Sender       User         `json:"sender"`
 }

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -29,20 +29,18 @@ func main() {
 	}
 
 	annotationCreate := buildkite.AnnotationCreate{
-		Style:   buildkite.String("info"),
-		Context: buildkite.String("default"),
-		Body:    buildkite.String("An example annotation!"),
-		Append:  buildkite.Bool(false),
+		Style:   "info",
+		Context: "default",
+		Body:    "An example annotation!",
+		Append:  false,
 	}
 
-	annotation, _, err := client.Annotations.Create(context.Background(), *org, *slug, *number, &annotationCreate)
-
+	annotation, _, err := client.Annotations.Create(context.Background(), *org, *slug, *number, annotationCreate)
 	if err != nil {
 		log.Fatalf("Listing annotations for build %s in pipeline %s failed: %s", *number, *slug, err)
 	}
 
 	data, err := json.MarshalIndent(annotation, "", "\t")
-
 	if err != nil {
 		log.Fatalf("json encode failed: %s", err)
 	}

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -44,8 +44,8 @@ func main() {
 
 			fmt.Fprintf(os.Stdout, "%s\n", string(data))
 		} else {
-			if *artifactName == *artifact.Filename || *artifactName == *artifact.ID {
-				_, err := client.Artifacts.DownloadArtifactByURL(context.Background(), *artifact.DownloadURL, os.Stdout)
+			if *artifactName == artifact.Filename || *artifactName == artifact.ID {
+				_, err := client.Artifacts.DownloadArtifactByURL(context.Background(), artifact.DownloadURL, os.Stdout)
 				if err != nil {
 					log.Fatalf("DownloadArtifactByURL failed: %s", err)
 				}

--- a/examples/cluster_queues/create/main.go
+++ b/examples/cluster_queues/create/main.go
@@ -28,11 +28,11 @@ func main() {
 	}
 
 	clusterQueueCreate := buildkite.ClusterQueueCreate{
-		Key:         buildkite.String("dev1"),
-		Description: buildkite.String("Development 1 Cluster queue"),
+		Key:         "dev1",
+		Description: "Development 1 Cluster queue",
 	}
 
-	queue, _, err := client.ClusterQueues.Create(context.Background(), *org, *clusterID, &clusterQueueCreate)
+	queue, _, err := client.ClusterQueues.Create(context.Background(), *org, *clusterID, clusterQueueCreate)
 
 	if err != nil {
 		log.Fatalf("Creating cluster queue failed: %s", err)

--- a/examples/cluster_queues/pause/main.go
+++ b/examples/cluster_queues/pause/main.go
@@ -15,6 +15,7 @@ var (
 	org       = kingpin.Flag("org", "Orginization slug").Required().String()
 	clusterID = kingpin.Flag("clusterID", "Cluster UUID").Required().String()
 	queueID   = kingpin.Flag("queueID", "Cluster queue UUID").Required().String()
+	pauseNote = kingpin.Flag("note", "Note to add to the pause").String()
 	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
@@ -26,15 +27,11 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterQueuePause := buildkite.ClusterQueuePause{
-		Note: "Pausing dispatch over the weekend",
-	}
-
-	resp, err := client.ClusterQueues.Pause(context.Background(), *org, *clusterID, *queueID, clusterQueuePause)
-
+	clusterQueuePause := buildkite.ClusterQueuePause{Note: *pauseNote}
+	cq, _, err := client.ClusterQueues.Pause(context.Background(), *org, *clusterID, *queueID, clusterQueuePause)
 	if err != nil {
 		log.Fatalf("Pausing dispatch on cluster queue %s failed: %s", *queueID, err)
 	}
 
-	fmt.Println(resp.StatusCode)
+	fmt.Printf("Paused dispatch on cluster queue: %s with reason %q\n", cq.ID, cq.DispatchPausedNote)
 }

--- a/examples/cluster_queues/pause/main.go
+++ b/examples/cluster_queues/pause/main.go
@@ -27,10 +27,10 @@ func main() {
 	}
 
 	clusterQueuePause := buildkite.ClusterQueuePause{
-		Note: buildkite.String("Pausing dispatch over the weekend"),
+		Note: "Pausing dispatch over the weekend",
 	}
 
-	resp, err := client.ClusterQueues.Pause(context.Background(), *org, *clusterID, *queueID, &clusterQueuePause)
+	resp, err := client.ClusterQueues.Pause(context.Background(), *org, *clusterID, *queueID, clusterQueuePause)
 
 	if err != nil {
 		log.Fatalf("Pausing dispatch on cluster queue %s failed: %s", *queueID, err)

--- a/examples/cluster_queues/update/main.go
+++ b/examples/cluster_queues/update/main.go
@@ -26,10 +26,10 @@ func main() {
 	}
 
 	clusterQueueUpdate := buildkite.ClusterQueueUpdate{
-		Description: buildkite.String("Development team cluster queue"),
+		Description: "Development team cluster queue",
 	}
 
-	resp, err := client.ClusterQueues.Update(context.Background(), *org, *clusterID, *queueID, &clusterQueueUpdate)
+	resp, err := client.ClusterQueues.Update(context.Background(), *org, *clusterID, *queueID, clusterQueueUpdate)
 
 	if err != nil {
 		log.Fatalf("Updating cluster queue failed: %s", err)

--- a/examples/cluster_queues/update/main.go
+++ b/examples/cluster_queues/update/main.go
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	apiToken  = kingpin.Flag("token", "API token").Required().String()
-	org       = kingpin.Flag("org", "Orginization slug").Required().String()
-	clusterID = kingpin.Flag("clusterID", "Cluster UUID").Required().String()
-	queueID   = kingpin.Flag("queueID", "Cluster queue UUID").Required().String()
-	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
+	apiToken       = kingpin.Flag("token", "API token").Required().String()
+	org            = kingpin.Flag("org", "Orginization slug").Required().String()
+	clusterID      = kingpin.Flag("clusterID", "Cluster UUID").Required().String()
+	queueID        = kingpin.Flag("queueID", "Cluster queue UUID").Required().String()
+	newDescription = kingpin.Flag("description", "New description for the cluster queue").Required().String()
+	debug          = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
 func main() {
@@ -25,15 +26,12 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterQueueUpdate := buildkite.ClusterQueueUpdate{
-		Description: "Development team cluster queue",
-	}
+	clusterQueueUpdate := buildkite.ClusterQueueUpdate{Description: *newDescription}
 
-	resp, err := client.ClusterQueues.Update(context.Background(), *org, *clusterID, *queueID, clusterQueueUpdate)
-
+	cq, _, err := client.ClusterQueues.Update(context.Background(), *org, *clusterID, *queueID, clusterQueueUpdate)
 	if err != nil {
 		log.Fatalf("Updating cluster queue failed: %s", err)
 	}
 
-	fmt.Println(resp.StatusCode)
+	fmt.Printf("Updated cluster queue: %v\n", cq)
 }

--- a/examples/cluster_tokens/create/main.go
+++ b/examples/cluster_tokens/create/main.go
@@ -27,18 +27,14 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterTokenCreate := buildkite.ClusterTokenCreateUpdate{
-		Description: buildkite.String("Dev squad agent fleet token"),
-	}
+	clusterTokenCreate := buildkite.ClusterTokenCreateUpdate{Description: "Dev squad agent fleet token"}
 
-	token, _, err := client.ClusterTokens.Create(context.Background(), *org, *clusterID, &clusterTokenCreate)
-
+	token, _, err := client.ClusterTokens.Create(context.Background(), *org, *clusterID, clusterTokenCreate)
 	if err != nil {
 		log.Fatalf("Creating cluster token failed: %s", err)
 	}
 
 	data, err := json.MarshalIndent(token, "", "\t")
-
 	if err != nil {
 		log.Fatalf("json encode failed: %s", err)
 	}

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -26,12 +26,9 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterTokenUpdate := buildkite.ClusterTokenCreateUpdate{
-		Description: buildkite.String("Dev squad agent token"),
-	}
+	clusterTokenUpdate := buildkite.ClusterTokenCreateUpdate{Description: "Dev squad agent token"}
 
-	resp, err := client.ClusterTokens.Update(context.Background(), *org, *clusterID, *tokenID, &clusterTokenUpdate)
-
+	resp, err := client.ClusterTokens.Update(context.Background(), *org, *clusterID, *tokenID, clusterTokenUpdate)
 	if err != nil {
 		log.Fatalf("Updating cluster token failed: %s", err)
 	}

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -11,11 +11,12 @@ import (
 )
 
 var (
-	apiToken  = kingpin.Flag("token", "API token").Required().String()
-	org       = kingpin.Flag("org", "Orginization slug").Required().String()
-	clusterID = kingpin.Flag("clusterID", "Cluster UUID").Required().String()
-	tokenID   = kingpin.Flag("tokenID", "Cluster token UUID").Required().String()
-	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
+	apiToken       = kingpin.Flag("token", "API token").Required().String()
+	org            = kingpin.Flag("org", "Orginization slug").Required().String()
+	clusterID      = kingpin.Flag("clusterID", "Cluster UUID").Required().String()
+	tokenID        = kingpin.Flag("tokenID", "Cluster token UUID").Required().String()
+	newDescription = kingpin.Flag("description", "New description for the cluster token").Required().String()
+	debug          = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
 func main() {
@@ -26,12 +27,12 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterTokenUpdate := buildkite.ClusterTokenCreateUpdate{Description: "Dev squad agent token"}
+	clusterTokenUpdate := buildkite.ClusterTokenCreateUpdate{Description: *newDescription}
 
-	resp, err := client.ClusterTokens.Update(context.Background(), *org, *clusterID, *tokenID, clusterTokenUpdate)
+	token, _, err := client.ClusterTokens.Update(context.Background(), *org, *clusterID, *tokenID, clusterTokenUpdate)
 	if err != nil {
 		log.Fatalf("Updating cluster token failed: %s", err)
 	}
 
-	fmt.Println(resp.StatusCode)
+	fmt.Printf("Updated cluster token: %s\n", token.Description)
 }

--- a/examples/clusters/create/main.go
+++ b/examples/clusters/create/main.go
@@ -28,12 +28,12 @@ func main() {
 
 	clusterCreate := buildkite.ClusterCreate{
 		Name:        "Development Cluster",
-		Description: buildkite.String("A cluster for development work"),
-		Emoji:       buildkite.String(":toolbox:"),
-		Color:       buildkite.String("#A9CCE3"),
+		Description: "A cluster for development work",
+		Emoji:       ":toolbox:",
+		Color:       "#A9CCE3",
 	}
 
-	cluster, _, err := client.Clusters.Create(context.Background(), *org, &clusterCreate)
+	cluster, _, err := client.Clusters.Create(context.Background(), *org, clusterCreate)
 
 	if err != nil {
 		log.Fatalf("Creating cluster failed: %s", err)

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -26,10 +26,10 @@ func main() {
 	}
 
 	clusterUpdate := buildkite.ClusterUpdate{
-		Description: buildkite.String("Development cluster"),
+		Description: "Development cluster",
 	}
 
-	resp, err := client.Clusters.Update(context.Background(), *org, *clusterID, &clusterUpdate)
+	resp, err := client.Clusters.Update(context.Background(), *org, *clusterID, clusterUpdate)
 
 	if err != nil {
 		log.Fatalf("Updating cluster %s failed: %s", *clusterID, err)

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	apiToken  = kingpin.Flag("token", "API token").Required().String()
-	org       = kingpin.Flag("org", "Orginization slug").Required().String()
-	clusterID = kingpin.Flag("clusterID", "Cluster UUID").Required().String()
-	debug     = kingpin.Flag("debug", "Enable debugging").Bool()
+	apiToken       = kingpin.Flag("token", "API token").Required().String()
+	org            = kingpin.Flag("org", "Orginization slug").Required().String()
+	clusterID      = kingpin.Flag("clusterID", "Cluster UUID").Required().String()
+	newDescription = kingpin.Flag("description", "New description for the cluster").Required().String()
+	debug          = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
 func main() {
@@ -25,15 +26,12 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterUpdate := buildkite.ClusterUpdate{
-		Description: "Development cluster",
-	}
+	clusterUpdate := buildkite.ClusterUpdate{Description: *newDescription}
 
-	resp, err := client.Clusters.Update(context.Background(), *org, *clusterID, clusterUpdate)
-
+	cluster, _, err := client.Clusters.Update(context.Background(), *org, *clusterID, clusterUpdate)
 	if err != nil {
 		log.Fatalf("Updating cluster %s failed: %s", *clusterID, err)
 	}
 
-	fmt.Println(resp.StatusCode)
+	fmt.Printf("Updated cluster %s: new description: %s\n", *clusterID, cluster.Description)
 }

--- a/examples/pipeline_templates/create/main.go
+++ b/examples/pipeline_templates/create/main.go
@@ -27,20 +27,18 @@ func main() {
 	}
 
 	pipelineTemplateCreate := buildkite.PipelineTemplateCreateUpdate{
-		Name:          buildkite.String("Production Pipeline uploader"),
-		Description:   buildkite.String("Production pipeline upload template"),
-		Configuration: buildkite.String("steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n"),
-		Available:     buildkite.Bool(true),
+		Name:          "Production Pipeline uploader",
+		Description:   "Production pipeline upload template",
+		Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n",
+		Available:     true,
 	}
 
-	pipelineTemplate, _, err := client.PipelineTemplates.Create(context.Background(), *org, &pipelineTemplateCreate)
-
+	pipelineTemplate, _, err := client.PipelineTemplates.Create(context.Background(), *org, pipelineTemplateCreate)
 	if err != nil {
 		log.Fatalf("Creating pipeline template failed: %s", err)
 	}
 
 	data, err := json.MarshalIndent(pipelineTemplate, "", "\t")
-
 	if err != nil {
 		log.Fatalf("json encode failed: %s", err)
 	}

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -26,11 +26,10 @@ func main() {
 	}
 
 	pipelineTemplateUpdate := buildkite.PipelineTemplateCreateUpdate{
-		Description: buildkite.String("Production pipeline template uploader"),
+		Description: "Production pipeline template uploader",
 	}
 
-	resp, err := client.PipelineTemplates.Update(context.Background(), *org, *templateUUID, &pipelineTemplateUpdate)
-
+	resp, err := client.PipelineTemplates.Update(context.Background(), *org, *templateUUID, pipelineTemplateUpdate)
 	if err != nil {
 		log.Fatalf("Updating cluster %s failed: %s", *templateUUID, err)
 	}

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	apiToken     = kingpin.Flag("token", "API token").Required().String()
-	org          = kingpin.Flag("org", "Orginization slug").Required().String()
-	templateUUID = kingpin.Flag("templateUUID", "Cluster UUID").Required().String()
-	debug        = kingpin.Flag("debug", "Enable debugging").Bool()
+	apiToken       = kingpin.Flag("token", "API token").Required().String()
+	org            = kingpin.Flag("org", "Orginization slug").Required().String()
+	templateUUID   = kingpin.Flag("templateUUID", "Cluster UUID").Required().String()
+	newDescription = kingpin.Flag("description", "New description for the pipeline template").Required().String()
+	debug          = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
 func main() {
@@ -25,14 +26,12 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pipelineTemplateUpdate := buildkite.PipelineTemplateCreateUpdate{
-		Description: "Production pipeline template uploader",
-	}
+	pipelineTemplateUpdate := buildkite.PipelineTemplateCreateUpdate{Description: "Production pipeline template uploader"}
 
-	resp, err := client.PipelineTemplates.Update(context.Background(), *org, *templateUUID, pipelineTemplateUpdate)
+	cluster, _, err := client.PipelineTemplates.Update(context.Background(), *org, *templateUUID, pipelineTemplateUpdate)
 	if err != nil {
 		log.Fatalf("Updating cluster %s failed: %s", *templateUUID, err)
 	}
 
-	fmt.Println(resp.StatusCode)
+	fmt.Printf("Updated cluster %s: new description: %s\n", *templateUUID, cluster.Description)
 }

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -27,17 +27,17 @@ func main() {
 	}
 
 	createPipeline := buildkite.CreatePipeline{
-		Name:          *buildkite.String("my-great-pipeline"),
-		Repository:    *buildkite.String("git@github.com:my_great_org/my_great_repo2.git"),
-		Configuration: *buildkite.String("env:\n \"FOO\": \"bar\"\nsteps:\n - command: \"script/release.sh\"\n   \"name\": \"Build 📦\""),
+		Name:          "my-great-pipeline",
+		Repository:    "git@github.com:my_great_org/my_great_repo2.git",
+		Configuration: "env:\n \"FOO\": \"bar\"\nsteps:\n - command: \"script/release.sh\"\n   \"name\": \"Build 📦\"",
 		Tags:          []string{"great", "pipeline"},
-		Description:   *buildkite.String("This ia a great pipeline!"),
+		Description:   "This ia a great pipeline!",
 		ProviderSettings: &buildkite.GitHubSettings{
-			TriggerMode: buildkite.String("code"),
+			TriggerMode: "code",
 		},
 	}
 
-	pipeline, _, err := client.Pipelines.Create(context.Background(), *org, &createPipeline)
+	pipeline, _, err := client.Pipelines.Create(context.Background(), *org, createPipeline)
 
 	if err != nil {
 		log.Fatalf("Updating pipeline failed: %s", err)

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -11,9 +11,11 @@ import (
 )
 
 var (
-	apiToken = kingpin.Flag("token", "API token").Required().String()
-	org      = kingpin.Flag("org", "Orginization slug").Required().String()
-	debug    = kingpin.Flag("debug", "Enable debugging").Bool()
+	apiToken       = kingpin.Flag("token", "API token").Required().String()
+	org            = kingpin.Flag("org", "Organization slug").Required().String()
+	pipelineSlug   = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+	newDescription = kingpin.Flag("description", "New pipeline description").Required().String()
+	debug          = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
 func main() {
@@ -24,22 +26,10 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pipeline := buildkite.Pipeline{
-		Slug:        buildkite.String("my-great-repo"),
-		Description: buildkite.String("This ia a great pipeline!"),
-		Provider: &buildkite.Provider{
-			Settings: &buildkite.GitHubSettings{
-				TriggerMode:       buildkite.String("fork"),
-				BuildPullRequests: buildkite.Bool(false),
-			},
-		},
-	}
-
-	resp, err := client.Pipelines.Update(context.Background(), *org, &pipeline)
-
+	_, _, err = client.Pipelines.Update(context.Background(), *org, *pipelineSlug, buildkite.UpdatePipeline{Description: *newDescription})
 	if err != nil {
 		log.Fatalf("Updating pipeline failed: %s", err)
 	}
 
-	fmt.Println(resp.StatusCode)
+	fmt.Println("Changed pipeline description to " + *newDescription)
 }

--- a/examples/test_suites/create/main.go
+++ b/examples/test_suites/create/main.go
@@ -32,7 +32,7 @@ func main() {
 		TeamUUIDs:     []string{"474de468-84d6-46dc-ba23-bac1add44a60"},
 	}
 
-	suite, _, err := client.TestSuites.Create(context.Background(), *org, &suiteCreate)
+	suite, _, err := client.TestSuites.Create(context.Background(), *org, suiteCreate)
 
 	if err != nil {
 		log.Fatalf("Creating test suite failed: %s", err)

--- a/examples/test_suites/update/main.go
+++ b/examples/test_suites/update/main.go
@@ -11,9 +11,11 @@ import (
 )
 
 var (
-	apiToken = kingpin.Flag("token", "API token").Required().String()
-	org      = kingpin.Flag("org", "Orginization slug").Required().String()
-	debug    = kingpin.Flag("debug", "Enable debugging").Bool()
+	apiToken         = kingpin.Flag("token", "API token").Required().String()
+	org              = kingpin.Flag("org", "Orginization slug").Required().String()
+	suite            = kingpin.Flag("suite", "Test suite slug").Required().String()
+	newDefaultBranch = kingpin.Flag("new-default-branch", "New default branch").String()
+	debug            = kingpin.Flag("debug", "Enable debugging").Bool()
 )
 
 func main() {
@@ -24,16 +26,12 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	suiteUpdate := buildkite.TestSuite{
-		DefaultBranch: buildkite.String("test"),
-		Slug:          buildkite.String("example-slug"),
-	}
+	suiteUpdate := buildkite.TestSuite{DefaultBranch: *newDefaultBranch}
 
-	resp, err := client.TestSuites.Update(context.Background(), *org, &suiteUpdate)
-
+	_, _, err = client.TestSuites.Update(context.Background(), *org, *suite, suiteUpdate)
 	if err != nil {
 		log.Fatalf("Updating test suite failed: %s", err)
 	}
 
-	fmt.Println(resp.StatusCode)
+	fmt.Println("Updated test suite with new default branch: ", *newDefaultBranch)
 }


### PR DESCRIPTION
**This PR:** Is a bit of a doozy!

When initially creating this library, we got super trigger happy with arguments that are pointers, to the point of making most arguments pointers to structs, and most of the members of those structs pointers to scalar types.

in 99% of cases, most of these things don't need to be pointers, so i've done a refactor with the philosophy of:
- Unless something _must_ be a pointer - that is, there's a meaningful semantic difference between `nil` and its empty value - don't use pointers
- If structs represent data only - they don't have any methods defined on them - return them as values, not pointers
- If structs as arguments don't need to be modified, and there's no no meaningful semantic difference between nil and zero values, don't use pointers to structs as arguments
  - Notably, there's one strain of argument that we _keep_ as pointers, and that's a variety of List options, eg [here](https://github.com/buildkite/go-buildkite/pull/197/files#diff-f8d935955c893b7714976c2064cf494781474b6009a8763b0384ed09b04a4ed8L58). In this case i _do_ think there's a meaningful semantic difference between zero and nil values, but i'm happy to argue about this
- In general, don't expose any unmarshalling semantics to users, again unless necessary. There was a pattern in this repo previously where you would have something like:
```go
fooUpdate := buildkite.FooUpdate{/* set some fields to update /*}
resp, err := bkclient.FooService.Update(ctx, &fooUpdate)
```

where `fooUpdate` would be the fields to update, but then the result of the update call would also be unmarshalled into `fooUpdate`, rather than returned. this is an issue because encoding/json behaves surprisingly ([#27172](https://github.com/golang/go/issues/27172), [#31924](https://github.com/golang/go/issues/31924), [#26946](https://github.com/golang/go/issues/26946), [#21092](https://github.com/golang/go/issues/21092)) when unmarshalling into non-empty structs, and is also just kind of a weird user interface IMO. this behaviour is replaced with something like
```go
fooUpdate := buildkite.FooUpdate{/* set some fields to update /*}
updated, resp, err := bkclient.FooService.Update(ctx, fooUpdate)
```
where `updated` is a full `buildkite.Foo` struct. See b116725545b9df7b7d5b24f7f61e33234cec202d for more info.