### PR TITLE
Add `ClusterMaintainersService` to manage cluster maintainer assignments

### DIFF
--- a/buildkite.go
+++ b/buildkite.go
@@ -51,6 +51,7 @@ type Client struct {
 	ClusterQueues            *ClusterQueuesService
 	ClusterTokens            *ClusterTokensService
 	ClusterSecrets           *ClusterSecretsService
+	ClusterMaintainers       *ClusterMaintainersService
 	FlakyTests               *FlakyTestsService
 	Jobs                     *JobsService
 	Members                  *MembersService
@@ -172,6 +173,7 @@ func (c *Client) populateDefaultServices() {
 	c.ClusterQueues = &ClusterQueuesService{c}
 	c.ClusterTokens = &ClusterTokensService{c}
 	c.ClusterSecrets = &ClusterSecretsService{c}
+	c.ClusterMaintainers = &ClusterMaintainersService{c}
 	c.FlakyTests = &FlakyTestsService{c}
 	c.Jobs = &JobsService{c}
 	c.Members = &MembersService{c}

--- a/cluster_maintainers.go
+++ b/cluster_maintainers.go
@@ -1,0 +1,89 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+)
+
+// ClusterMaintainersService handles API calls for cluster maintainer assignments.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/rest-api/clusters/maintainers
+
+type ClusterMaintainersService struct {
+	client *Client
+}
+
+// ClusterMaintainersListOptions controls pagination for listing maintainers.
+type ClusterMaintainersListOptions struct {
+	ListOptions
+}
+
+// List returns the maintainers assigned to a cluster.
+func (cms *ClusterMaintainersService) List(ctx context.Context, org, clusterID string, opt *ClusterMaintainersListOptions) ([]ClusterMaintainerEntry, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/maintainers", org, clusterID)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := cms.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var maintainers []ClusterMaintainerEntry
+	resp, err := cms.client.Do(req, &maintainers)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return maintainers, resp, err
+}
+
+// Get returns one maintainer assignment by ID.
+func (cms *ClusterMaintainersService) Get(ctx context.Context, org, clusterID, id string) (ClusterMaintainerEntry, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/maintainers/%s", org, clusterID, id)
+
+	req, err := cms.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return ClusterMaintainerEntry{}, nil, err
+	}
+
+	var maintainer ClusterMaintainerEntry
+	resp, err := cms.client.Do(req, &maintainer)
+	if err != nil {
+		return ClusterMaintainerEntry{}, resp, err
+	}
+
+	return maintainer, resp, err
+}
+
+// Create assigns a user or team as a maintainer.
+func (cms *ClusterMaintainersService) Create(ctx context.Context, org, clusterID string, input ClusterMaintainer) (ClusterMaintainerEntry, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/maintainers", org, clusterID)
+
+	req, err := cms.client.NewRequest(ctx, "POST", u, input)
+	if err != nil {
+		return ClusterMaintainerEntry{}, nil, err
+	}
+
+	var maintainer ClusterMaintainerEntry
+	resp, err := cms.client.Do(req, &maintainer)
+	if err != nil {
+		return ClusterMaintainerEntry{}, resp, err
+	}
+
+	return maintainer, resp, err
+}
+
+// Delete removes a maintainer assignment from a cluster.
+func (cms *ClusterMaintainersService) Delete(ctx context.Context, org, clusterID, id string) (*Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/maintainers/%s", org, clusterID, id)
+
+	req, err := cms.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return cms.client.Do(req, nil)
+}

