### PR TITLE
Add support for excluding jobs and pipeline data from List Builds

### DIFF
--- a/builds.go
+++ b/builds.go
@@ -168,6 +168,12 @@ type BuildsListOptions struct {
 	// Filters results by metadata.
 	MetaData MetaDataFilters `url:"meta_data,omitempty"`
 
+	// Exclude jobs from the API response
+	ExcludeJobs bool `url:"exclude_jobs,omitempty"`
+
+	// Exclude pipeline data from the API response
+	ExcludePipeline bool `url:"exclude_pipeline,omitempty"`
+
 	ListOptions
 }
 

--- a/builds_test.go
+++ b/builds_test.go
@@ -326,6 +326,62 @@ func TestBuildsService_List_by_multiple_branches(t *testing.T) {
 	}
 }
 
+func TestBuildsService_List_with_exclude_jobs(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"exclude_jobs": "true",
+		})
+		_, _ = fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
+	})
+
+	opt := &BuildsListOptions{
+		ExcludeJobs: true,
+	}
+	builds, _, err := client.Builds.List(context.Background(), opt)
+	if err != nil {
+		t.Errorf("Builds.List returned error: %v", err)
+	}
+
+	want := []Build{{ID: "123"}, {ID: "1234"}}
+	if diff := cmp.Diff(builds, want); diff != "" {
+		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestBuildsService_List_with_exclude_pipeline(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/builds", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"exclude_pipeline": "true",
+		})
+		_, _ = fmt.Fprint(w, `[{"id":"123"},{"id":"1234"}]`)
+	})
+
+	opt := &BuildsListOptions{
+		ExcludePipeline: true,
+	}
+	builds, _, err := client.Builds.List(context.Background(), opt)
+	if err != nil {
+		t.Errorf("Builds.List returned error: %v", err)
+	}
+
+	want := []Build{{ID: "123"}, {ID: "1234"}}
+	if diff := cmp.Diff(builds, want); diff != "" {
+		t.Errorf("Builds.List diff: (-got +want)\n%s", diff)
+	}
+}
+
 func TestBuildsService_ListByPipeline(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When querying for builds using buildkite-mcp-server the context size quickly grows too large because of all the jobs and pipeline data returned in the response. We can reduce this by excluding them in the response.