### PR TITLE
Add support for test engine run ids

### DIFF
--- a/builds.go
+++ b/builds.go
@@ -83,6 +83,20 @@ type TriggeredFrom struct {
 	BuildPipelineSlug string `json:"build_pipeline_slug,omitempty"`
 }
 
+type TestEngineSuite struct {
+	ID   string `json:"id,omitempty"`
+	Slug string `json:"slug,omitempty"`
+}
+
+type TestEngineRun struct {
+	ID    string          `json:"id,omitempty"`
+	Suite TestEngineSuite `json:"suite"`
+}
+
+type TestEngineProperty struct {
+	Runs []TestEngineRun `json:"runs,omitempty"`
+}
+
 // Build represents a build which has run in buildkite
 type Build struct {
 	ID          string                 `json:"id,omitempty"`
@@ -120,6 +134,8 @@ type Build struct {
 	// the build that this build is triggered from
 	// https://buildkite.com/docs/pipelines/trigger-step
 	TriggeredFrom *TriggeredFrom `json:"triggered_from,omitempty"`
+
+	TestEngine *TestEngineProperty `json:"test_engine,omitempty"`
 }
 
 type MetaDataFilters struct {

--- a/builds_test.go
+++ b/builds_test.go
@@ -540,6 +540,49 @@ func TestJSONUnMarshallBuild(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "build with test engine run ids",
+			json: `{
+				"id": "456",
+				"state": "passed",
+				"blocked": false,
+				"message": "Test run",
+				"commit": "abc123",
+				"branch": "main",
+				"source": "api",
+				"test_engine": {
+					"runs": [
+						{
+							"id": "2fd5c15a-a3a6-45ab-b1b2-6ea59616c1cf",
+							"suite": {
+								"id": "b1c349b6-c7d6-4633-8941-7e615459c03d",
+								"slug": "banana"
+							}
+						}
+					]
+				}
+		}`,
+			expect: Build{
+				ID:      "456",
+				State:   "passed",
+				Blocked: false,
+				Message: "Test run",
+				Commit:  "abc123",
+				Branch:  "main",
+				Source:  "api",
+				TestEngine: &TestEngineProperty{
+					Runs: []TestEngineRun{
+						{
+							ID: "2fd5c15a-a3a6-45ab-b1b2-6ea59616c1cf",
+							Suite: TestEngineSuite{
+								ID:   "b1c349b6-c7d6-4633-8941-7e615459c03d",
+								Slug: "banana",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We need an easy way for the buildkite-mcp-server to go from a given build to its associated runs. This adds support for the new test engine properties which I've added to the Buildkite Rest API.