### PR TITLE
fix: update cluster maintainers to match REST api for create and list

### DIFF
--- a/clusters.go
+++ b/clusters.go
@@ -30,20 +30,20 @@ type ClusterUpdate struct {
 }
 
 type Cluster struct {
-	ID              string              `json:"id,omitempty"`
-	GraphQLID       string              `json:"graphql_id,omitempty"`
-	DefaultQueueID  string              `json:"default_queue_id,omitempty"`
-	Name            string              `json:"name,omitempty"`
-	Description     string              `json:"description,omitempty"`
-	Emoji           string              `json:"emoji,omitempty"`
-	Color           string              `json:"color,omitempty"`
-	URL             string              `json:"url,omitempty"`
-	WebURL          string              `json:"web_url,omitempty"`
-	QueuesURL       string              `json:"queues_url,omitempty"`
-	DefaultQueueURL string              `json:"default_queue_url,omitempty"`
-	CreatedAt       *Timestamp          `json:"created_at,omitempty"`
-	CreatedBy       ClusterCreator      `json:"created_by,omitempty"`
-	Maintainers     []ClusterMaintainer `json:"maintainers,omitempty"`
+	ID              string                 `json:"id,omitempty"`
+	GraphQLID       string                 `json:"graphql_id,omitempty"`
+	DefaultQueueID  string                 `json:"default_queue_id,omitempty"`
+	Name            string                 `json:"name,omitempty"`
+	Description     string                 `json:"description,omitempty"`
+	Emoji           string                 `json:"emoji,omitempty"`
+	Color           string                 `json:"color,omitempty"`
+	URL             string                 `json:"url,omitempty"`
+	WebURL          string                 `json:"web_url,omitempty"`
+	QueuesURL       string                 `json:"queues_url,omitempty"`
+	DefaultQueueURL string                 `json:"default_queue_url,omitempty"`
+	CreatedAt       *Timestamp             `json:"created_at,omitempty"`
+	CreatedBy       ClusterCreator         `json:"created_by,omitempty"`
+	Maintainers     ClusterMaintainersList `json:"maintainers,omitempty"`
 }
 
 type ClusterCreator struct {
@@ -60,6 +60,26 @@ type ClusterMaintainer struct {
 	TeamID string `json:"team,omitempty"`
 }
 
+// ClusterMaintainersList represents the maintainers of a cluster with separate lists for users and teams.
+type ClusterMaintainersList struct {
+	Users []ClusterMaintainerEntry `json:"users,omitempty"`
+	Teams []ClusterMaintainerEntry `json:"teams,omitempty"`
+}
+
+// ClusterMaintainerEntry represents either a user or a team which is indicated by the Type field in the Actor.
+type ClusterMaintainerEntry struct {
+	ID    string                 `json:"id,omitempty"`
+	Actor ClusterMaintainerActor `json:"actor,omitempty"`
+}
+
+type ClusterMaintainerActor struct {
+	ID        string `json:"id,omitempty"`
+	GraphQLID string `json:"graphql_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Email     string `json:"email,omitempty"`
+	Type      string `json:"type,omitempty"` // "user" or "team"
+	Slug      string `json:"slug,omitempty"`
+}
 type ClustersListOptions struct{ ListOptions }
 
 func (cs *ClustersService) List(ctx context.Context, org string, opt *ClustersListOptions) ([]Cluster, *Response, error) {

--- a/clusters_test.go
+++ b/clusters_test.go
@@ -29,6 +29,10 @@ func TestClustersService_List(t *testing.T) {
 					"description": "A cluster for development pipelines",
 					"emoji": ":toolbox:",
 					"color": "#A9CCE3",
+					"maintainers": {
+						"users": [],
+						"teams": []
+					},
 					"url": "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
 					"web_url": "https://buildkite.com/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
 					"queues_url": "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0/queues",
@@ -49,6 +53,10 @@ func TestClustersService_List(t *testing.T) {
 					"description": "A cluster for production pipelines",
 					"emoji": ":toolbox:",
 					"color": "#B9E3A9",
+					"maintainers": {
+						"users": [],
+						"teams": []
+					},
 					"url": "https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e",
 					"web_url": "https://buildkite.com/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e",
 					"queues_url": "https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e/queues",
@@ -91,11 +99,15 @@ func TestClustersService_List(t *testing.T) {
 			Description: "A cluster for development pipelines",
 			Emoji:       ":toolbox:",
 			Color:       "#A9CCE3",
-			URL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
-			WebURL:      "https://buildkite.com/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
-			QueuesURL:   "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0/queues",
-			CreatedAt:   NewTimestamp(devClusterCreatedAt),
-			CreatedBy:   clusterCreator,
+			Maintainers: ClusterMaintainersList{
+				Users: []ClusterMaintainerEntry{},
+				Teams: []ClusterMaintainerEntry{},
+			},
+			URL:       "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
+			WebURL:    "https://buildkite.com/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0",
+			QueuesURL: "https://api.buildkite.com/v2/organizations/my-great-org/clusters/528000d8-4ee1-4479-8af1-032b143185f0/queues",
+			CreatedAt: NewTimestamp(devClusterCreatedAt),
+			CreatedBy: clusterCreator,
 		},
 		{
 			ID:          "3edcecdb-5191-44f1-a5ae-370083c8f92e",
@@ -104,11 +116,15 @@ func TestClustersService_List(t *testing.T) {
 			Description: "A cluster for production pipelines",
 			Emoji:       ":toolbox:",
 			Color:       "#B9E3A9",
-			URL:         "https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e",
-			WebURL:      "https://buildkite.com/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e",
-			QueuesURL:   "https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e/queues",
-			CreatedAt:   NewTimestamp(prodClusterCreatedAt),
-			CreatedBy:   clusterCreator,
+			Maintainers: ClusterMaintainersList{
+				Users: []ClusterMaintainerEntry{},
+				Teams: []ClusterMaintainerEntry{},
+			},
+			URL:       "https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e",
+			WebURL:    "https://buildkite.com/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e",
+			QueuesURL: "https://api.buildkite.com/v2/organizations/my-great-org/clusters/3edcecdb-5191-44f1-a5ae-370083c8f92e/queues",
+			CreatedAt: NewTimestamp(prodClusterCreatedAt),
+			CreatedBy: clusterCreator,
 		},
 	}
 
@@ -185,6 +201,90 @@ func TestClustersService_Get(t *testing.T) {
 	}
 }
 
+func TestClustersService_CreateWithMaintainers(t *testing.T) {
+
+	clusterCreate := ClusterCreate{
+		Name:        "Testing Cluster",
+		Description: "A cluster for testing",
+		Emoji:       ":construction:",
+		Color:       "E5F185",
+		Maintainers: []ClusterMaintainer{
+			{
+				UserID: "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+			},
+		},
+	}
+
+	clusterExpect := Cluster{
+		Name:        "Testing Cluster",
+		Description: "A cluster for testing",
+		Emoji:       ":construction:",
+		Color:       "E5F185",
+		Maintainers: ClusterMaintainersList{
+			Users: []ClusterMaintainerEntry{
+				{
+					ID: "a51e41d4-7f60-4305-b6ba-c1c5a9611470",
+					Actor: ClusterMaintainerActor{
+						ID:    "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+						Name:  "Barry White",
+						Email: "barry.white@example.com",
+						Type:  "user",
+					},
+				},
+			},
+			Teams: []ClusterMaintainerEntry{},
+		},
+	}
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/clusters", func(w http.ResponseWriter, r *http.Request) {
+		var v ClusterCreate
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
+
+		testMethod(t, r, "POST")
+
+		if diff := cmp.Diff(v, clusterCreate); diff != "" {
+			t.Errorf("Request body diff: (-got +want)\n%s", diff)
+		}
+
+		_, _ = fmt.Fprint(w,
+			`{
+						"name": "Testing Cluster",
+						"description": "A cluster for testing",
+						"emoji": ":construction:",
+						"color": "E5F185",
+						"maintainers": {
+							"users": [
+								{ 
+									"id": "a51e41d4-7f60-4305-b6ba-c1c5a9611470",
+									"actor": {
+										"id": "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
+										"name": "Barry White",
+										"email": "barry.white@example.com",
+										"type": "user"
+									}
+								}
+							],
+							"teams": []
+						}
+					}`)
+	})
+
+	cluster, _, err := client.Clusters.Create(context.Background(), "my-great-org", clusterCreate)
+	if err != nil {
+		t.Errorf("TestClusters.CreateWithMaintainers returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(cluster, clusterExpect); diff != "" {
+		t.Errorf("TestClusters.Create diff: (-got +want)\n%s", diff)
+	}
+}
+
 func TestClustersService_Create(t *testing.T) {
 	t.Parallel()
 
@@ -210,6 +310,10 @@ func TestClustersService_Create(t *testing.T) {
 				Description: "A cluster for testing",
 				Emoji:       ":construction:",
 				Color:       "E5F185",
+				Maintainers: ClusterMaintainersList{
+					Users: []ClusterMaintainerEntry{},
+					Teams: []ClusterMaintainerEntry{},
+				},
 			},
 		},
 		{
@@ -219,21 +323,15 @@ func TestClustersService_Create(t *testing.T) {
 				Description: "A cluster for testing",
 				Emoji:       ":construction:",
 				Color:       "E5F185",
-				Maintainers: []ClusterMaintainer{
-					{
-						UserID: "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
-					},
-				},
 			},
 			want: Cluster{
 				Name:        "Testing Cluster",
 				Description: "A cluster for testing",
 				Emoji:       ":construction:",
 				Color:       "E5F185",
-				Maintainers: []ClusterMaintainer{
-					{
-						UserID: "7da07e25-0383-4aff-a7cf-14d1a9aa098f",
-					},
+				Maintainers: ClusterMaintainersList{
+					Users: []ClusterMaintainerEntry{},
+					Teams: []ClusterMaintainerEntry{},
 				},
 			},
 		},
@@ -274,20 +372,17 @@ func TestClustersService_Create(t *testing.T) {
 					return
 				}
 
-				maintainersJSON := "null"
-				if len(tt.input.Maintainers) > 0 {
-					maintainersBytes, _ := json.Marshal(tt.input.Maintainers)
-					maintainersJSON = string(maintainersBytes)
-				}
-
-				_, _ = fmt.Fprintf(w,
+				_, _ = fmt.Fprint(w,
 					`{
 						"name": "Testing Cluster",
 						"description": "A cluster for testing",
 						"emoji": ":construction:",
 						"color": "E5F185",
-						"maintainers": %s
-					}`, maintainersJSON)
+						"maintainers": {
+							"users": [],
+							"teams": []
+						}
+					}`)
 			})
 
 			cluster, _, err := client.Clusters.Create(context.Background(), "my-great-org", tt.input)


### PR DESCRIPTION
So at the moment I am getting the following error when I list clusters via the go-buildkite.

```
json: cannot unmarshal object into Go struct field Cluster.maintainers of type []buildkite.ClusterMaintainer
```

This problem was introduced in #240 which correctly specified the maintainers in the `ClusterCreate` however what we get back from the api differs from this. I have updated the tests to demonstrate the issue and added structures to support what is returned by the API. 