### PR TITLE
List registry packages + delete packages

### DIFF
--- a/examples/package_registries/list_packages/main.go
+++ b/examples/package_registries/list_packages/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	registry = kingpin.Flag("registry", "Registry slug").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(
+		buildkite.WithTokenAuth(*apiToken),
+		buildkite.WithBaseURL("http://api.buildkite.localhost"),
+	)
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	opts := &buildkite.RegistryPackagesOptions{PerPage: "2"}
+	packages, _, err := client.PackageRegistriesService.ListPackages(context.Background(), *org, *registry, opts)
+	if err != nil {
+		log.Fatalf("Getting registry packages failed: %v", err)
+	}
+
+	data, err := json.MarshalIndent(packages, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	log.Println(string(data))
+
+	nextOpts, err := packages.Links.Next.ToOptions()
+	if err != nil {
+		log.Fatalf("options encoding failed: %s", err)
+	}
+
+	nextPackages, _, err := client.PackageRegistriesService.ListPackages(context.Background(), *org, *registry, nextOpts)
+	if err != nil {
+		log.Fatalf("Getting registry packages failed: %v", err)
+	}
+
+	data, err = json.MarshalIndent(nextPackages, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	log.Println(string(data))
+}

--- a/examples/packages/delete/main.go
+++ b/examples/packages/delete/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 
 	"github.com/buildkite/go-buildkite/v4"
@@ -25,15 +24,10 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pkg, _, err := client.PackagesService.Get(context.Background(), *org, *registrySlug, *packageID)
+	_, err = client.PackagesService.Delete(context.Background(), *org, *registrySlug, *packageID)
 	if err != nil {
-		log.Fatalf("Getting package %s failed: %s", *registrySlug, err)
+		log.Fatalf("deleting package %s failed: %s", *registrySlug, err)
 	}
 
-	data, err := json.MarshalIndent(pkg, "", "\t")
-	if err != nil {
-		log.Fatalf("json encode failed: %s", err)
-	}
-
-	log.Println(string(data))
+	log.Printf("Deleted package with ID %s\n", *packageID)
 }

