### PR TITLE
Setting min go version to 1.23 with toolchain version to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/buildkite/go-buildkite/v4
 
-go 1.23.0
+go 1.23
 
-toolchain go1.24.0
+toolchain go1.24
 
 require (
 	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/buildkite/go-buildkite/v4
 
-go 1.24
+go 1.23.0
+
+toolchain go1.24.0
 
 require (
 	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/buildkite/go-buildkite/v4
 
-go 1.23
+go 1.23.0
 
-toolchain go1.24
+toolchain go1.24.0
 
 require (
 	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf


### PR DESCRIPTION
PR to lower the minimum Go version to 1.23.

Ensures CI/dev still uses Go 1.24 via the toolchain.