### PR TITLE
Allow fetching optional failure_expanded from failed_executions API

### DIFF
--- a/test_runs.go
+++ b/test_runs.go
@@ -22,25 +22,35 @@ type TestRun struct {
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 }
 
+type FailureExpanded struct {
+	Backtrace []string `json:"backtrace,omitempty"`
+	Expanded  []string `json:"expanded,omitempty"`
+}
+
 type FailedExecution struct {
-	ExecutionID      string     `json:"execution_id,omitempty"`
-	RunID            string     `json:"run_id,omitempty"`
-	TestID           string     `json:"test_id,omitempty"`
-	RunName          string     `json:"run_name,omitempty"`
-	CommitSHA        string     `json:"commit_sha,omitempty"`
-	CreatedAt        *Timestamp `json:"created_at,omitempty"`
-	Branch           string     `json:"branch,omitempty"`
-	FailureReason    string     `json:"failure_reason,omitempty"`
-	Duration         float64    `json:"duration,omitempty"`
-	Location         string     `json:"location,omitempty"`
-	TestName         string     `json:"test_name,omitempty"`
-	RunURL           string     `json:"run_url,omitempty"`
-	TestURL          string     `json:"test_url,omitempty"`
-	TestExecutionURL string     `json:"test_execution_url,omitempty"`
+	ExecutionID      string            `json:"execution_id,omitempty"`
+	RunID            string            `json:"run_id,omitempty"`
+	TestID           string            `json:"test_id,omitempty"`
+	RunName          string            `json:"run_name,omitempty"`
+	CommitSHA        string            `json:"commit_sha,omitempty"`
+	CreatedAt        *Timestamp        `json:"created_at,omitempty"`
+	Branch           string            `json:"branch,omitempty"`
+	FailureReason    string            `json:"failure_reason,omitempty"`
+	FailureExpanded  []FailureExpanded `json:"failure_expanded,omitempty"`
+	Duration         float64           `json:"duration,omitempty"`
+	Location         string            `json:"location,omitempty"`
+	TestName         string            `json:"test_name,omitempty"`
+	RunURL           string            `json:"run_url,omitempty"`
+	TestURL          string            `json:"test_url,omitempty"`
+	TestExecutionURL string            `json:"test_execution_url,omitempty"`
 }
 
 type TestRunsListOptions struct {
 	ListOptions
+}
+
+type FailedExecutionsOptions struct {
+	IncludeFailureExpanded bool `url:"include_failure_expanded,omitempty"`
 }
 
 func (trs *TestRunsService) List(ctx context.Context, org, slug string, opt *TestRunsListOptions) ([]TestRun, *Response, error) {
@@ -80,8 +90,13 @@ func (trs *TestRunsService) Get(ctx context.Context, org, slug, runID string) (T
 	return testRun, resp, err
 }
 
-func (trs *TestRunsService) GetFailedExecutions(ctx context.Context, org, slug, runID string) ([]FailedExecution, *Response, error) {
+func (trs *TestRunsService) GetFailedExecutions(ctx context.Context, org, slug, runID string, opt *FailedExecutionsOptions) ([]FailedExecution, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/runs/%s/failed_executions", org, slug, runID)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	req, err := trs.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {
 		return nil, nil, err

--- a/test_runs_test.go
+++ b/test_runs_test.go
@@ -143,6 +143,17 @@ func TestTestRunsService_GetFailedExecutions(t *testing.T) {
 					"created_at": "2025-02-03T05:32:53.228Z",
 					"branch": "main",
 					"failure_reason": "it didn't work",
+					"failure_expanded": [
+						{
+							"backtrace": [
+								"./spec/models/user.rb:23:in 'block (2 levels) in <top (required)>'"
+							],
+							"expanded": [
+								"RuntimeError:",
+								"it didn't work"
+							]
+						}
+					],
 					"duration": 3.79073,
 					"location": "./spec/models/user.rb:23",
 					"test_name": "Deploy should be available",
@@ -153,7 +164,89 @@ func TestTestRunsService_GetFailedExecutions(t *testing.T) {
 			]`)
 	})
 
-	failedExecutions, _, err := client.TestRuns.GetFailedExecutions(context.Background(), "my-great-org", "suite-example", "3c90a8ad-8e86-4e78-87b4-acae5e808de4")
+	failedExecutions, _, err := client.TestRuns.GetFailedExecutions(context.Background(), "my-great-org", "suite-example", "3c90a8ad-8e86-4e78-87b4-acae5e808de4", nil)
+
+	if err != nil {
+		t.Errorf("TestRuns.GetFailedExecutions returned error: %v", err)
+	}
+
+	// Create Time instance from string in BuildKiteDateFormat friendly format
+	parsedTime, err := time.Parse(BuildKiteDateFormat, "2025-02-03T05:32:53.228Z")
+	if err != nil {
+		t.Errorf("TestRuns.GetFailedExecutions time.Parse error: %v", err)
+	}
+
+	want := []FailedExecution{
+		{
+			ExecutionID:   "60f0e64c-ae4b-870e-b41f-5431205caf06",
+			RunID:         "075bbcd9-662c-86f5-9d40-adfa6549eff1",
+			TestID:        "f6cb6c43-df94-8b60-81ed-14f9db7bbfd8",
+			RunName:       "075bbcd9-662c-86f5-9d40-adfa6549eff1",
+			CommitSHA:     "1c3214fcceb2c14579a2c3c50cd78f1442fd8936",
+			CreatedAt:     NewTimestamp(parsedTime),
+			Branch:        "main",
+			FailureReason: "it didn't work",
+			FailureExpanded: []FailureExpanded{
+				{
+					Backtrace: []string{"./spec/models/user.rb:23:in 'block (2 levels) in <top (required)>'"},
+					Expanded:  []string{"RuntimeError:", "it didn't work"},
+				},
+			},
+			Duration:         3.79073,
+			Location:         "./spec/models/user.rb:23",
+			TestName:         "Deploy should be available",
+			RunURL:           "https://buildkite.com/organizations/buildkite/analytics/suites/my-test-suite/runs/075bbcd9-662c-86f5-9d40-adfa6549eff1",
+			TestURL:          "https://buildkite.com/organizations/buildkite/analytics/suites/my-test-suite/tests/f6cb6c43-df94-8b60-81ed-14f9db7bbfd8",
+			TestExecutionURL: "https://buildkite.com/organizations/buildkite/analytics/suites/my-test-suite/tests/f6cb6c43-df94-8b60-81ed-14f9db7bbfd8?execution_id=60f0e64c-ae4b-870e-b41f-5431205caf06",
+		},
+	}
+
+	if diff := cmp.Diff(failedExecutions, want); diff != "" {
+		t.Errorf("TestRuns.GetFailedExecutions diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestTestRunsService_GetFailedExecutions_WithFailureExpanded(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/runs/3c90a8ad-8e86-4e78-87b4-acae5e808de4/failed_executions", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+
+		// Check that include_failure_expanded parameter is included
+		if r.URL.Query().Get("include_failure_expanded") != "true" {
+			t.Errorf("Expected include_failure_expanded=true in query parameters, got: %s", r.URL.Query().Get("include_failure_expanded"))
+		}
+
+		_, _ = fmt.Fprint(w,
+			`
+			[
+				{
+					"execution_id": "60f0e64c-ae4b-870e-b41f-5431205caf06",
+					"run_id": "075bbcd9-662c-86f5-9d40-adfa6549eff1",
+					"test_id": "f6cb6c43-df94-8b60-81ed-14f9db7bbfd8",
+					"run_name": "075bbcd9-662c-86f5-9d40-adfa6549eff1",
+					"commit_sha": "1c3214fcceb2c14579a2c3c50cd78f1442fd8936",
+					"created_at": "2025-02-03T05:32:53.228Z",
+					"branch": "main",
+					"failure_reason": "it didn't work",
+					"duration": 3.79073,
+					"location": "./spec/models/user.rb:23",
+					"test_name": "Deploy should be available",
+					"run_url": "https://buildkite.com/organizations/buildkite/analytics/suites/my-test-suite/runs/075bbcd9-662c-86f5-9d40-adfa6549eff1",
+					"test_url": "https://buildkite.com/organizations/buildkite/analytics/suites/my-test-suite/tests/f6cb6c43-df94-8b60-81ed-14f9db7bbfd8",
+					"test_execution_url": "https://buildkite.com/organizations/buildkite/analytics/suites/my-test-suite/tests/f6cb6c43-df94-8b60-81ed-14f9db7bbfd8?execution_id=60f0e64c-ae4b-870e-b41f-5431205caf06"
+				}
+			]`)
+	})
+
+	options := &FailedExecutionsOptions{
+		IncludeFailureExpanded: true,
+	}
+
+	failedExecutions, _, err := client.TestRuns.GetFailedExecutions(context.Background(), "my-great-org", "suite-example", "3c90a8ad-8e86-4e78-87b4-acae5e808de4", options)
 
 	if err != nil {
 		t.Errorf("TestRuns.GetFailedExecutions returned error: %v", err)


### PR DESCRIPTION
This supports the addition of requesting "failure_expanded" from the Test Engine failed executions API.