### PR TITLE
feat: Add job-level annotations API support

### DIFF
--- a/annotations.go
+++ b/annotations.go
@@ -19,16 +19,19 @@ type Annotation struct {
 	ID        string     `json:"id,omitempty"`
 	Context   string     `json:"context,omitempty"`
 	Style     string     `json:"style,omitempty"`
+	Scope     string     `json:"scope,omitempty"`
+	Priority  int        `json:"priority,omitempty"`
 	BodyHTML  string     `json:"body_html,omitempty"`
 	CreatedAt *Timestamp `json:"created_at,omitempty"`
 	UpdatedAt *Timestamp `json:"updated_at,omitempty"`
 }
 
 type AnnotationCreate struct {
-	Body    string `json:"body,omitempty"`
-	Context string `json:"context,omitempty"`
-	Style   string `json:"style,omitempty"`
-	Append  bool   `json:"append"`
+	Body     string `json:"body,omitempty"`
+	Context  string `json:"context,omitempty"`
+	Style    string `json:"style,omitempty"`
+	Priority int    `json:"priority,omitempty"`
+	Append   bool   `json:"append"`
 }
 
 // AnnotationListOptions specifies the optional parameters to the
@@ -78,6 +81,61 @@ func (as *AnnotationsService) Create(ctx context.Context, org, pipeline, build s
 
 func (as *AnnotationsService) Delete(ctx context.Context, org, pipeline, build, annotationUUID string) (*Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/annotations/%s", org, pipeline, build, annotationUUID)
+	req, err := as.client.NewRequest(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return as.client.Do(req, nil)
+}
+
+// ListByJob gets annotations for a specific job
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/annotations#list-annotations-for-a-job
+func (as *AnnotationsService) ListByJob(ctx context.Context, org, pipeline, build, jobID string, opt *AnnotationListOptions) ([]Annotation, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/annotations", org, pipeline, build, jobID)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := as.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var annotations []Annotation
+	resp, err := as.client.Do(req, &annotations)
+	if err != nil {
+		return nil, resp, err
+	}
+	return annotations, resp, err
+}
+
+// CreateForJob creates an annotation scoped to a specific job
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/annotations#create-an-annotation-on-a-job
+func (as *AnnotationsService) CreateForJob(ctx context.Context, org, pipeline, build, jobID string, ac AnnotationCreate) (Annotation, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/annotations", org, pipeline, build, jobID)
+	req, err := as.client.NewRequest(ctx, "POST", u, ac)
+	if err != nil {
+		return Annotation{}, nil, err
+	}
+
+	var annotation Annotation
+	resp, err := as.client.Do(req, &annotation)
+	if err != nil {
+		return Annotation{}, resp, err
+	}
+
+	return annotation, resp, err
+}
+
+// DeleteForJob deletes an annotation on a job
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/annotations#delete-an-annotation-on-a-job
+func (as *AnnotationsService) DeleteForJob(ctx context.Context, org, pipeline, build, jobID, annotationUUID string) (*Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/annotations/%s", org, pipeline, build, jobID, annotationUUID)
 	req, err := as.client.NewRequest(ctx, http.MethodDelete, u, nil)
 	if err != nil {
 		return nil, err

--- a/annotations_test.go
+++ b/annotations_test.go
@@ -23,6 +23,8 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 			"id": "de0d4ab5-6360-467a-a34b-e5ef5db5320d",
 			"context": "default",
 			"style": "info",
+			"scope": "build",
+			"priority": 3,
 			"body_html": "<h1>My Markdown Heading</h1>\n<img src=\"artifact://indy.png\" alt=\"Belongs in a museum\" height=250 />",
 			"created_at": "2019-04-09T18:07:15.775Z",
 			"updated_at": "2019-08-06T20:58:49.396Z"
@@ -31,6 +33,8 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 			"id": "5b3ceff6-78cb-4fe9-88ae-51be5f145977",
 			"context": "coverage",
 			"style": "info",
+			"scope": "build",
+			"priority": 3,
 			"body_html": "Read the <a href=\"artifact://coverage/index.html\">uploaded coverage report</a>",
 			"created_at": "2019-04-09T18:07:16.320Z",
 			"updated_at": "2019-04-09T18:07:16.320Z"
@@ -47,6 +51,8 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 			ID:        "de0d4ab5-6360-467a-a34b-e5ef5db5320d",
 			Context:   "default",
 			Style:     "info",
+			Scope:     "build",
+			Priority:  3,
 			BodyHTML:  "<h1>My Markdown Heading</h1>\n<img src=\"artifact://indy.png\" alt=\"Belongs in a museum\" height=250 />",
 			CreatedAt: NewTimestamp(time.Date(2019, 4, 9, 18, 7, 15, 775000000, time.UTC)),
 			UpdatedAt: NewTimestamp(time.Date(2019, 8, 6, 20, 58, 49, 396000000, time.UTC)),
@@ -55,6 +61,8 @@ func TestAnnotationsService_ListByBuild(t *testing.T) {
 			ID:        "5b3ceff6-78cb-4fe9-88ae-51be5f145977",
 			Context:   "coverage",
 			Style:     "info",
+			Scope:     "build",
+			Priority:  3,
 			BodyHTML:  "Read the <a href=\"artifact://coverage/index.html\">uploaded coverage report</a>",
 			CreatedAt: NewTimestamp(time.Date(2019, 4, 9, 18, 7, 16, 320000000, time.UTC)),
 			UpdatedAt: NewTimestamp(time.Date(2019, 4, 9, 18, 7, 16, 320000000, time.UTC)),
@@ -97,6 +105,8 @@ func TestAnnotationsService_Create(t *testing.T) {
 				"id": "68aef727-f754-48e1-aad8-5f5da8a9960c",
 				"context": "default",
 				"style": "info",
+				"scope": "build",
+				"priority": 3,
 				"body_html": "<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>",
 				"created_at": "2023-08-21T08:50:05.824Z",
 				"updated_at": "2023-08-21T08:50:05.824Z"
@@ -115,6 +125,8 @@ func TestAnnotationsService_Create(t *testing.T) {
 		ID:        "68aef727-f754-48e1-aad8-5f5da8a9960c",
 		Context:   "default",
 		Style:     "info",
+		Scope:     "build",
+		Priority:  3,
 		BodyHTML:  "<h1>My Markdown Heading</h1>\n<p>An example annotation!</p>",
 		CreatedAt: NewTimestamp(annotationCreatedAt),
 		UpdatedAt: NewTimestamp(annotationUpatedAt),
@@ -138,5 +150,123 @@ func TestAnnotationsService_Delete(t *testing.T) {
 	_, err := client.Annotations.Delete(context.Background(), "my-great-org", "my-great-pipeline", "10", "68aef727-f754-48e1-aad8-5f5da8a9960c")
 	if err != nil {
 		t.Errorf("TestAnnotations.Delete returned error: %v", err)
+	}
+}
+
+func TestAnnotationsService_ListByJob(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/a7c5b1d2-4f3e-4a1b-9c8d-6e2f1a3b4c5d/annotations", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = fmt.Fprint(w, `[{
+			"id": "de0d4ab5-6360-467a-a34b-e5ef5db5320d",
+			"context": "test-results",
+			"style": "success",
+			"scope": "job",
+			"priority": 3,
+			"body_html": "<p>All 42 tests passed</p>\n",
+			"created_at": "2024-01-15T10:30:00.000Z",
+			"updated_at": "2024-01-15T10:30:00.000Z"
+		}]`)
+	})
+
+	annotations, _, err := client.Annotations.ListByJob(context.Background(), "my-great-org", "sup-keith", "awesome-build", "a7c5b1d2-4f3e-4a1b-9c8d-6e2f1a3b4c5d", nil)
+	if err != nil {
+		t.Errorf("ListByJob returned error: %v", err)
+	}
+
+	want := []Annotation{
+		{
+			ID:        "de0d4ab5-6360-467a-a34b-e5ef5db5320d",
+			Context:   "test-results",
+			Style:     "success",
+			Scope:     "job",
+			Priority:  3,
+			BodyHTML:  "<p>All 42 tests passed</p>\n",
+			CreatedAt: NewTimestamp(time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)),
+			UpdatedAt: NewTimestamp(time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)),
+		},
+	}
+	if diff := cmp.Diff(annotations, want); diff != "" {
+		t.Errorf("ListByJob diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestAnnotationsService_CreateForJob(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	input := AnnotationCreate{
+		Style:   "success",
+		Context: "test-results",
+		Body:    "Test results: 42 passed",
+		Append:  false,
+	}
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline/builds/10/jobs/a7c5b1d2-4f3e-4a1b-9c8d-6e2f1a3b4c5d/annotations", func(w http.ResponseWriter, r *http.Request) {
+		var v AnnotationCreate
+		err := json.NewDecoder(r.Body).Decode(&v)
+		if err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
+
+		testMethod(t, r, "POST")
+
+		if diff := cmp.Diff(v, input); diff != "" {
+			t.Errorf("Request body diff: (-got +want)\n%s", diff)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{
+			"id": "a7c5b1d2-4f3e-4a1b-9c8d-6e2f1a3b4c5d",
+			"context": "test-results",
+			"style": "success",
+			"scope": "job",
+			"priority": 3,
+			"body_html": "<p>Test results: 42 passed</p>\n",
+			"created_at": "2024-01-15T10:30:00.000Z",
+			"updated_at": "2024-01-15T10:30:00.000Z"
+		}`)
+	})
+
+	annotation, _, err := client.Annotations.CreateForJob(context.Background(), "my-great-org", "my-great-pipeline", "10", "a7c5b1d2-4f3e-4a1b-9c8d-6e2f1a3b4c5d", input)
+	if err != nil {
+		t.Errorf("CreateForJob returned error: %v", err)
+	}
+
+	want := Annotation{
+		ID:        "a7c5b1d2-4f3e-4a1b-9c8d-6e2f1a3b4c5d",
+		Context:   "test-results",
+		Style:     "success",
+		Scope:     "job",
+		Priority:  3,
+		BodyHTML:  "<p>Test results: 42 passed</p>\n",
+		CreatedAt: NewTimestamp(time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)),
+		UpdatedAt: NewTimestamp(time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)),
+	}
+
+	if diff := cmp.Diff(annotation, want); diff != "" {
+		t.Errorf("CreateForJob diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestAnnotationsService_DeleteForJob(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-pipeline/builds/10/jobs/a7c5b1d2-4f3e-4a1b-9c8d-6e2f1a3b4c5d/annotations/68aef727-f754-48e1-aad8-5f5da8a9960c", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+	})
+
+	_, err := client.Annotations.DeleteForJob(context.Background(), "my-great-org", "my-great-pipeline", "10", "a7c5b1d2-4f3e-4a1b-9c8d-6e2f1a3b4c5d", "68aef727-f754-48e1-aad8-5f5da8a9960c")
+	if err != nil {
+		t.Errorf("DeleteForJob returned error: %v", err)
 	}
 }

