### PR TITLE
Fix unmarshal into non-pointer on Build Create

### DIFF
--- a/builds.go
+++ b/builds.go
@@ -186,7 +186,7 @@ func (bs *BuildsService) Create(ctx context.Context, org string, pipeline string
 	}
 
 	var build Build
-	resp, err := bs.client.Do(req, build)
+	resp, err := bs.client.Do(req, &build)
 	if err != nil {
 		return Build{}, resp, err
 	}


### PR DESCRIPTION
It looks like in #197, i missed a spot where i was passing a non-pointer into a call to `client.Do()`, which unmarshals JSON into its second argument. The method this happened in - `BuildService.Create` - wasn't covered by tests, and so the change went unnoticed.

This PR fixes that issue and adds a test for that method. I've also gone in and manually made sure that this mistake hasn't been made anywhere else.