### PR TITLE
GolangCI Lint

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ steps:
     command: .buildkite/steps/lint.sh
     plugins:
       - docker#v5.9.0:
-          image: "golang:1.22"
+          image: "golangci/golangci-lint:v1.61-alpine"
 
   - name: ":go::test_tube: Test"
     key: test

--- a/.buildkite/steps/lint.sh
+++ b/.buildkite/steps/lint.sh
@@ -1,6 +1,6 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-set -Eeufo pipefail
+set -eufo
 
 echo --- :go: Checking go mod tidiness...
 go mod tidy
@@ -22,8 +22,8 @@ if ! git diff --no-ext-diff --exit-code; then
   exit 1
 fi
 
-echo --- :go: Checking go vet...
-go vet ./...
+echo --- :go: Running golangci-lint...
+golangci-lint run
 
 echo --- :go: Checking code generation...
 go generate ./...

--- a/buildkite/access_tokens.go
+++ b/buildkite/access_tokens.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"context"
-	"fmt"
 )
 
 type AccessTokensService struct {
@@ -18,7 +17,7 @@ type AccessToken struct {
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/access-token
 func (ats *AccessTokensService) Get(ctx context.Context) (AccessToken, *Response, error) {
-	u := fmt.Sprintf("v2/access-token")
+	u := "v2/access-token"
 	req, err := ats.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return AccessToken{}, nil, err
@@ -37,7 +36,7 @@ func (ats *AccessTokensService) Get(ctx context.Context) (AccessToken, *Response
 //
 // buildkite API docs: https://buildkite.com/docs/rest-api/access-token
 func (ats *AccessTokensService) Revoke(ctx context.Context) (*Response, error) {
-	u := fmt.Sprintf("v2/access-token")
+	u := "v2/access-token"
 	req, err := ats.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
 		return nil, err

--- a/buildkite/agents_test.go
+++ b/buildkite/agents_test.go
@@ -66,7 +66,10 @@ func TestAgentsService_Create(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/agents", func(w http.ResponseWriter, r *http.Request) {
 		var v Agent
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 

--- a/buildkite/annotations_test.go
+++ b/buildkite/annotations_test.go
@@ -80,7 +80,10 @@ func TestAnnotationsService_Create(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline/builds/10/annotations", func(w http.ResponseWriter, r *http.Request) {
 		var v AnnotationCreate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 

--- a/buildkite/buildkite_test.go
+++ b/buildkite/buildkite_test.go
@@ -70,7 +70,11 @@ func testFormValues(t *testing.T, r *http.Request, values values) {
 		want.Add(k, v)
 	}
 
-	r.ParseForm()
+	err := r.ParseForm()
+	if err != nil {
+		t.Fatalf("parsing HTTP form body: %v", err)
+	}
+
 	if diff := cmp.Diff(r.Form, want); diff != "" {
 		t.Errorf("Request parameters diff: (-got +want)\n%s", diff)
 	}
@@ -82,7 +86,11 @@ func testFormValuesList(t *testing.T, r *http.Request, values valuesList) {
 		want.Add(v.key, v.val)
 	}
 
-	r.ParseForm()
+	err := r.ParseForm()
+	if err != nil {
+		t.Fatalf("parsing HTTP form body: %v", err)
+	}
+
 	if diff := cmp.Diff(r.Form, want); diff != "" {
 		t.Errorf("Request parameters diff: (-got +want)\n%s", diff)
 	}

--- a/buildkite/builds.go
+++ b/buildkite/builds.go
@@ -223,7 +223,7 @@ func (bs *BuildsService) Get(ctx context.Context, org string, pipeline string, i
 //
 // buildkite API docs: https://buildkite.com/docs/api/builds#list-all-builds
 func (bs *BuildsService) List(ctx context.Context, opt *BuildsListOptions) ([]Build, *Response, error) {
-	u := fmt.Sprintf("v2/builds")
+	u := "v2/builds"
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err

--- a/buildkite/cluster_queues_test.go
+++ b/buildkite/cluster_queues_test.go
@@ -222,7 +222,10 @@ func TestClusterQueuesService_Create(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues", func(w http.ResponseWriter, r *http.Request) {
 		var v ClusterQueueCreate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -262,7 +265,10 @@ func TestClusterQueuesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
 		var v ClusterQueueUpdate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "PATCH")
 

--- a/buildkite/cluster_tokens_test.go
+++ b/buildkite/cluster_tokens_test.go
@@ -176,7 +176,10 @@ func TestClusterTokensService_Create(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
 		var v ClusterTokenCreateUpdate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -211,7 +214,10 @@ func TestClusterTokensService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
 		var v ClusterTokenCreateUpdate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "PATCH")
 

--- a/buildkite/clusters_test.go
+++ b/buildkite/clusters_test.go
@@ -202,7 +202,10 @@ func TestClustersService_Create(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
 		var v ClusterCreate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -249,7 +252,10 @@ func TestClustersService_Update(t *testing.T) {
 	clustersPutEndpoint := fmt.Sprintf("/v2/organizations/%s/clusters/%s", orgSlug, clusterID)
 	server.HandleFunc(clustersPutEndpoint, func(w http.ResponseWriter, r *http.Request) {
 		var v ClusterUpdate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "PATCH")
 

--- a/buildkite/jobs.go
+++ b/buildkite/jobs.go
@@ -85,7 +85,7 @@ type JobLog struct {
 
 // JobEnvs represent job environments output
 type JobEnvs struct {
-	EnvironmentVariables map[string]string `json:"env,string"`
+	EnvironmentVariables map[string]string `json:"env"`
 }
 
 type TriggeredBuild struct {

--- a/buildkite/organizations.go
+++ b/buildkite/organizations.go
@@ -36,7 +36,7 @@ type OrganizationListOptions struct{ ListOptions }
 //
 // buildkite API docs: https://buildkite.com/docs/api/organizations#list-organizations
 func (os *OrganizationsService) List(ctx context.Context, opt *OrganizationListOptions) ([]Organization, *Response, error) {
-	u := fmt.Sprintf("v2/organizations")
+	u := "v2/organizations"
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err

--- a/buildkite/packages.go
+++ b/buildkite/packages.go
@@ -67,7 +67,10 @@ func (ps *PackagesService) Create(ctx context.Context, organizationSlug, registr
 	}()
 
 	s := bkmultipart.NewStreamer()
-	s.WriteFile(fileFormKey, packageTempFile, filename)
+	err = s.WriteFile(fileFormKey, packageTempFile, filename)
+	if err != nil {
+		return Package{}, nil, fmt.Errorf("writing package to multipart stream: %v", err)
+	}
 
 	url := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages", organizationSlug, registrySlug)
 	req, err := ps.client.NewRequest(ctx, "POST", url, s.Reader())

--- a/buildkite/pipeline_templates_test.go
+++ b/buildkite/pipeline_templates_test.go
@@ -229,7 +229,10 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
 		var v PipelineTemplateCreateUpdate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -277,7 +280,10 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", func(w http.ResponseWriter, r *http.Request) {
 		var v PipelineTemplateCreateUpdate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "PATCH")
 

--- a/buildkite/pipelines_test.go
+++ b/buildkite/pipelines_test.go
@@ -62,7 +62,10 @@ func TestPipelinesService_Create(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		var v CreatePipeline
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -140,7 +143,10 @@ func TestPipelinesService_CreateByConfiguration(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		var v CreatePipeline
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -266,7 +272,10 @@ func TestPipelinesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
 		var v CreatePipeline
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -301,7 +310,10 @@ func TestPipelinesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-repo", func(w http.ResponseWriter, r *http.Request) {
 		var v UpdatePipeline
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		if diff := cmp.Diff(v, UpdatePipeline{Name: "derp"}); diff != "" {
 			t.Errorf("Request body diff: (-got +want)\n%s", diff)

--- a/buildkite/test_suites_test.go
+++ b/buildkite/test_suites_test.go
@@ -129,7 +129,10 @@ func TestTestSuitesService_Create(t *testing.T) {
 
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
 		var v TestSuiteCreate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -176,7 +179,10 @@ func TestTestSuitesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites", func(w http.ResponseWriter, r *http.Request) {
 		var v TestSuiteCreate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "POST")
 
@@ -201,7 +207,10 @@ func TestTestSuitesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-4", func(w http.ResponseWriter, r *http.Request) {
 		var v TestSuiteCreate
-		json.NewDecoder(r.Body).Decode(&v)
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
 
 		testMethod(t, r, "PATCH")
 

--- a/buildkite/user.go
+++ b/buildkite/user.go
@@ -2,7 +2,6 @@ package buildkite
 
 import (
 	"context"
-	"fmt"
 )
 
 // UserService handles communication with the user related
@@ -25,7 +24,7 @@ type User struct {
 //
 // buildkite API docs: https://buildkite.com/docs/api
 func (us *UserService) CurrentUser(ctx context.Context) (User, *Response, error) {
-	u := fmt.Sprintf("v2/user")
+	u := "v2/user"
 	req, err := us.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return User{}, nil, err

--- a/internal/bkmultipart/streamer.go
+++ b/internal/bkmultipart/streamer.go
@@ -19,10 +19,9 @@ type Streamer struct {
 	bodyBuffer  *bytes.Buffer
 	bodyWriter  *multipart.Writer
 	closeBuffer *bytes.Reader
-	file        *os.File
 
-	fileLength  int64
-	writtenFile bool
+	file       *os.File
+	fileLength int64
 }
 
 // NewStreamer initializes a new Streamer.


### PR DESCRIPTION
**This PR:** Adds golangci-lint, a stricter and more opinionated version of go vet, into this library, and fixes the issues it found in this codebase. Most of the issues were us not checking the error returns for function calls (mostly calls to unmarshal JSON), but there were a couple of other bits and bobs as well.