### PR TITLE
support X-Buildkite-Token in headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .gopath
+.claude/
+.opencode/


### PR DESCRIPTION
## Changes

- Allows users to set `X-Buildkite-Token` in headers, as per the docs

Fixes https://github.com/buildkite/go-buildkite/issues/207
