### PR TITLE
Add agent pause and resume functionality

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -150,23 +150,14 @@ type AgentPauseOptions struct {
 	TimeoutInMinutes int    `json:"timeout_in_minutes,omitempty"`
 }
 
-// Pause an agent.
+// Pause an agent with optional note and timeout.
 //
 // buildkite API docs: https://buildkite.com/docs/api/agents#pause-an-agent
-func (as *AgentsService) Pause(ctx context.Context, org string, id string) (*Response, error) {
+func (as *AgentsService) Pause(ctx context.Context, org string, id string, opts *AgentPauseOptions) (*Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/agents/%s/pause", org, id)
-	req, err := as.client.NewRequest(ctx, "PUT", u, struct{}{})
-	if err != nil {
-		return nil, err
+	if opts == nil {
+		opts = &AgentPauseOptions{}
 	}
-	return as.client.Do(req, nil)
-}
-
-// PauseWithOptions pauses an agent with optional note and timeout.
-//
-// buildkite API docs: https://buildkite.com/docs/api/agents#pause-an-agent
-func (as *AgentsService) PauseWithOptions(ctx context.Context, org string, id string, opts *AgentPauseOptions) (*Response, error) {
-	u := fmt.Sprintf("v2/organizations/%s/agents/%s/pause", org, id)
 	req, err := as.client.NewRequest(ctx, "PUT", u, opts)
 	if err != nil {
 		return nil, err

--- a/agents.go
+++ b/agents.go
@@ -143,3 +143,45 @@ func (as *AgentsService) Stop(ctx context.Context, org string, id string, force 
 
 	return as.client.Do(req, nil)
 }
+
+// AgentPauseOptions specifies the optional parameters to pause an agent
+type AgentPauseOptions struct {
+	Note             string `json:"note,omitempty"`
+	TimeoutInMinutes int    `json:"timeout_in_minutes,omitempty"`
+}
+
+// Pause an agent.
+//
+// buildkite API docs: https://buildkite.com/docs/api/agents#pause-an-agent
+func (as *AgentsService) Pause(ctx context.Context, org string, id string) (*Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/agents/%s/pause", org, id)
+	req, err := as.client.NewRequest(ctx, "PUT", u, struct{}{})
+	if err != nil {
+		return nil, err
+	}
+	return as.client.Do(req, nil)
+}
+
+// PauseWithOptions pauses an agent with optional note and timeout.
+//
+// buildkite API docs: https://buildkite.com/docs/api/agents#pause-an-agent
+func (as *AgentsService) PauseWithOptions(ctx context.Context, org string, id string, opts *AgentPauseOptions) (*Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/agents/%s/pause", org, id)
+	req, err := as.client.NewRequest(ctx, "PUT", u, opts)
+	if err != nil {
+		return nil, err
+	}
+	return as.client.Do(req, nil)
+}
+
+// Resume an agent.
+//
+// buildkite API docs: https://buildkite.com/docs/api/agents#resume-an-agent
+func (as *AgentsService) Resume(ctx context.Context, org string, id string) (*Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/agents/%s/resume", org, id)
+	req, err := as.client.NewRequest(ctx, "PUT", u, struct{}{})
+	if err != nil {
+		return nil, err
+	}
+	return as.client.Do(req, nil)
+}

--- a/agents_test.go
+++ b/agents_test.go
@@ -135,65 +135,65 @@ func TestAgentsService_Stop(t *testing.T) {
 func TestAgentsService_Pause(t *testing.T) {
 	t.Parallel()
 
-	server, client, teardown := newMockServerAndClient(t)
-	t.Cleanup(teardown)
+	t.Run("without options", func(t *testing.T) {
+		server, client, teardown := newMockServerAndClient(t)
+		t.Cleanup(teardown)
 
-	server.HandleFunc("/v2/organizations/my-great-org/agents/123/pause", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		body, err := io.ReadAll(r.Body)
+		server.HandleFunc("/v2/organizations/my-great-org/agents/123/pause", func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "PUT")
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("could not read request body: %v", err)
+			}
+			expectedBody := "{}"
+			actualBody := strings.TrimSpace(string(body))
+			if actualBody != expectedBody {
+				t.Errorf("Expected request body %q, got %q", expectedBody, actualBody)
+			}
+		})
+
+		_, err := client.Agents.Pause(context.Background(), "my-great-org", "123", nil)
 		if err != nil {
-			t.Errorf("could not read request body: %v", err)
-		}
-		expectedBody := "{}"
-		actualBody := strings.TrimSpace(string(body))
-		if actualBody != expectedBody {
-			t.Errorf("Expected request body %q, got %q", expectedBody, actualBody)
+			t.Errorf("Agents.Pause returned error: %v", err)
 		}
 	})
 
-	_, err := client.Agents.Pause(context.Background(), "my-great-org", "123")
-	if err != nil {
-		t.Errorf("Agents.Pause returned error: %v", err)
-	}
-}
+	t.Run("with options", func(t *testing.T) {
+		server, client, teardown := newMockServerAndClient(t)
+		t.Cleanup(teardown)
 
-func TestAgentsService_PauseWithOptions(t *testing.T) {
-	t.Parallel()
+		server.HandleFunc("/v2/organizations/my-great-org/agents/123/pause", func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "PUT")
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("could not read request body: %v", err)
+			}
 
-	server, client, teardown := newMockServerAndClient(t)
-	t.Cleanup(teardown)
+			var requestBody AgentPauseOptions
+			err = json.Unmarshal(body, &requestBody)
+			if err != nil {
+				t.Errorf("could not unmarshal request body: %v", err)
+			}
 
-	server.HandleFunc("/v2/organizations/my-great-org/agents/123/pause", func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "PUT")
-		body, err := io.ReadAll(r.Body)
+			if requestBody.Note != "Maintenance scheduled" {
+				t.Errorf("Expected note %q, got %q", "Maintenance scheduled", requestBody.Note)
+			}
+
+			if requestBody.TimeoutInMinutes != 60 {
+				t.Errorf("Expected timeout %d, got %d", 60, requestBody.TimeoutInMinutes)
+			}
+		})
+
+		opts := &AgentPauseOptions{
+			Note:             "Maintenance scheduled",
+			TimeoutInMinutes: 60,
+		}
+
+		_, err := client.Agents.Pause(context.Background(), "my-great-org", "123", opts)
 		if err != nil {
-			t.Errorf("could not read request body: %v", err)
-		}
-
-		var requestBody AgentPauseOptions
-		err = json.Unmarshal(body, &requestBody)
-		if err != nil {
-			t.Errorf("could not unmarshal request body: %v", err)
-		}
-
-		if requestBody.Note != "Maintenance scheduled" {
-			t.Errorf("Expected note %q, got %q", "Maintenance scheduled", requestBody.Note)
-		}
-
-		if requestBody.TimeoutInMinutes != 60 {
-			t.Errorf("Expected timeout %d, got %d", 60, requestBody.TimeoutInMinutes)
+			t.Errorf("Agents.Pause returned error: %v", err)
 		}
 	})
-
-	opts := &AgentPauseOptions{
-		Note:             "Maintenance scheduled",
-		TimeoutInMinutes: 60,
-	}
-
-	_, err := client.Agents.PauseWithOptions(context.Background(), "my-great-org", "123", opts)
-	if err != nil {
-		t.Errorf("Agents.PauseWithOptions returned error: %v", err)
-	}
 }
 
 func TestAgentsService_Resume(t *testing.T) {

--- a/agents_test.go
+++ b/agents_test.go
@@ -131,3 +131,90 @@ func TestAgentsService_Stop(t *testing.T) {
 		t.Errorf("Agents.Stop returned error: %v", err)
 	}
 }
