### PR TITLE
Add OIDC policy scopes

### DIFF
--- a/examples/package_registries/create/main.go
+++ b/examples/package_registries/create/main.go
@@ -34,6 +34,7 @@ func main() {
 		OIDCPolicy: buildkite.PackageRegistryOIDCPolicy{
 			buildkite.OIDCPolicyStatement{
 				Issuer: "https://agent.buildkite.com",
+				Scopes: []string{"read_packages"},
 				Claims: map[string]buildkite.ClaimRule{
 					"pipeline_slug": {
 						Equals: "my-pipeline",

--- a/package_registries.go
+++ b/package_registries.go
@@ -40,6 +40,7 @@ type PackageRegistryOIDCPolicy []OIDCPolicyStatement
 
 type OIDCPolicyStatement struct {
 	Issuer string               `json:"iss"`
+	Scopes []string             `json:"scopes,omitzero"`
 	Claims map[string]ClaimRule `json:"claims"`
 }
 


### PR DESCRIPTION
We recently added a `scopes` key to package registry OIDC policies, and made it mandatory. This PR adds that key to this library.

I've updated go 1.24 to add the json `omitzero` directive in `encoding/json`. OIDC policies will complain if a statement doesn't have a `scopes` key, but a `scopes` key whose value is an empty array is valid. The `omitzero` directive allows us to leverage this functionality -- if we were using `omitempty`, a user would not be able to specify a (valid) empty scopes array, but if we didn't have any omit directives, the user would always have to specify the full OIDC policy when updating a registry.