### PR TITLE
bm/artifact get

### DIFF
--- a/artifacts.go
+++ b/artifacts.go
@@ -83,7 +83,7 @@ func (as *ArtifactsService) ListByJob(ctx context.Context, org string, pipeline 
 	return artifacts, resp, err
 }
 
-func (as *ArtifactsService) GetArtifact(ctx context.Context, org, pipeline, build, job, id string) (Artifact, *Response, error) {
+func (as *ArtifactsService) Get(ctx context.Context, org, pipeline, build, job, id string) (Artifact, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/artifacts/%s", org, pipeline, build, job, id)
 	req, err := as.client.NewRequest(ctx, "GET", u, nil)
 	if err != nil {

--- a/artifacts_test.go
+++ b/artifacts_test.go
@@ -114,7 +114,7 @@ func TestArtifactsService_ListByJob_WithPagination(t *testing.T) {
 	}
 }
 
-func TestArtifactsService_GetArtifact(t *testing.T) {
+func TestArtifactsService_Get(t *testing.T) {
 	t.Parallel()
 
 	server, client, teardown := newMockServerAndClient(t)
@@ -137,9 +137,9 @@ func TestArtifactsService_GetArtifact(t *testing.T) {
 		}`)
 	})
 
-	artifact, _, err := client.Artifacts.GetArtifact(context.Background(), "my-great-org", "sup-keith", "123", "job-456", "art-789")
+	artifact, _, err := client.Artifacts.Get(context.Background(), "my-great-org", "sup-keith", "123", "job-456", "art-789")
 	if err != nil {
-		t.Errorf("GetArtifact returned error: %v", err)
+		t.Errorf("Get returned error: %v", err)
 	}
 
 	want := Artifact{
@@ -156,7 +156,7 @@ func TestArtifactsService_GetArtifact(t *testing.T) {
 		SHA1:        "abc123def456",
 	}
 	if diff := cmp.Diff(artifact, want); diff != "" {
-		t.Errorf("GetArtifact diff: (-got +want)\n%s", diff)
+		t.Errorf("Get diff: (-got +want)\n%s", diff)
 	}
 }
 


### PR DESCRIPTION
## Description

Get a single artifact and add missing tests.

## Changes

- Adds a `Get` method to the `ArtifactsService` to get a single artifact
- Adds tests for the `ArtifactsService` as there weren't any tests
