### PR TITLE
Add build id to test runs

### DIFF
--- a/test_runs.go
+++ b/test_runs.go
@@ -22,6 +22,7 @@ type TestRun struct {
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	State     string     `json:"state,omitempty"`
 	Result    string     `json:"result,omitempty"`
+	BuildID   string     `json:"build_id,omitempty"`
 }
 
 type FailureExpanded struct {

--- a/test_runs_test.go
+++ b/test_runs_test.go
@@ -103,7 +103,8 @@ func TestTestRunsService_Get(t *testing.T) {
 				"commit_sha": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
 				"created_at": "2023-05-20T10:25:50.264Z",
 				"state": "finished",
-				"result": "failed"
+				"result": "failed",
+				"build_id": "0191bd22-3c60-7a96-aa84-e173e79bb7f5"
 			}`)
 	})
 
@@ -127,6 +128,7 @@ func TestTestRunsService_Get(t *testing.T) {
 		CreatedAt: NewTimestamp(parsedTime),
 		State:     "finished",
 		Result:    "failed",
+		BuildID:   "0191bd22-3c60-7a96-aa84-e173e79bb7f5",
 	}
 
 	if diff := cmp.Diff(run, want); diff != "" {


### PR DESCRIPTION
A customer reported that the `build_id` was missing from the Runs API in Buildkite MCP and I asked Amp and the response was that the `build_id` was missing upstream from this package. This code was entirely AI written 🤖 