+
+func TestAgentsService_Pause(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/agents/123/pause", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("could not read request body: %v", err)
+		}
+		expectedBody := "{}"
+		actualBody := strings.TrimSpace(string(body))
+		if actualBody != expectedBody {
+			t.Errorf("Expected request body %q, got %q", expectedBody, actualBody)
+		}
+	})
+
+	_, err := client.Agents.Pause(context.Background(), "my-great-org", "123")
+	if err != nil {
+		t.Errorf("Agents.Pause returned error: %v", err)
+	}
+}
+
+func TestAgentsService_PauseWithOptions(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/agents/123/pause", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("could not read request body: %v", err)
+		}
+
+		var requestBody AgentPauseOptions
+		err = json.Unmarshal(body, &requestBody)
+		if err != nil {
+			t.Errorf("could not unmarshal request body: %v", err)
+		}
+
+		if requestBody.Note != "Maintenance scheduled" {
+			t.Errorf("Expected note %q, got %q", "Maintenance scheduled", requestBody.Note)
+		}
+
+		if requestBody.TimeoutInMinutes != 60 {
+			t.Errorf("Expected timeout %d, got %d", 60, requestBody.TimeoutInMinutes)
+		}
+	})
+
+	opts := &AgentPauseOptions{
+		Note:             "Maintenance scheduled",
+		TimeoutInMinutes: 60,
+	}
+
+	_, err := client.Agents.PauseWithOptions(context.Background(), "my-great-org", "123", opts)
+	if err != nil {
+		t.Errorf("Agents.PauseWithOptions returned error: %v", err)
+	}
+}
+
+func TestAgentsService_Resume(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/agents/123/resume", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PUT")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("could not read request body: %v", err)
+		}
+		if strings.TrimSpace(string(body)) != "{}" {
+			t.Errorf("Expected request body %q, got %q", "{}", strings.TrimSpace(string(body)))
+		}
+	})
+
+	_, err := client.Agents.Resume(context.Background(), "my-great-org", "123")
+	if err != nil {
+		t.Errorf("Agents.Resume returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Add agent pause and resume methods

- Add Pause() method
- Add Resume() method
- Add AgentPauseOptions struct for note and timeout support as per [API Spec](https://buildkite.com/docs/apis/rest-api/agents#pause-an-agent)
- Add tests for new methods