--- a/cluster_maintainers_test.go
+++ b/cluster_maintainers_test.go
@@ -1,0 +1,100 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestClusterMaintainersService_List(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = fmt.Fprint(w, `[
+			{"id": "aaa", "actor": {"id": "u1", "name": "Alice", "type": "user"}},
+			{"id": "bbb", "actor": {"id": "t1", "name": "Ops Team", "type": "team"}}
+		]`)
+	})
+
+	got, _, err := client.ClusterMaintainers.List(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", nil)
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+
+	want := []ClusterMaintainerEntry{
+		{ID: "aaa", Actor: ClusterMaintainerActor{ID: "u1", Name: "Alice", Type: "user"}},
+		{ID: "bbb", Actor: ClusterMaintainerActor{ID: "t1", Name: "Ops Team", Type: "team"}},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("List mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestClusterMaintainersService_Get(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers/aaa", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = fmt.Fprint(w, `{"id": "aaa", "actor": {"id": "u1", "name": "Alice", "type": "user"}}`)
+	})
+
+	got, _, err := client.ClusterMaintainers.Get(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "aaa")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+
+	want := ClusterMaintainerEntry{ID: "aaa", Actor: ClusterMaintainerActor{ID: "u1", Name: "Alice", Type: "user"}}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Get mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestClusterMaintainersService_Create(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{"id": "aaa", "actor": {"id": "u1", "name": "Alice", "type": "user"}}`)
+	})
+
+	got, _, err := client.ClusterMaintainers.Create(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", ClusterMaintainer{UserID: "u1"})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	want := ClusterMaintainerEntry{ID: "aaa", Actor: ClusterMaintainerActor{ID: "u1", Name: "Alice", Type: "user"}}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Create mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestClusterMaintainersService_Delete(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers/aaa", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	_, err := client.ClusterMaintainers.Delete(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "aaa")
+	if err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+}

--- a/cluster_maintainers_test.go
+++ b/cluster_maintainers_test.go
@@ -98,3 +98,96 @@ func TestClusterMaintainersService_Delete(t *testing.T) {
 		t.Fatalf("Delete returned error: %v", err)
 	}
 }
+
+func TestClusterMaintainersService_List_pagination(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"page":     "2",
+			"per_page": "5",
+		})
+		_, _ = fmt.Fprint(w, `[{"id": "ccc", "actor": {"id": "u2", "name": "Bob", "type": "user"}}]`)
+	})
+
+	opt := &ClusterMaintainersListOptions{ListOptions: ListOptions{Page: 2, PerPage: 5}}
+	got, _, err := client.ClusterMaintainers.List(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", opt)
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+
+	want := []ClusterMaintainerEntry{
+		{ID: "ccc", Actor: ClusterMaintainerActor{ID: "u2", Name: "Bob", Type: "user"}},
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("List mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestClusterMaintainersService_List_serverError(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, _, err := client.ClusterMaintainers.List(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", nil)
+	if err == nil {
+		t.Fatal("expected error on 500 response, got nil")
+	}
+}
+
+func TestClusterMaintainersService_Get_serverError(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, _, err := client.ClusterMaintainers.Get(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "aaa")
+	if err == nil {
+		t.Fatal("expected error on 404 response, got nil")
+	}
+}
+
+func TestClusterMaintainersService_Create_serverError(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+	})
+
+	_, _, err := client.ClusterMaintainers.Create(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", ClusterMaintainer{UserID: "u1"})
+	if err == nil {
+		t.Fatal("expected error on 422 response, got nil")
+	}
+}
+
+func TestClusterMaintainersService_Delete_serverError(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/maintainers/aaa", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	_, err := client.ClusterMaintainers.Delete(context.Background(), "my-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "aaa")
+	if err == nil {
+		t.Fatal("expected error on 500 response, got nil")
+	}
+}


### PR DESCRIPTION
Introduces `ClusterMaintainersService` with `List`, `Get`, `Create`, and `Delete` methods for the cluster maintainers REST API available at `/maintainers`.

Currently, maintainers can only be set during the initial cluster `Create` request with no way to manage them independently afterwards. This adds the missing CRUD surface, enabling consumers such as the CLI and Terraform provider to properly manage maintainer assignments over the lifetime of a cluster.

Includes tests covering success paths, error responses (4xx/5xx), and pagination behaviour for `List`.

