### PR TITLE
Add support for getting failed executions

### DIFF
--- a/test_runs.go
+++ b/test_runs.go
@@ -22,6 +22,23 @@ type TestRun struct {
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
+type FailedExecution struct {
+	ExecutionID      string     `json:"execution_id,omitempty"`
+	RunID            string     `json:"run_id,omitempty"`
+	TestID           string     `json:"test_id,omitempty"`
+	RunName          string     `json:"run_name,omitempty"`
+	CommitSHA        string     `json:"commit_sha,omitempty"`
+	CreatedAt        *Timestamp `json:"created_at,omitempty"`
+	Branch           string     `json:"branch,omitempty"`
+	FailureReason    string     `json:"failure_reason,omitempty"`
+	Duration         float64    `json:"duration,omitempty"`
+	Location         string     `json:"location,omitempty"`
+	TestName         string     `json:"test_name,omitempty"`
+	RunURL           string     `json:"run_url,omitempty"`
+	TestURL          string     `json:"test_url,omitempty"`
+	TestExecutionURL string     `json:"test_execution_url,omitempty"`
+}
+
 type TestRunsListOptions struct {
 	ListOptions
 }
@@ -61,4 +78,20 @@ func (trs *TestRunsService) Get(ctx context.Context, org, slug, runID string) (T
 	}
 
 	return testRun, resp, err
+}
+
+func (trs *TestRunsService) GetFailedExecutions(ctx context.Context, org, slug, runID string) ([]FailedExecution, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/runs/%s/failed_executions", org, slug, runID)
+	req, err := trs.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var failedExecutions []FailedExecution
+	resp, err := trs.client.Do(req, &failedExecutions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return failedExecutions, resp, err
 }


### PR DESCRIPTION
This adds support for the Test Runs failed executions endpoint - https://buildkite.com/docs/apis/rest-api/test-engine/runs#get-failed-execution-data