### PR TITLE
Add lefthook

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,8 @@
+pre-commit:
+  commands:
+    gofmt:
+      glob: "*.go"
+      run: gofmt -s -w .
+    gomodtidy:
+      glob: "*.go"
+      run: go mod tidy


### PR DESCRIPTION
## Changes

- Adds a `lefthook.yml` file to the root of the project
    - Adds in some best pracise commands pre-commit

## Refs

- [lefthook](https://lefthook.dev/) can be installed locally and used to ensure _things_ are done at certain stages
    - In our `lefthook.yml` file, we ensure `go fmt` is run before the files are committed
