### PR TITLE
Support job reprioritization

### DIFF
--- a/examples/jobs/reprioritize/main.go
+++ b/examples/jobs/reprioritize/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Organization slug").Required().String()
+	pipeline = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+	build    = kingpin.Flag("build", "Build number").Required().String()
+	job      = kingpin.Flag("job", "Job ID").Required().String()
+	priority = kingpin.Flag("priority", "New priority for the job").Required().Int()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	updatedJob, _, err := client.Jobs.ReprioritizeJob(
+		context.Background(),
+		*org,
+		*pipeline,
+		*build,
+		*job,
+		&buildkite.JobReprioritizationOptions{Priority: *priority},
+	)
+	if err != nil {
+		log.Fatalf("Reprioritizing job %s failed: %s", *job, err)
+	}
+
+	data, err := json.MarshalIndent(updatedJob, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/jobs.go
+++ b/jobs.go
@@ -101,6 +101,11 @@ type JobPriority struct {
 	Number int `json:"number,omitempty"`
 }
 
+// JobReprioritizationOptions represent the new priority of a job
+type JobReprioritizationOptions struct {
+	Priority int `json:"priority"`
+}
+
 // StepSignature represents the signature of a step
 type StepSignature struct {
 	Value        string   `json:"value,omitempty"`
@@ -201,4 +206,23 @@ func (js *JobsService) GetJobEnvironmentVariables(ctx context.Context, org strin
 	}
 
 	return jobEnvs, resp, err
+}
+
+// ReprioritizeJob - reprioritize a job
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#reprioritize-a-job
+func (js *JobsService) ReprioritizeJob(ctx context.Context, org, pipeline, buildNumber, jobID string, opt *JobReprioritizationOptions) (Job, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/reprioritize", org, pipeline, buildNumber, jobID)
+	req, err := js.client.NewRequest(ctx, "PUT", u, opt)
+	if err != nil {
+		return Job{}, nil, err
+	}
+
+	var job Job
+	resp, err := js.client.Do(req, &job)
+	if err != nil {
+		return Job{}, resp, err
+	}
+
+	return job, resp, err
 }


### PR DESCRIPTION
## Description

We can use the `/reprioritize` endpoints provided by the REST API to allow for job reprioritization in go-buildkite.

## Changes

- added a new method for reprioritization of jobs
- added a test for `priority` change 
- added an example for folks to use

## Testing

I've tested this successfully in my own pipeline;

```yaml
steps:
  - label: "Hello 👋"
    command: sleep 180
    soft_fail: true
  - wait: ~
  - label: "Higher priority"
    priority: 100
    command: |
      echo "I'm the important job"
  - label: "Lower priority"
    priority: 5
    command: |
      echo "I'm not as important"
```

Then running the example, setting the `priority` of the _lower_ priority job to `200`, where it ran before the _higher_ priority job.
