### PR TITLE
fix the import path for kingpin/v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Simple shortened example for listing all pipelines:
 ```go
 import (
     "github.com/buildkite/go-buildkite/v4"
-    "gopkg.in/alecthomas/kingpin.v2"
+    "github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/buildkite/go-buildkite/v4"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (

--- a/examples/build_tests/list/main.go
+++ b/examples/build_tests/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/builds/get/main.go
+++ b/examples/builds/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_queues/create/main.go
+++ b/examples/cluster_queues/create/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_queues/delete/main.go
+++ b/examples/cluster_queues/delete/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_queues/get/main.go
+++ b/examples/cluster_queues/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_queues/list/main.go
+++ b/examples/cluster_queues/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_queues/pause/main.go
+++ b/examples/cluster_queues/pause/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_queues/resume/main.go
+++ b/examples/cluster_queues/resume/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_queues/update/main.go
+++ b/examples/cluster_queues/update/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/buildkite/go-buildkite/v4"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (

--- a/examples/cluster_tokens/create/main.go
+++ b/examples/cluster_tokens/create/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_tokens/delete/main.go
+++ b/examples/cluster_tokens/delete/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_tokens/get/main.go
+++ b/examples/cluster_tokens/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_tokens/list/main.go
+++ b/examples/cluster_tokens/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/clusters/create/main.go
+++ b/examples/clusters/create/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/clusters/delete/main.go
+++ b/examples/clusters/delete/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/clusters/get/main.go
+++ b/examples/clusters/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/clusters/list/main.go
+++ b/examples/clusters/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/flaky_tests/list/main.go
+++ b/examples/flaky_tests/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/jobs/reprioritize/main.go
+++ b/examples/jobs/reprioritize/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/members/get/main.go
+++ b/examples/members/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/members/list/main.go
+++ b/examples/members/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/package_registries/create/main.go
+++ b/examples/package_registries/create/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/package_registries/delete/main.go
+++ b/examples/package_registries/delete/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/package_registries/get/main.go
+++ b/examples/package_registries/get/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/package_registries/list/main.go
+++ b/examples/package_registries/list/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/package_registries/list_packages/main.go
+++ b/examples/package_registries/list_packages/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/packages/create/main.go
+++ b/examples/packages/create/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/packages/create_presigned_upload/main.go
+++ b/examples/packages/create_presigned_upload/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
+	"github.com/alecthomas/kingpin/v2"
 	"github.com/buildkite/go-buildkite/v4"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (

--- a/examples/packages/delete/main.go
+++ b/examples/packages/delete/main.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/packages/get/main.go
+++ b/examples/packages/get/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/pipeline_templates/create/main.go
+++ b/examples/pipeline_templates/create/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/pipeline_templates/delete/main.go
+++ b/examples/pipeline_templates/delete/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/pipeline_templates/get/main.go
+++ b/examples/pipeline_templates/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/pipeline_templates/list/main.go
+++ b/examples/pipeline_templates/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/pipelines/list/main.go
+++ b/examples/pipelines/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/rate_limits/get/main.go
+++ b/examples/rate_limits/get/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/test_runs/get/main.go
+++ b/examples/test_runs/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/test_runs/list/main.go
+++ b/examples/test_runs/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/test_suites/create/main.go
+++ b/examples/test_suites/create/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/test_suites/delete/main.go
+++ b/examples/test_suites/delete/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/test_suites/get/main.go
+++ b/examples/test_suites/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/test_suites/list/main.go
+++ b/examples/test_suites/list/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/test_suites/update/main.go
+++ b/examples/test_suites/update/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/examples/tests/get/main.go
+++ b/examples/tests/get/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/buildkite/go-buildkite/v4"
 
-	"gopkg.in/alecthomas/kingpin.v2"
+	"github.com/alecthomas/kingpin/v2"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,16 @@ module github.com/buildkite/go-buildkite/v4
 go 1.25
 
 require (
+	github.com/alecthomas/kingpin/v2 v2.4.0
 	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.2.0
 	github.com/google/uuid v1.6.0
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
 require (
-	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
-	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
+	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjHpqDjYY=
+github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
+github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf h1:yxlp0s+Sge9UsKEK0Bsvjiopb9XRk+vxylmZ9eGBfm8=
 github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -20,10 +20,10 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
+github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
 golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
 golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Description

Fixes the import path for kingpin v2.

## Changes

- Replaces `"gopkg.in/alecthomas/kingpin.v2"` with `"github.com/alecthomas/kingpin/v2"`
- Ran `go mod tidy`
