### PR TITLE
support metrics api

### DIFF
--- a/buildkite.go
+++ b/buildkite.go
@@ -48,6 +48,7 @@ type Client struct {
 	ClusterTokens            *ClusterTokensService
 	FlakyTests               *FlakyTestsService
 	Jobs                     *JobsService
+	Metrics                  *MetricsService
 	Organizations            *OrganizationsService
 	PackagesService          *PackagesService
 	PackageRegistriesService *PackageRegistriesService
@@ -156,6 +157,7 @@ func (c *Client) populateDefaultServices() {
 	c.ClusterTokens = &ClusterTokensService{c}
 	c.FlakyTests = &FlakyTestsService{c}
 	c.Jobs = &JobsService{c}
+	c.Metrics = &MetricsService{c}
 	c.Organizations = &OrganizationsService{c}
 	c.PackagesService = &PackagesService{c}
 	c.PackageRegistriesService = &PackageRegistriesService{c}

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,76 @@
+package buildkite
+
+import (
+	"context"
+)
+
+// MetricsService handles communication with the metrics related
+// methods of the buildkite API.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/agent-api#metrics
+type MetricsService struct {
+	client *Client
+}
+
+// QueueMetrics represents metrics for a specific queue
+type QueueMetrics struct {
+	Idle  int `json:"idle"`
+	Busy  int `json:"busy"`
+	Total int `json:"total"`
+}
+
+// AgentMetrics represents metrics about agents
+type AgentMetrics struct {
+	Idle   int                     `json:"idle"`
+	Busy   int                     `json:"busy"`
+	Total  int                     `json:"total"`
+	Queues map[string]QueueMetrics `json:"queues"`
+}
+
+// JobMetrics represents metrics about jobs
+type JobMetrics struct {
+	Scheduled int                        `json:"scheduled"`
+	Running   int                        `json:"running"`
+	Waiting   int                        `json:"waiting"`
+	Total     int                        `json:"total"`
+	Queues    map[string]JobQueueMetrics `json:"queues"`
+}
+
+// JobQueueMetrics represents metrics for jobs in a specific queue
+type JobQueueMetrics struct {
+	Scheduled int `json:"scheduled"`
+	Running   int `json:"running"`
+	Waiting   int `json:"waiting"`
+	Total     int `json:"total"`
+}
+
+// OrganizationMetrics represents organization information
+type OrganizationMetrics struct {
+	Slug string `json:"slug"`
+}
+
+// Metrics represents the full metrics response
+type Metrics struct {
+	Agents       AgentMetrics        `json:"agents"`
+	Jobs         JobMetrics          `json:"jobs"`
+	Organization OrganizationMetrics `json:"organization"`
+}
+
+// Get fetches the current metrics.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/agent-api#metrics
+func (ms *MetricsService) Get(ctx context.Context) (*Metrics, *Response, error) {
+	u := "v3/metrics"
+	req, err := ms.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	metrics := new(Metrics)
+	resp, err := ms.client.Do(req, metrics)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return metrics, resp, nil
+}

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -1,0 +1,93 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMetricsService_Get(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v3/metrics", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"agents": {
+				"idle": 1,
+				"busy": 0,
+				"total": 1,
+				"queues": {
+					"default": {
+						"idle": 1,
+						"busy": 0,
+						"total": 1
+					}
+				}
+			},
+			"jobs": {
+				"scheduled": 5,
+				"running": 0,
+				"waiting": 0,
+				"total": 5,
+				"queues": {
+					"default": {
+						"scheduled": 5,
+						"running": 0,
+						"waiting": 0,
+						"total": 5
+					}
+				}
+			},
+			"organization": {
+				"slug": "buildkite"
+			}
+		}`)
+	})
+
+	metrics, _, err := client.Metrics.Get(context.Background())
+	if err != nil {
+		t.Errorf("Metrics.Get returned error: %v", err)
+	}
+
+	want := &Metrics{
+		Agents: AgentMetrics{
+			Idle:  1,
+			Busy:  0,
+			Total: 1,
+			Queues: map[string]QueueMetrics{
+				"default": {
+					Idle:  1,
+					Busy:  0,
+					Total: 1,
+				},
+			},
+		},
+		Jobs: JobMetrics{
+			Scheduled: 5,
+			Running:   0,
+			Waiting:   0,
+			Total:     5,
+			Queues: map[string]JobQueueMetrics{
+				"default": {
+					Scheduled: 5,
+					Running:   0,
+					Waiting:   0,
+					Total:     5,
+				},
+			},
+		},
+		Organization: OrganizationMetrics{
+			Slug: "buildkite",
+		},
+	}
+
+	if diff := cmp.Diff(metrics, want); diff != "" {
+		t.Errorf("Metrics.Get returned diff: (-got +want)\n%s", diff)
+	}
+}


### PR DESCRIPTION
## Changes
- Adds in support for a metrics service
- Provides a `GET` method on that service
- Tests
- Added to the core Buildkite client

Addresses https://github.com/buildkite/go-buildkite/issues/211