--- a/examples/annotations/create_for_job/main.go
+++ b/examples/annotations/create_for_job/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	apiToken = kingpin.Flag("token", "API token").Required().String()
-	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	org      = kingpin.Flag("org", "Organization slug").Required().String()
 	slug     = kingpin.Flag("slug", "Pipeline slug").Required().String()
 	number   = kingpin.Flag("number", "Build number").Required().String()
 	jobID    = kingpin.Flag("job", "Job ID").Required().String()

--- a/examples/annotations/create_for_job/main.go
+++ b/examples/annotations/create_for_job/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	slug     = kingpin.Flag("slug", "Pipeline slug").Required().String()
+	number   = kingpin.Flag("number", "Build number").Required().String()
+	jobID    = kingpin.Flag("job", "Job ID").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	annotationCreate := buildkite.AnnotationCreate{
+		Style:   "info",
+		Context: "default",
+		Body:    "An example job annotation!",
+		Append:  false,
+	}
+
+	annotation, _, err := client.Annotations.CreateForJob(context.Background(), *org, *slug, *number, *jobID, annotationCreate)
+	if err != nil {
+		log.Fatalf("Creating annotation for job %s in build %s failed: %s", *jobID, *number, err)
+	}
+
+	data, err := json.MarshalIndent(annotation, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/examples/annotations/list_by_job/main.go
+++ b/examples/annotations/list_by_job/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	apiToken = kingpin.Flag("token", "API token").Required().String()
-	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	org      = kingpin.Flag("org", "Organization slug").Required().String()
 	slug     = kingpin.Flag("slug", "Pipeline slug").Required().String()
 	number   = kingpin.Flag("number", "Build number").Required().String()
 	jobID    = kingpin.Flag("job", "Job ID").Required().String()

--- a/examples/annotations/list_by_job/main.go
+++ b/examples/annotations/list_by_job/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	slug     = kingpin.Flag("slug", "Pipeline slug").Required().String()
+	number   = kingpin.Flag("number", "Build number").Required().String()
+	jobID    = kingpin.Flag("job", "Job ID").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	annotations, _, err := client.Annotations.ListByJob(context.Background(), *org, *slug, *number, *jobID, nil)
+	if err != nil {
+		log.Fatalf("Listing annotations for job %s in build %s failed: %s", *jobID, *number, err)
+	}
+
+	data, err := json.MarshalIndent(annotations, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}


### PR DESCRIPTION
## Description
Adds support for job-level annotations, as the Annotations API has added supported for [job-level annotations](https://buildkite.com/docs/apis/rest-api/annotations#list-annotations-for-a-job)

## Changes
- Adds `ListByJob`, `CreateForJob` and `DeleteForJob` methods to AnnotationService
- Extends `Annotation` and `AnnotationCreate` structs with new scope and priority fields
- Adds examples for invoking annotations API for job-level annotations

## Disclosures/Credits
Code changes authored via Claude