### PR TITLE
Don't use omitempty for bool fields

### DIFF
--- a/annotations.go
+++ b/annotations.go
@@ -27,7 +27,7 @@ type AnnotationCreate struct {
 	Body    string `json:"body,omitempty"`
 	Context string `json:"context,omitempty"`
 	Style   string `json:"style,omitempty"`
-	Append  bool   `json:"append,omitempty"`
+	Append  bool   `json:"append"`
 }
 
 // AnnotationListOptions specifies the optional parameters to the

--- a/builds.go
+++ b/builds.go
@@ -30,10 +30,10 @@ type CreateBuild struct {
 
 	// Optional fields
 	Author                      Author            `json:"author,omitempty"`
-	CleanCheckout               bool              `json:"clean_checkout,omitempty"`
+	CleanCheckout               bool              `json:"clean_checkout"`
 	Env                         map[string]string `json:"env,omitempty"`
 	MetaData                    map[string]string `json:"meta_data,omitempty"`
-	IgnorePipelineBranchFilters bool              `json:"ignore_pipeline_branch_filters,omitempty"`
+	IgnorePipelineBranchFilters bool              `json:"ignore_pipeline_branch_filters"`
 	PullRequestBaseBranch       string            `json:"pull_request_base_branch,omitempty"`
 	PullRequestID               int64             `json:"pull_request_id,omitempty"`
 	PullRequestRepository       string            `json:"pull_request_repository,omitempty"`
@@ -76,7 +76,7 @@ type Build struct {
 	WebURL      string                 `json:"web_url,omitempty"`
 	Number      int                    `json:"number,omitempty"`
 	State       string                 `json:"state,omitempty"`
-	Blocked     bool                   `json:"blocked,omitempty"`
+	Blocked     bool                   `json:"blocked"`
 	Message     string                 `json:"message,omitempty"`
 	Commit      string                 `json:"commit,omitempty"`
 	Branch      string                 `json:"branch,omitempty"`

--- a/cluster_queues.go
+++ b/cluster_queues.go
@@ -21,7 +21,7 @@ type ClusterQueue struct {
 	URL                string          `json:"url,omitempty"`
 	WebURL             string          `json:"web_url,omitempty"`
 	ClusterURL         string          `json:"cluster_url,omitempty"`
-	DispatchPaused     bool            `json:"dispatch_paused,omitempty"`
+	DispatchPaused     bool            `json:"dispatch_paused"`
 	DispatchPausedBy   *ClusterCreator `json:"dispatch_paused_by,omitempty"`
 	DispatchPausedAt   *Timestamp      `json:"dispatch_paused_at,omitempty"`
 	DispatchPausedNote string          `json:"dispatch_paused_note,omitempty"`

--- a/jobs.go
+++ b/jobs.go
@@ -38,14 +38,14 @@ type Job struct {
 	Agent              Agent           `json:"agent,omitempty"`
 	AgentQueryRules    []string        `json:"agent_query_rules,omitempty"`
 	WebURL             string          `json:"web_url"`
-	Retried            bool            `json:"retried,omitempty"`
+	Retried            bool            `json:"retried"`
 	RetriedInJobID     string          `json:"retried_in_job_id,omitempty"`
 	RetriesCount       int             `json:"retries_count,omitempty"`
 	RetrySource        *JobRetrySource `json:"retry_source,omitempty"`
 	RetryType          string          `json:"retry_type,omitempty"`
-	SoftFailed         bool            `json:"soft_failed,omitempty"`
+	SoftFailed         bool            `json:"soft_failed"`
 	UnblockedBy        *UnblockedBy    `json:"unblocked_by,omitempty"`
-	Unblockable        bool            `json:"unblockable,omitempty"`
+	Unblockable        bool            `json:"unblockable"`
 	UnblockURL         string          `json:"unblock_url,omitempty"`
 	ParallelGroupIndex *int            `json:"parallel_group_index,omitempty"`
 	ParallelGroupTotal *int            `json:"parallel_group_total,omitempty"`

--- a/pipeline_templates.go
+++ b/pipeline_templates.go
@@ -19,7 +19,7 @@ type PipelineTemplate struct {
 	Name          string `json:"name,omitempty"`
 	Description   string `json:"description,omitempty"`
 	Configuration string `json:"configuration,omitempty"`
-	Available     bool   `json:"available,omitempty"`
+	Available     bool   `json:"available"`
 	URL           string `json:"url,omitempty"`
 	WebURL        string `json:"web_url,omitempty"`
 
@@ -34,7 +34,7 @@ type PipelineTemplateCreateUpdate struct {
 	Name          string `json:"name,omitempty"`
 	Configuration string `json:"configuration,omitempty"`
 	Description   string `json:"description,omitempty"`
-	Available     bool   `json:"available,omitempty"`
+	Available     bool   `json:"available"`
 }
 
 type PipelineTemplateCreator struct {

--- a/pipelines.go
+++ b/pipelines.go
@@ -29,9 +29,9 @@ type CreatePipeline struct {
 	Env                             map[string]string `json:"env,omitempty"`
 	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty"`
 	BranchConfiguration             string            `json:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds"`
 	SkipQueuedBranchBuildsFilter    string            `json:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds"`
 	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty"`
 	TeamUuids                       []string          `json:"team_uuids,omitempty"`
 	ClusterID                       string            `json:"cluster_id,omitempty"`
@@ -50,9 +50,9 @@ type UpdatePipeline struct {
 	Description                     string           `json:"description,omitempty"`
 	ProviderSettings                ProviderSettings `json:"provider_settings,omitempty"`
 	BranchConfiguration             string           `json:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          bool             `json:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuilds          bool             `json:"skip_queued_branch_builds"`
 	SkipQueuedBranchBuildsFilter    string           `json:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       bool             `json:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuilds       bool             `json:"cancel_running_branch_builds"`
 	CancelRunningBranchBuildsFilter string           `json:"cancel_running_branch_builds_filter,omitempty"`
 	ClusterID                       string           `json:"cluster_id,omitempty"`
 	Visibility                      string           `json:"visibility,omitempty"`
@@ -75,9 +75,9 @@ type Pipeline struct {
 	DefaultBranch                   string     `json:"default_branch,omitempty"`
 	Description                     string     `json:"description,omitempty"`
 	BranchConfiguration             string     `json:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          bool       `json:"skip_queued_branch_builds,omitempty"`
+	SkipQueuedBranchBuilds          bool       `json:"skip_queued_branch_builds"`
 	SkipQueuedBranchBuildsFilter    string     `json:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       bool       `json:"cancel_running_branch_builds,omitempty"`
+	CancelRunningBranchBuilds       bool       `json:"cancel_running_branch_builds"`
 	CancelRunningBranchBuildsFilter string     `json:"cancel_running_branch_builds_filter,omitempty"`
 	ClusterID                       string     `json:"cluster_id,omitempty"`
 	Visibility                      string     `json:"visibility,omitempty"`

--- a/providers.go
+++ b/providers.go
@@ -53,14 +53,14 @@ type ProviderSettings interface {
 
 // BitbucketSettings are settings for pipelines building from Bitbucket repositories.
 type BitbucketSettings struct {
-	BuildPullRequests                       bool   `json:"build_pull_requests,omitempty"`
-	BuildBranches                           bool   `json:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	BuildPullRequests                       bool   `json:"build_pull_requests"`
+	BuildBranches                           bool   `json:"build_branches"`
+	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled"`
 	PullRequestBranchFilterConfiguration    string `json:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildTags                               bool   `json:"build_tags,omitempty"`
-	PublishCommitStatus                     bool   `json:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step,omitempty"`
+	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits"`
+	BuildTags                               bool   `json:"build_tags"`
+	PublishCommitStatus                     bool   `json:"publish_commit_status"`
+	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step"`
 
 	// Read-only
 	Repository string `json:"repository,omitempty"`
@@ -71,20 +71,20 @@ func (s *BitbucketSettings) isProviderSettings() {}
 // GitHubSettings are settings for pipelines building from GitHub repositories.
 type GitHubSettings struct {
 	TriggerMode                             string `json:"trigger_mode,omitempty"`
-	BuildPullRequests                       bool   `json:"build_pull_requests,omitempty"`
-	BuildBranches                           bool   `json:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	BuildPullRequests                       bool   `json:"build_pull_requests"`
+	BuildBranches                           bool   `json:"build_branches"`
+	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled"`
 	PullRequestBranchFilterConfiguration    string `json:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildPullRequestForks                   bool   `json:"build_pull_request_forks,omitempty"`
-	PrefixPullRequestForkBranchNames        bool   `json:"prefix_pull_request_fork_branch_names,omitempty"`
-	BuildTags                               bool   `json:"build_tags,omitempty"`
-	PublishCommitStatus                     bool   `json:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step,omitempty"`
-	FilterEnabled                           bool   `json:"filter_enabled,omitempty"`
+	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits"`
+	BuildPullRequestForks                   bool   `json:"build_pull_request_forks"`
+	PrefixPullRequestForkBranchNames        bool   `json:"prefix_pull_request_fork_branch_names"`
+	BuildTags                               bool   `json:"build_tags"`
+	PublishCommitStatus                     bool   `json:"publish_commit_status"`
+	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step"`
+	FilterEnabled                           bool   `json:"filter_enabled"`
 	FilterCondition                         string `json:"filter_condition,omitempty"`
-	SeparatePullRequestStatuses             bool   `json:"separate_pull_request_statuses,omitempty"`
-	PublishBlockedAsPending                 bool   `json:"publish_blocked_as_pending,omitempty"`
+	SeparatePullRequestStatuses             bool   `json:"separate_pull_request_statuses"`
+	PublishBlockedAsPending                 bool   `json:"publish_blocked_as_pending"`
 
 	// Read-only
 	Repository string `json:"repository,omitempty"`
@@ -95,14 +95,14 @@ func (s *GitHubSettings) isProviderSettings() {}
 // GitHubEnterpriseSettings are settings for pipelines building from GitHub Enterprise repositories.
 type GitHubEnterpriseSettings struct {
 	TriggerMode                             string `json:"trigger_mode,omitempty"`
-	BuildPullRequests                       bool   `json:"build_pull_requests,omitempty"`
-	BuildBranches                           bool   `json:"build_branches,omitempty"`
-	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled,omitempty"`
+	BuildPullRequests                       bool   `json:"build_pull_requests"`
+	BuildBranches                           bool   `json:"build_branches"`
+	PullRequestBranchFilterEnabled          bool   `json:"pull_request_branch_filter_enabled"`
 	PullRequestBranchFilterConfiguration    string `json:"pull_request_branch_filter_configuration,omitempty"`
-	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits,omitempty"`
-	BuildTags                               bool   `json:"build_tags,omitempty"`
-	PublishCommitStatus                     bool   `json:"publish_commit_status,omitempty"`
-	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step,omitempty"`
+	SkipPullRequestBuildsForExistingCommits bool   `json:"skip_pull_request_builds_for_existing_commits"`
+	BuildTags                               bool   `json:"build_tags"`
+	PublishCommitStatus                     bool   `json:"publish_commit_status"`
+	PublishCommitStatusPerStep              bool   `json:"publish_commit_status_per_step"`
 
 	// Read-only
 	Repository string `json:"repository,omitempty"`

--- a/teams.go
+++ b/teams.go
@@ -23,7 +23,7 @@ type Team struct {
 	Slug        string     `json:"slug,omitempty"`
 	Description string     `json:"description,omitempty"`
 	Privacy     string     `json:"privacy,omitempty"`
-	Default     bool       `json:"default,omitempty"`
+	Default     bool       `json:"default"`
 	CreatedAt   *Timestamp `json:"created_at,omitempty"`
 	CreatedBy   *User      `json:"created_by,omitempty"`
 }
@@ -40,9 +40,9 @@ type CreateTeam struct {
 	Name                      string `json:"name,omitempty"`
 	Description               string `json:"description,omitempty"`
 	Privacy                   string `json:"privacy,omitempty"`
-	IsDefaultTeam             bool   `json:"is_default_team,omitempty"`
+	IsDefaultTeam             bool   `json:"is_default_team"`
 	DefaultMemberRole         string `json:"default_member_role,omitempty"`
-	MembersCanCreatePipelines bool   `json:"members_can_create_pipelines,omitempty"`
+	MembersCanCreatePipelines bool   `json:"members_can_create_pipelines"`
 }
 
 // Get the teams for an org.

--- a/test_suites.go
+++ b/test_suites.go
@@ -16,7 +16,7 @@ type TestSuitesService struct {
 type TestSuiteCreate struct {
 	Name          string   `json:"name"`
 	DefaultBranch string   `json:"default_branch,omitempty"`
-	ShowAPIToken  bool     `json:"show_api_token,omitempty"`
+	ShowAPIToken  bool     `json:"show_api_token"`
 	TeamUUIDs     []string `json:"team_ids,omitempty"`
 }
 


### PR DESCRIPTION
It means that they can't be set to false. For most update structs, there's still no option for "i don't care, leave it as is", but this can be addressed in a future release.

Closes #208.

