### PR TITLE
Release v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# buildkite-go [![Go Reference](https://pkg.go.dev/badge/github.com/buildkite/go-buildkite.svg)](https://pkg.go.dev/github.com/buildkite/go-buildkite/v3) [![Build status](https://badge.buildkite.com/b16a0d730b8732a1cfba06068f8450aa7cc4b2cf40eb6e6717.svg?branch=master)](https://buildkite.com/buildkite/go-buildkite)
+# buildkite-go [![Go Reference](https://pkg.go.dev/badge/github.com/buildkite/go-buildkite.svg)](https://pkg.go.dev/github.com/buildkite/go-buildkite/v4) [![Build status](https://badge.buildkite.com/b16a0d730b8732a1cfba06068f8450aa7cc4b2cf40eb6e6717.svg?branch=master)](https://buildkite.com/buildkite/go-buildkite)
 
 A [Go](http://golang.org) library and client for the [Buildkite API](https://buildkite.com/docs/api). This project draws a lot of its structure and testing methods from [go-github](https://github.com/google/go-github).
 
@@ -7,14 +7,14 @@ A [Go](http://golang.org) library and client for the [Buildkite API](https://bui
 To get the package, execute:
 
 ```
-go get github.com/buildkite/go-buildkite/v3
+go get github.com/buildkite/go-buildkite/v4
 ```
 
 Simple shortened example for listing all pipelines:
 
 ```go
 import (
-    "github.com/buildkite/go-buildkite/v3"
+    "github.com/buildkite/go-buildkite/v4"
     "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/buildkite.go
+++ b/buildkite.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/go-buildkite/v3/internal/bkmultipart"
+	"github.com/buildkite/go-buildkite/v4/internal/bkmultipart"
 	"github.com/cenkalti/backoff"
 	"github.com/google/go-querystring/query"
 )

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/examples/builds/get/main.go
+++ b/examples/builds/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_queues/create/main.go
+++ b/examples/cluster_queues/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_queues/delete/main.go
+++ b/examples/cluster_queues/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_queues/get/main.go
+++ b/examples/cluster_queues/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_queues/list/main.go
+++ b/examples/cluster_queues/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_queues/pause/main.go
+++ b/examples/cluster_queues/pause/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_queues/resume/main.go
+++ b/examples/cluster_queues/resume/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_queues/update/main.go
+++ b/examples/cluster_queues/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/examples/cluster_tokens/create/main.go
+++ b/examples/cluster_tokens/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_tokens/delete/main.go
+++ b/examples/cluster_tokens/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_tokens/get/main.go
+++ b/examples/cluster_tokens/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_tokens/list/main.go
+++ b/examples/cluster_tokens/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/clusters/create/main.go
+++ b/examples/clusters/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/clusters/delete/main.go
+++ b/examples/clusters/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/clusters/get/main.go
+++ b/examples/clusters/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/clusters/list/main.go
+++ b/examples/clusters/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/flaky_tests/list/main.go
+++ b/examples/flaky_tests/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/package_registries/create/main.go
+++ b/examples/package_registries/create/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/package_registries/delete/main.go
+++ b/examples/package_registries/delete/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/package_registries/get/main.go
+++ b/examples/package_registries/get/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/package_registries/list/main.go
+++ b/examples/package_registries/list/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/packages/create/main.go
+++ b/examples/packages/create/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/packages/create_presigned_upload/main.go
+++ b/examples/packages/create_presigned_upload/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/examples/packages/get/main.go
+++ b/examples/packages/get/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/pipeline_templates/create/main.go
+++ b/examples/pipeline_templates/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/pipeline_templates/delete/main.go
+++ b/examples/pipeline_templates/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/pipeline_templates/get/main.go
+++ b/examples/pipeline_templates/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/pipeline_templates/list/main.go
+++ b/examples/pipeline_templates/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/pipelines/list/main.go
+++ b/examples/pipelines/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/test_runs/get/main.go
+++ b/examples/test_runs/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/test_runs/list/main.go
+++ b/examples/test_runs/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/test_suites/create/main.go
+++ b/examples/test_suites/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/test_suites/delete/main.go
+++ b/examples/test_suites/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/test_suites/get/main.go
+++ b/examples/test_suites/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/test_suites/list/main.go
+++ b/examples/test_suites/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/test_suites/update/main.go
+++ b/examples/test_suites/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/examples/tests/get/main.go
+++ b/examples/tests/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v3"
+	"github.com/buildkite/go-buildkite/v4"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/buildkite/go-buildkite/v3
+module github.com/buildkite/go-buildkite/v4
 
 go 1.22
 

--- a/internal/bkmultipart/streamer_test.go
+++ b/internal/bkmultipart/streamer_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/buildkite/go-buildkite/v3/internal/bkmultipart"
+	"github.com/buildkite/go-buildkite/v4/internal/bkmultipart"
 )
 
 func TestEncodingFormFields(t *testing.T) {

--- a/package_uploads.go
+++ b/package_uploads.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/buildkite/go-buildkite/v3/internal/bkmultipart"
+	"github.com/buildkite/go-buildkite/v4/internal/bkmultipart"
 )
 
 // CreatePackageInput specifies the input parameters for the Create method.

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package buildkite
 
 // Version the library version number
-const Version = "3.13.0"
+const Version = "4.0.0"


### PR DESCRIPTION
## [v4.0.0](https://github.com/buildkite/go-buildkite/tree/v4.0.0) (2024-10-21)

Our first major release in a little while! This release is mostly a cleanup release, which __does not contain any major feature releases__.

### Notable Breaking Changes

#### Import Path
The module import path has changed from `github.com/buildkite/go-buildkite/v3/buildkite` to `github.com/buildkite/go-buildkite/v4`. Note that the version number has changed, and that the `buildkite` package is now at the root of the module.

#### Contexts
All methods that interact with Buildkite API now require a context parameter. This is to allow for better control over timeouts and cancellations. For example, to spend a maximum of five seconds trying to get a list of builds for a pipeline, you could run:
```go
ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
builds, _, err := client.Builds.ListByPipeline(ctx, "my-org", "my-pipeline", nil)
```

#### Removal of pointers
Previously, this library had a lot of pointers in its method signatures and struct values. Where practical, we've removed these pointers to make the API clearer and more idiomatic. This means that you'll need to update your code to pass values directly instead of pointers. For example, previously you might have done:
```go
pipeline := &buildkite.Pipeline{
  Name: buildkite.String("My Pipeline"),
}
_, _, err := client.Pipelines.Create(ctx, "my-org", pipeline)
```

Now, you should do:
```go
pipeline := buildkite.Pipeline{
  Name: "My Pipeline",
}
_, _, err := client.Pipelines.Create(ctx, "my-org", pipeline)
```

Along with this change, we've removed the `buildkite.String`, `buildkite.Bool`, and `buildkite.Int` helper functions. You should now pass values directly to the struct fields.

One notable difference in API after this change is that many (but not all!) `Update` methods for various API resources previously unmarshalled their response into a parameter that was passed into them. This is no longer the case, and the response is now returned directly from the method. For example, previously you might have done:
```go
updatePipeline := buildkite.UpdatePipeline{
  Name: buildkite.String("My Pipeline"),
}

_, err := client.Pipelines.Update("my-org", "my-pipeline", &updatePipeline)
// Result of update is unmarshalled into updatePipeline, with surprising results in some cases
```
now, you should do:
```go
updatePipeline := buildkite.UpdatePipeline{
  Name: "My Pipeline",
}
updated, _, err := client.Pipelines.Update(ctx, "my-org", "my-pipeline", updatePipeline)
// updated is the result of the update
// updatePipeline is unchanged
```

#### New Client Creation
We've changed the `buildkite.NewClient` method so that it includes functional args. Previously, you would have done something like this to create a client:
```go
config, err := buildkite.NewTokenConfig(apiToken, debug)
if err != nil {
  return fmt.Errorf("client config failed: %w", err)
}

client := buildkite.NewClient(config.Client())
```
Config creation has been moved inside the `NewClient` method and its functional arguments, so the new equivalent is:
```go
client, err := buildkite.NewClient(
  buildkite.WithTokenAuth(apitoken),
  buildkite.WithHTTPDebug(debug),
)
```

For a full list of functional arguments to `NewClient`, see the [godoc](https://pkg.go.dev/github.com/buildkite/go-buildkite/v4@v4.0.0).

The `NewOpts` method, which was introduced in v3.12.0, remains in place as an alias for `NewClient`.

#### Removal of YAML Bindings
We've removed the YAML bindings for exported data types. This means that marshalling the data types to and from YAML will no longer work. Code like the following will no longer work, and will produce undefined behaviour:
```go
pipeline := buildkite.Pipeline{
  Name: "My Pipeline",
  Repository: "https://github.com/buildkite/go-buildkite",
}

yamlBytes, err := yaml.Marshal(pipeline)
```

These YAML bindings weren't used within the library itself, and so aren't necessary for the operation of this library. If you were marshalling this library's data types to YAML, you should be able to use the `encoding/json` package instead, as all JSON is a subset of YAML.

### Other Changes

#### Changed
- Create packages using presigned uploads, rather than transiting them through the buildkite backend [#194](https://github.com/buildkite/go-buildkite/pull/194) [#195](https://github.com/buildkite/go-buildkite/pull/195) (@moskyb)

#### Internal
- Use golang-ci lint in CI [#199](https://github.com/buildkite/go-buildkite/pull/199) (@moskyb)
- Update README with NewOpts client/kingpin example [#192](https://github.com/buildkite/go-buildkite/pull/192) (@james2791)
- Update tests to use cmp.Diff instead of reflect.DeepEqual [#198](https://github.com/buildkite/go-buildkite/pull/198) (@moskyb)
