### PR TITLE
feat: add support for pipeline schedules

### DIFF
--- a/buildkite.go
+++ b/buildkite.go
@@ -60,6 +60,7 @@ type Client struct {
 	PackagesService          *PackagesService
 	PackageRegistriesService *PackageRegistriesService
 	Pipelines                *PipelinesService
+	PipelineSchedules        *PipelineSchedulesService
 	PipelineTemplates        *PipelineTemplatesService
 	RateLimit                *RateLimitService
 	Rules                    *RulesService
@@ -182,6 +183,7 @@ func (c *Client) populateDefaultServices() {
 	c.PackagesService = &PackagesService{c}
 	c.PackageRegistriesService = &PackageRegistriesService{c}
 	c.Pipelines = &PipelinesService{c}
+	c.PipelineSchedules = &PipelineSchedulesService{c}
 	c.PipelineTemplates = &PipelineTemplatesService{c}
 	c.RateLimit = &RateLimitService{c}
 	c.Rules = &RulesService{c}

--- a/examples/pipeline_schedules/create/main.go
+++ b/examples/pipeline_schedules/create/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	pipeline = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	enabled := true
+	scheduleCreate := buildkite.CreatePipelineSchedule{
+		Label:    "Nightly build",
+		Cronline: "@daily",
+		Message:  "Nightly build",
+		Branch:   "main",
+		Commit:   "HEAD",
+		Env:      map[string]string{"NIGHTLY": "true"},
+		Enabled:  &enabled,
+	}
+
+	schedule, _, err := client.PipelineSchedules.Create(context.Background(), *org, *pipeline, scheduleCreate)
+	if err != nil {
+		log.Fatalf("Creating pipeline schedule failed: %s", err)
+	}
+
+	data, err := json.MarshalIndent(schedule, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/examples/pipeline_schedules/delete/main.go
+++ b/examples/pipeline_schedules/delete/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	apiToken   = kingpin.Flag("token", "API token").Required().String()
+	org        = kingpin.Flag("org", "Orginization slug").Required().String()
+	pipeline   = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+	scheduleID = kingpin.Flag("scheduleID", "Pipeline schedule UUID").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	resp, err := client.PipelineSchedules.Delete(context.Background(), *org, *pipeline, *scheduleID)
+	if err != nil {
+		log.Fatalf("Deleting pipeline schedule %s failed: %s", *scheduleID, err)
+	}
+
+	fmt.Println(resp.StatusCode)
+}

--- a/examples/pipeline_schedules/get/main.go
+++ b/examples/pipeline_schedules/get/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	apiToken   = kingpin.Flag("token", "API token").Required().String()
+	org        = kingpin.Flag("org", "Orginization slug").Required().String()
+	pipeline   = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+	scheduleID = kingpin.Flag("scheduleID", "Pipeline schedule UUID").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	schedule, _, err := client.PipelineSchedules.Get(context.Background(), *org, *pipeline, *scheduleID)
+	if err != nil {
+		log.Fatalf("Getting pipeline schedule %s failed: %s", *scheduleID, err)
+	}
+
+	data, err := json.MarshalIndent(schedule, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/examples/pipeline_schedules/list/main.go
+++ b/examples/pipeline_schedules/list/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Orginization slug").Required().String()
+	pipeline = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	schedules, _, err := client.PipelineSchedules.List(context.Background(), *org, *pipeline, nil)
+	if err != nil {
+		log.Fatalf("listing pipeline schedules failed: %s", err)
+	}
+
+	data, err := json.MarshalIndent(schedules, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/examples/pipeline_schedules/update/main.go
+++ b/examples/pipeline_schedules/update/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/buildkite/go-buildkite/v4"
+
+	"github.com/alecthomas/kingpin/v2"
+)
+
+var (
+	apiToken   = kingpin.Flag("token", "API token").Required().String()
+	org        = kingpin.Flag("org", "Orginization slug").Required().String()
+	pipeline   = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+	scheduleID = kingpin.Flag("scheduleID", "Pipeline schedule UUID").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	enabled := false
+	scheduleUpdate := buildkite.UpdatePipelineSchedule{
+		Label:   "Nightly build (paused)",
+		Enabled: &enabled,
+	}
+
+	schedule, _, err := client.PipelineSchedules.Update(context.Background(), *org, *pipeline, *scheduleID, scheduleUpdate)
+	if err != nil {
+		log.Fatalf("Updating pipeline schedule %s failed: %s", *scheduleID, err)
+	}
+
+	fmt.Printf("Updated schedule %s: label=%q enabled=%t\n", *scheduleID, schedule.Label, schedule.Enabled)
+}

--- a/pipeline_schedules.go
+++ b/pipeline_schedules.go
@@ -1,0 +1,160 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+)
+
+// PipelineSchedulesService handles communication with the pipeline schedule
+// related methods of the buildkite API.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipeline-schedules
+type PipelineSchedulesService struct {
+	client *Client
+}
+
+// PipelineSchedule represents a buildkite pipeline schedule.
+type PipelineSchedule struct {
+	ID            string            `json:"id,omitempty"`
+	GraphQLID     string            `json:"graphql_id,omitempty"`
+	URL           string            `json:"url,omitempty"`
+	Label         string            `json:"label,omitempty"`
+	Cronline      string            `json:"cronline,omitempty"`
+	Message       string            `json:"message,omitempty"`
+	Commit        string            `json:"commit,omitempty"`
+	Branch        string            `json:"branch,omitempty"`
+	Env           map[string]string `json:"env,omitempty"`
+	Enabled       bool              `json:"enabled"`
+	NextBuildAt   *Timestamp        `json:"next_build_at,omitempty"`
+	FailedMessage string            `json:"failed_message,omitempty"`
+	FailedAt      *Timestamp        `json:"failed_at,omitempty"`
+	CreatedAt     *Timestamp        `json:"created_at,omitempty"`
+	CreatedBy     *Creator          `json:"created_by,omitempty"`
+	Pipeline      *Pipeline         `json:"pipeline,omitempty"`
+}
+
+// CreatePipelineSchedule represents the request body for creating a pipeline schedule.
+type CreatePipelineSchedule struct {
+	Cronline string            `json:"cronline"`
+	Label    string            `json:"label,omitempty"`
+	Message  string            `json:"message,omitempty"`
+	Commit   string            `json:"commit,omitempty"`
+	Branch   string            `json:"branch,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	Enabled  *bool             `json:"enabled,omitempty"`
+}
+
+// UpdatePipelineSchedule represents the request body for updating a pipeline schedule.
+type UpdatePipelineSchedule struct {
+	Cronline string            `json:"cronline,omitempty"`
+	Label    string            `json:"label,omitempty"`
+	Message  string            `json:"message,omitempty"`
+	Commit   string            `json:"commit,omitempty"`
+	Branch   string            `json:"branch,omitempty"`
+	Env      map[string]string `json:"env,omitempty"`
+	Enabled  *bool             `json:"enabled,omitempty"`
+}
+
+// PipelineScheduleListOptions specifies the optional parameters to the
+// PipelineSchedulesService.List method.
+type PipelineScheduleListOptions struct {
+	ListOptions
+}
+
+// List the pipeline schedules for a pipeline.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipeline-schedules#list-pipeline-schedules
+func (pss *PipelineSchedulesService) List(ctx context.Context, org, pipelineSlug string, opt *PipelineScheduleListOptions) ([]PipelineSchedule, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/schedules", org, pipelineSlug)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := pss.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var schedules []PipelineSchedule
+	resp, err := pss.client.Do(req, &schedules)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return schedules, resp, err
+}
+
+// Get a pipeline schedule by ID.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipeline-schedules#get-a-pipeline-schedule
+func (pss *PipelineSchedulesService) Get(ctx context.Context, org, pipelineSlug, id string) (PipelineSchedule, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/schedules/%s", org, pipelineSlug, id)
+
+	req, err := pss.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return PipelineSchedule{}, nil, err
+	}
+
+	var schedule PipelineSchedule
+	resp, err := pss.client.Do(req, &schedule)
+	if err != nil {
+		return PipelineSchedule{}, resp, err
+	}
+
+	return schedule, resp, err
+}
+
+// Create a new pipeline schedule.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipeline-schedules#create-a-pipeline-schedule
+func (pss *PipelineSchedulesService) Create(ctx context.Context, org, pipelineSlug string, in CreatePipelineSchedule) (PipelineSchedule, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/schedules", org, pipelineSlug)
+
+	req, err := pss.client.NewRequest(ctx, "POST", u, in)
+	if err != nil {
+		return PipelineSchedule{}, nil, err
+	}
+
+	var schedule PipelineSchedule
+	resp, err := pss.client.Do(req, &schedule)
+	if err != nil {
+		return PipelineSchedule{}, resp, err
+	}
+
+	return schedule, resp, err
+}
+
+// Update an existing pipeline schedule.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipeline-schedules#update-a-pipeline-schedule
+func (pss *PipelineSchedulesService) Update(ctx context.Context, org, pipelineSlug, id string, in UpdatePipelineSchedule) (PipelineSchedule, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/schedules/%s", org, pipelineSlug, id)
+
+	req, err := pss.client.NewRequest(ctx, "PATCH", u, in)
+	if err != nil {
+		return PipelineSchedule{}, nil, err
+	}
+
+	var schedule PipelineSchedule
+	resp, err := pss.client.Do(req, &schedule)
+	if err != nil {
+		return PipelineSchedule{}, resp, err
+	}
+
+	return schedule, resp, err
+}
+
+// Delete a pipeline schedule.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/pipeline-schedules#delete-a-pipeline-schedule
+func (pss *PipelineSchedulesService) Delete(ctx context.Context, org, pipelineSlug, id string) (*Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/schedules/%s", org, pipelineSlug, id)
+
+	req, err := pss.client.NewRequest(ctx, "DELETE", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return pss.client.Do(req, nil)
+}

--- a/pipeline_schedules_test.go
+++ b/pipeline_schedules_test.go
@@ -1,0 +1,221 @@
+package buildkite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func TestPipelineSchedulesService_List(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/pipelines/my-pipeline/schedules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = fmt.Fprint(w, `[
+			{
+				"id": "1bb821f4-3aaf-4d7a-bcb8-26a7fec6f7e2",
+				"graphql_id": "UGlwZWxpbmVTY2hlZHVsZS0tLTFiYjgyMWY0",
+				"url": "https://api.buildkite.com/v2/organizations/my-org/pipelines/my-pipeline/schedules/1bb821f4-3aaf-4d7a-bcb8-26a7fec6f7e2",
+				"label": "Nightly build",
+				"cronline": "@daily",
+				"branch": "main",
+				"commit": "HEAD",
+				"message": "Nightly build",
+				"env": {"FOO": "bar"},
+				"enabled": true,
+				"next_build_at": "2026-05-07T00:00:00Z",
+				"failed_message": null,
+				"failed_at": null,
+				"created_at": "2026-05-01T00:00:00Z",
+				"created_by": {
+					"id": "user-1",
+					"name": "Alice",
+					"email": "alice@example.com",
+					"avatar_url": "https://example.com/avatar.png",
+					"created_at": "2024-01-01T00:00:00Z"
+				}
+			}
+		]`)
+	})
+
+	got, _, err := client.PipelineSchedules.List(context.Background(), "my-org", "my-pipeline", nil)
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("List returned %d schedules, want 1", len(got))
+	}
+	if got[0].ID != "1bb821f4-3aaf-4d7a-bcb8-26a7fec6f7e2" {
+		t.Errorf("schedule id = %q, want %q", got[0].ID, "1bb821f4-3aaf-4d7a-bcb8-26a7fec6f7e2")
+	}
+	if got[0].Cronline != "@daily" {
+		t.Errorf("schedule cronline = %q, want %q", got[0].Cronline, "@daily")
+	}
+	if !got[0].Enabled {
+		t.Errorf("schedule enabled = false, want true")
+	}
+	if diff := cmp.Diff(map[string]string{"FOO": "bar"}, got[0].Env); diff != "" {
+		t.Errorf("schedule env mismatch (-want +got):\n%s", diff)
+	}
+	if got[0].CreatedBy == nil || got[0].CreatedBy.Name != "Alice" {
+		t.Errorf("schedule created_by = %+v, want name=Alice", got[0].CreatedBy)
+	}
+}
+
+func TestPipelineSchedulesService_Get(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/pipelines/my-pipeline/schedules/1bb821f4-3aaf-4d7a-bcb8-26a7fec6f7e2", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = fmt.Fprint(w, `{
+			"id": "1bb821f4-3aaf-4d7a-bcb8-26a7fec6f7e2",
+			"label": "Nightly build",
+			"cronline": "@daily",
+			"branch": "main",
+			"enabled": true
+		}`)
+	})
+
+	got, _, err := client.PipelineSchedules.Get(context.Background(), "my-org", "my-pipeline", "1bb821f4-3aaf-4d7a-bcb8-26a7fec6f7e2")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+
+	want := PipelineSchedule{
+		ID:       "1bb821f4-3aaf-4d7a-bcb8-26a7fec6f7e2",
+		Label:    "Nightly build",
+		Cronline: "@daily",
+		Branch:   "main",
+		Enabled:  true,
+	}
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Get mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestPipelineSchedulesService_Create(t *testing.T) {
+	t.Parallel()
+
+	in := CreatePipelineSchedule{
+		Cronline: "@daily",
+		Label:    "Nightly build",
+		Message:  "Nightly build",
+		Branch:   "main",
+		Commit:   "HEAD",
+		Env:      map[string]string{"FOO": "bar"},
+		Enabled:  boolPtr(false),
+	}
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/pipelines/my-pipeline/schedules", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+
+		var got CreatePipelineSchedule
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		if diff := cmp.Diff(in, got); diff != "" {
+			t.Errorf("Create request body mismatch (-want +got):\n%s", diff)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		_, _ = fmt.Fprint(w, `{
+			"id": "new-id",
+			"cronline": "@daily",
+			"label": "Nightly build",
+			"branch": "main",
+			"commit": "HEAD",
+			"env": {"FOO": "bar"},
+			"enabled": false
+		}`)
+	})
+
+	got, _, err := client.PipelineSchedules.Create(context.Background(), "my-org", "my-pipeline", in)
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+
+	if got.ID != "new-id" {
+		t.Errorf("Create id = %q, want %q", got.ID, "new-id")
+	}
+	if got.Enabled {
+		t.Errorf("Create enabled = true, want false")
+	}
+}
+
+func TestPipelineSchedulesService_Update(t *testing.T) {
+	t.Parallel()
+
+	in := UpdatePipelineSchedule{
+		Label:   "Updated label",
+		Enabled: boolPtr(true),
+	}
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/pipelines/my-pipeline/schedules/abc", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+
+		var got UpdatePipelineSchedule
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatalf("decoding request body: %v", err)
+		}
+		if diff := cmp.Diff(in, got); diff != "" {
+			t.Errorf("Update request body mismatch (-want +got):\n%s", diff)
+		}
+
+		_, _ = fmt.Fprint(w, `{
+			"id": "abc",
+			"label": "Updated label",
+			"enabled": true
+		}`)
+	})
+
+	got, _, err := client.PipelineSchedules.Update(context.Background(), "my-org", "my-pipeline", "abc", in)
+	if err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	if got.Label != "Updated label" {
+		t.Errorf("Update label = %q, want %q", got.Label, "Updated label")
+	}
+	if !got.Enabled {
+		t.Errorf("Update enabled = false, want true")
+	}
+}
+
+func TestPipelineSchedulesService_Delete(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/pipelines/my-pipeline/schedules/abc", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "DELETE")
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	resp, err := client.PipelineSchedules.Delete(context.Background(), "my-org", "my-pipeline", "abc")
+	if err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("Delete status = %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+}


### PR DESCRIPTION
This provides access to support added to the REST API recently https://buildkite.com/docs/apis/rest-api/pipeline-schedules