--- a/package_registries.go
+++ b/package_registries.go
@@ -57,7 +57,7 @@ func (rs *PackageRegistriesService) Create(ctx context.Context, organizationSlug
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries", organizationSlug)
 	req, err := rs.client.NewRequest(ctx, "POST", u, cpri)
 	if err != nil {
-		return PackageRegistry{}, nil, fmt.Errorf("creating POST package registry request: %v", err)
+		return PackageRegistry{}, nil, fmt.Errorf("creating POST package registry request: %w", err)
 	}
 
 	var pr PackageRegistry
@@ -82,7 +82,7 @@ func (rs *PackageRegistriesService) Update(ctx context.Context, organizationSlug
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s", organizationSlug, registrySlug)
 	req, err := rs.client.NewRequest(ctx, "PATCH", u, upri)
 	if err != nil {
-		return PackageRegistry{}, nil, fmt.Errorf("creating PATCH package registry request: %v", err)
+		return PackageRegistry{}, nil, fmt.Errorf("creating PATCH package registry request: %w", err)
 	}
 
 	var pr PackageRegistry
@@ -99,7 +99,7 @@ func (rs *PackageRegistriesService) Get(ctx context.Context, organizationSlug, r
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s", organizationSlug, registrySlug)
 	req, err := rs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return PackageRegistry{}, nil, fmt.Errorf("creating GET package registry request: %v", err)
+		return PackageRegistry{}, nil, fmt.Errorf("creating GET package registry request: %w", err)
 	}
 
 	var pr PackageRegistry
@@ -116,7 +116,7 @@ func (rs *PackageRegistriesService) List(ctx context.Context, organizationSlug s
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries", organizationSlug)
 	req, err := rs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
-		return nil, nil, fmt.Errorf("creating GET package registry request: %v", err)
+		return nil, nil, fmt.Errorf("creating GET package registry request: %w", err)
 	}
 
 	var prs []PackageRegistry
@@ -133,7 +133,7 @@ func (rs *PackageRegistriesService) Delete(ctx context.Context, organizationSlug
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s", organizationSlug, registrySlug)
 	req, err := rs.client.NewRequest(ctx, "DELETE", u, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating DELETE package registry request: %v", err)
+		return nil, fmt.Errorf("creating DELETE package registry request: %w", err)
 	}
 
 	resp, err := rs.client.Do(req, nil)

--- a/package_registries.go
+++ b/package_registries.go
@@ -13,18 +13,18 @@ type PackageRegistriesService struct {
 
 // PackageRegistry represents a package registry within Buildkite
 type PackageRegistry struct {
-	ID          string `json:"id"`
-	GraphQLID   string `json:"graphql_id"`
-	Slug        string `json:"slug"`
-	URL         string `json:"url"`
-	WebURL      string `json:"web_url"`
-	Name        string `json:"name"`
-	Ecosystem   string `json:"ecosystem"`
-	Description string `json:"description"`
-	Emoji       string `json:"emoji"`
-	Color       string `json:"color"`
-	Public      bool   `json:"public"`
-	OIDCPolicy  string `json:"oidc_policy"`
+	ID          string `json:"id,omitempty"`
+	GraphQLID   string `json:"graphql_id,omitempty"`
+	Slug        string `json:"slug,omitempty"`
+	URL         string `json:"url,omitempty"`
+	WebURL      string `json:"web_url,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Ecosystem   string `json:"ecosystem,omitempty"`
+	Description string `json:"description,omitempty"`
+	Emoji       string `json:"emoji,omitempty"`
+	Color       string `json:"color,omitempty"`
+	Public      bool   `json:"public,omitempty"`
+	OIDCPolicy  string `json:"oidc_policy,omitempty"`
 }
 
 // CreatePackageRegistryInput represents the input to create a package registry.

--- a/packages.go
+++ b/packages.go
@@ -40,3 +40,18 @@ func (ps *PackagesService) Get(ctx context.Context, organizationSlug, registrySl
 
 	return p, resp, err
 }
+
+func (ps *PackagesService) Delete(ctx context.Context, organizationSlug, registrySlug, packageID string) (*Response, error) {
+	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages/%s", organizationSlug, registrySlug, packageID)
+	req, err := ps.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating DELETE package request: %w", err)
+	}
+
+	resp, err := ps.client.Do(req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}

--- a/packages.go
+++ b/packages.go
@@ -16,6 +16,9 @@ type PackagesService struct {
 type Package struct {
 	ID           string          `json:"id"`
 	Name         string          `json:"name"`
+	Version      string          `json:"version"`
+	Variant      *string         `json:"variant"`
+	Metadata     map[string]any  `json:"metadata"`
 	URL          string          `json:"url"`
 	WebURL       string          `json:"web_url"`
 	Organization Organization    `json:"organization"`

--- a/packages.go
+++ b/packages.go
@@ -26,13 +26,13 @@ func (ps *PackagesService) Get(ctx context.Context, organizationSlug, registrySl
 	url := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages/%s", organizationSlug, registrySlug, packageID)
 	req, err := ps.client.NewRequest(ctx, "GET", url, nil)
 	if err != nil {
-		return Package{}, nil, fmt.Errorf("creating GET package request: %v", err)
+		return Package{}, nil, fmt.Errorf("creating GET package request: %w", err)
 	}
 
 	var p Package
 	resp, err := ps.client.Do(req, &p)
 	if err != nil {
-		return Package{}, resp, fmt.Errorf("executing GET package request: %v", err)
+		return Package{}, resp, fmt.Errorf("executing GET package request: %w", err)
 	}
 
 	return p, resp, err

--- a/webhook.go
+++ b/webhook.go
@@ -113,7 +113,7 @@ func getTimestampAndSignature(sig string) (timestamp string, signature []byte, e
 	sigStr := strings.Split(sg, "=")[1]
 	signature, err = hex.DecodeString(sigStr)
 	if err != nil {
-		return "", nil, fmt.Errorf("error decoding signature %q: %v", sigStr, err)
+		return "", nil, fmt.Errorf("error decoding signature %q: %w", sigStr, err)
 	}
 
 	return timestamp, signature, nil


### PR DESCRIPTION
This PR adds methods to this package to:
- List the packages for a given registry
- Delete a given package

It also has some convenience changes, like properly wrapping errors using `%w`, and adding `omitempty` markers to the registry type