### PR TITLE
feat: command timeouts on pipeline create/update

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -26,8 +26,10 @@ type CreatePipeline struct {
 
 	// Optional fields
 	DefaultBranch                   string            `json:"default_branch,omitempty"`
+	DefaultCommandStepTimeout       int               `json:"default_command_step_timeout,omitempty"`
 	Description                     string            `json:"description,omitempty"`
 	Env                             map[string]string `json:"env,omitempty"`
+	MaximumCommandStepTimeout       int               `json:"maximum_command_step_timeout,omitempty"`
 	ProviderSettings                ProviderSettings  `json:"provider_settings,omitempty"`
 	BranchConfiguration             string            `json:"branch_configuration,omitempty"`
 	SkipQueuedBranchBuilds          bool              `json:"skip_queued_branch_builds"`
@@ -47,7 +49,9 @@ type UpdatePipeline struct {
 	Name                            string           `json:"name,omitempty"`
 	Repository                      string           `json:"repository,omitempty"`
 	DefaultBranch                   string           `json:"default_branch,omitempty"`
+	DefaultCommandStepTimeout       int              `json:"default_command_step_timeout,omitempty"`
 	Description                     string           `json:"description,omitempty"`
+	MaximumCommandStepTimeout       int              `json:"maximum_command_step_timeout,omitempty"`
 	ProviderSettings                ProviderSettings `json:"provider_settings,omitempty"`
 	BranchConfiguration             string           `json:"branch_configuration,omitempty"`
 	SkipQueuedBranchBuilds          bool             `json:"skip_queued_branch_builds"`
@@ -96,6 +100,10 @@ type Pipeline struct {
 	Steps         []Step         `json:"steps,omitempty"`
 	Configuration string         `json:"configuration,omitempty"`
 	Env           map[string]any `json:"env,omitempty"`
+
+	// timeouts
+	DefaultCommandStepTimeout int `json:"default_command_step_timeout,omitempty"`
+	MaximumCommandStepTimeout int `json:"maximum_command_step_timeout,omitempty"`
 }
 
 // Step represents a build step in buildkites build pipeline


### PR DESCRIPTION
## Description

We can set the _default_ and _maximum_ command step timeouts for both `Create` and `Update` calls.

## Changes

- Adds the _default_ and _maximum_ timeout options for `create` and `update` methods
- We `omitempty` as standard, but for the `Pipeline` struct this is required as the fields aren't returned in the response currently
- The return is feature gated for now, it may become globally enabled and then we can extend our test coverage for these fields
