### PR TITLE
fix: fixes gitlab enterprise which appears in webhooks

### DIFF
--- a/providers.go
+++ b/providers.go
@@ -31,7 +31,7 @@ func (p *Provider) UnmarshalJSON(data []byte) error {
 		settings = &GitHubSettings{}
 	case "github_enterprise":
 		settings = &GitHubEnterpriseSettings{}
-	case "gitlab":
+	case "gitlab", "gitlab_ee":
 		settings = &GitLabSettings{}
 	default:
 		return nil
@@ -113,7 +113,8 @@ func (s *GitHubEnterpriseSettings) isProviderSettings() {}
 // GitLabSettings are settings for pipelines building from GitLab repositories.
 type GitLabSettings struct {
 	// Read-only
-	Repository string `json:"repository,omitempty"`
+	FilterEnabled bool   `json:"filter_enabled"`
+	Repository    string `json:"repository,omitempty"`
 }
 
 func (s *GitLabSettings) isProviderSettings() {}

--- a/providers_test.go
+++ b/providers_test.go
@@ -75,6 +75,23 @@ func TestUnmarshalGitLabProvider(t *testing.T) {
 	}
 }
 
+func TestUnmarshalGitLabEnterpriseProvider(t *testing.T) {
+	var provider Provider
+	err := json.Unmarshal([]byte(`{"id": "gitlab_ee", "settings": {"repository": "my-gitlab-repo"}}`), &provider)
+	if err != nil {
+		t.Errorf("Error unmarshalling GitLab provider: %v", err)
+	}
+
+	want := Provider{
+		ID:       "gitlab_ee",
+		Settings: &GitLabSettings{Repository: "my-gitlab-repo"},
+	}
+
+	if diff := cmp.Diff(provider, want); diff != "" {
+		t.Errorf("Unmarshalling GitLab Enterprise provider JSON produced unexpected output. diff: (-got +want)\n%s", diff)
+	}
+}
+
 func TestUnmarshalUnknownProvider(t *testing.T) {
 	var provider Provider
 	err := json.Unmarshal([]byte(`{"id": "unknown", "settings": {"emoji": ":shrug:"}}`), &provider)


### PR DESCRIPTION
Webhooks using a gitlab enterprise repository have `gitlab_ee` set as the provider id