### PR TITLE
chore(release): simplify the release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,9 @@ Note: not all API features are supported by `go-buildkite` just yet. If you need
 
 # Releasing
 
-1. Update the version number in `version.go`
-2. Generate a changelog using [ghch](https://github.com/Songmu/ghch): `ghch --format=markdown --next-version=v<next-version-number>`, and update it in `CHANGELOG.md`
-3. Commit and tag the new version
-4. Create a matching [GitHub release](https://github.com/buildkite/go-buildkite/releases)
+1. Generate a changelog using [ghch](https://github.com/Songmu/ghch): `ghch --format=markdown --next-version=v<next-version-number>`, and update it in `CHANGELOG.md`
+3. Commit the changelog
+4. Create a release using GitHub CLI: `gh release create`, ensuring you update the release notes with the new CHANGELOG.md content
 
 # License
 

--- a/buildkite.go
+++ b/buildkite.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	DefaultBaseURL   = "https://api.buildkite.com/"
-	DefaultUserAgent = "go-buildkite/" + Version
+	DefaultBaseURL = "https://api.buildkite.com/"
 )
+
+// DefaultUserAgent is the default user agent used for API requests
+var DefaultUserAgent = "go-buildkite/" + Version
 
 // Client - A Client manages communication with the buildkite API.
 type Client struct {

--- a/version.go
+++ b/version.go
@@ -12,20 +12,20 @@ var Version = func() string {
 	if !ok {
 		return "dev" // No build info available
 	}
-	
+
 	// For the main module
 	if info.Main.Path == "github.com/buildkite/go-buildkite/v4" && info.Main.Version != "(devel)" {
 		// Remove the 'v' prefix if present
 		return strings.TrimPrefix(info.Main.Version, "v")
 	}
-	
+
 	// Try to find this module in the dependency list
 	for _, dep := range info.Deps {
 		if dep.Path == "github.com/buildkite/go-buildkite/v4" && dep.Version != "(devel)" {
 			return strings.TrimPrefix(dep.Version, "v")
 		}
 	}
-	
+
 	// If we're in development mode, try to get VCS info
 	for _, setting := range info.Settings {
 		if setting.Key == "vcs.revision" {
@@ -36,7 +36,7 @@ var Version = func() string {
 			return "dev+" + setting.Value
 		}
 	}
-	
+
 	// Last resort fallback
 	return "dev"
 }()

--- a/version.go
+++ b/version.go
@@ -1,4 +1,42 @@
 package buildkite
 
-// Version the library version number
-const Version = "4.1.0"
+import (
+	"runtime/debug"
+	"strings"
+)
+
+// Version returns the library version number based on Go module information
+var Version = func() string {
+	// Try to get version from build info
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "dev" // No build info available
+	}
+	
+	// For the main module
+	if info.Main.Path == "github.com/buildkite/go-buildkite/v4" && info.Main.Version != "(devel)" {
+		// Remove the 'v' prefix if present
+		return strings.TrimPrefix(info.Main.Version, "v")
+	}
+	
+	// Try to find this module in the dependency list
+	for _, dep := range info.Deps {
+		if dep.Path == "github.com/buildkite/go-buildkite/v4" && dep.Version != "(devel)" {
+			return strings.TrimPrefix(dep.Version, "v")
+		}
+	}
+	
+	// If we're in development mode, try to get VCS info
+	for _, setting := range info.Settings {
+		if setting.Key == "vcs.revision" {
+			// Return shortened git commit hash
+			if len(setting.Value) >= 7 {
+				return "dev+" + setting.Value[:7]
+			}
+			return "dev+" + setting.Value
+		}
+	}
+	
+	// Last resort fallback
+	return "dev"
+}()


### PR DESCRIPTION
## Changes

- We've removed the need to update the `version.go` file entirely
    - `version.go` now sets `dev` etc accordingly
- Adjusted the release creation to use `gh` CLI instead of manual, web-based process
