### PR TITLE
feat: Make update payloads presence-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [v5.0.0](https://github.com/buildkite/go-buildkite/compare/v4.23.0...v5.0.0) (2026-05-26)
+
+* breaking: move the module path to `github.com/buildkite/go-buildkite/v5`
+* breaking: make update request payloads presence-aware with `Optional[T]` and `Some`
+* breaking: split shared create/update request types for cluster tokens, pipeline templates, teams, and test suites
+* fix: allow update requests to clear fields by sending empty strings, empty maps, empty slices, `0`, or `false`
+
 ## [v4.23.0](https://github.com/buildkite/go-buildkite/compare/v4.22.0...v4.23.0) (2026-05-26)
 
 * Fix: expose expires_at on AccessToken (SUP-7112) [#307](https://github.com/buildkite/go-buildkite/pull/307) ([stephanieatte](https://github.com/stephanieatte))

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -4,7 +4,8 @@
 
 - Added `Optional[T]` and `Some[T]` as the presence primitive for PATCH request structs.
 - Confirmed the repo targets Go 1.25, so `json:",omitzero"` can use `Optional[T].IsZero()` to omit unset fields before `MarshalJSON` runs.
-- Chose to make explicit `null` count as present in `UnmarshalJSON`; absent and present-null should not collapse into the same state.
+- Kept `Optional[T]` request-only: it implements JSON marshaling and zero-value omission, but not unmarshaling.
+- Documented that `Some([]T(nil))` and `Some(map[K]V(nil))` encode as `null`; callers should use initialized empty collections when the API expects `[]` or `{}`.
 - Converted dedicated update structs to `Optional[T]`: clusters, cluster queues, cluster secrets, package registries, pipelines, pipeline schedules, team pipelines, and team suites.
 - Added raw request-body assertions for update tests so omitted keys and explicit empty values are visible to tests.
 - Added regression coverage for clearing `UpdatePipelineSchedule.Env`, clearing `UpdatePipeline.Tags`, and sending `skip_queued_branch_builds: false` deliberately.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -6,3 +6,6 @@
 - Added `Optional[T]` and `Some[T]` as the presence primitive for PATCH request structs.
 - Confirmed the repo targets Go 1.25, so `json:",omitzero"` can use `Optional[T].IsZero()` to omit unset fields before `MarshalJSON` runs.
 - Chose to make explicit `null` count as present in `UnmarshalJSON`; absent and present-null should not collapse into the same state.
+- Converted dedicated update structs to `Optional[T]`: clusters, cluster queues, cluster secrets, package registries, pipelines, pipeline schedules, team pipelines, and team suites.
+- Added raw request-body assertions for update tests so omitted keys and explicit empty values are visible to tests.
+- Added regression coverage for clearing `UpdatePipelineSchedule.Env`, clearing `UpdatePipeline.Tags`, and sending `skip_queued_branch_builds: false` deliberately.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -9,3 +9,6 @@
 - Converted dedicated update structs to `Optional[T]`: clusters, cluster queues, cluster secrets, package registries, pipelines, pipeline schedules, team pipelines, and team suites.
 - Added raw request-body assertions for update tests so omitted keys and explicit empty values are visible to tests.
 - Added regression coverage for clearing `UpdatePipelineSchedule.Env`, clearing `UpdatePipeline.Tags`, and sending `skip_queued_branch_builds: false` deliberately.
+- Split shared create/update structs for cluster tokens, pipeline templates, teams, and test suites. Create structs keep plain values; update structs use `Optional[T]`.
+- Fixed `TestSuitesService.Update` to return the request construction error instead of `nil`.
+- Added raw request-body coverage for shared-type updates, including explicit false for pipeline template availability and team permission booleans.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -13,3 +13,4 @@
 - Fixed `TestSuitesService.Update` to return the request construction error instead of `nil`.
 - Added raw request-body coverage for shared-type updates, including explicit false for pipeline template availability and team permission booleans.
 - Updated the module path and examples from `/v4` to `/v5` because the exported request structs are intentionally breaking.
+- Moved `buildkite-mcp-server` onto the local `/v5` module so its update tools preserve clear intent. The MCP branch keeps a temporary `replace github.com/buildkite/go-buildkite/v5 => ../go-buildkite` until v5 is tagged or otherwise consumable, and keeps a v4 client only for `buildkite-logs`, which has not migrated yet.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,8 @@
+# Implementation notes
+
+## 2026-05-20
+
+- Created `lox/optional-update-payloads`.
+- Added `Optional[T]` and `Some[T]` as the presence primitive for PATCH request structs.
+- Confirmed the repo targets Go 1.25, so `json:",omitzero"` can use `Optional[T].IsZero()` to omit unset fields before `MarshalJSON` runs.
+- Chose to make explicit `null` count as present in `UnmarshalJSON`; absent and present-null should not collapse into the same state.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,8 +1,7 @@
-# Implementation notes
+# v5 update payload notes
 
 ## 2026-05-20
 
-- Created `lox/optional-update-payloads`.
 - Added `Optional[T]` and `Some[T]` as the presence primitive for PATCH request structs.
 - Confirmed the repo targets Go 1.25, so `json:",omitzero"` can use `Optional[T].IsZero()` to omit unset fields before `MarshalJSON` runs.
 - Chose to make explicit `null` count as present in `UnmarshalJSON`; absent and present-null should not collapse into the same state.
@@ -13,4 +12,3 @@
 - Fixed `TestSuitesService.Update` to return the request construction error instead of `nil`.
 - Added raw request-body coverage for shared-type updates, including explicit false for pipeline template availability and team permission booleans.
 - Updated the module path and examples from `/v4` to `/v5` because the exported request structs are intentionally breaking.
-- Moved `buildkite-mcp-server` onto the local `/v5` module so its update tools preserve clear intent. The MCP branch keeps a temporary `replace github.com/buildkite/go-buildkite/v5 => ../go-buildkite` until v5 is tagged or otherwise consumable, and keeps a v4 client only for `buildkite-logs`, which has not migrated yet.

--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -12,3 +12,4 @@
 - Split shared create/update structs for cluster tokens, pipeline templates, teams, and test suites. Create structs keep plain values; update structs use `Optional[T]`.
 - Fixed `TestSuitesService.Update` to return the request construction error instead of `nil`.
 - Added raw request-body coverage for shared-type updates, including explicit false for pipeline template availability and team permission booleans.
+- Updated the module path and examples from `/v4` to `/v5` because the exported request structs are intentionally breaking.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ value omits the field. Wrap values with `buildkite.Some(...)` when the field
 should be sent, including empty strings, empty maps, empty slices, `0`, or
 `false`.
 
+Use initialized empty slices and maps when the API expects `[]` or `{}`. Nil
+slices and maps wrapped with `buildkite.Some(...)` are encoded as `null`.
+
 ```go
 _, _, err := client.Pipelines.Update(ctx, org, pipelineSlug, buildkite.UpdatePipeline{
     Description:              buildkite.Some(""),

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# buildkite-go [![Go Reference](https://pkg.go.dev/badge/github.com/buildkite/go-buildkite.svg)](https://pkg.go.dev/github.com/buildkite/go-buildkite/v4) [![Build status](https://badge.buildkite.com/b16a0d730b8732a1cfba06068f8450aa7cc4b2cf40eb6e6717.svg?branch=master)](https://buildkite.com/buildkite/go-buildkite)
+# buildkite-go [![Go Reference](https://pkg.go.dev/badge/github.com/buildkite/go-buildkite.svg)](https://pkg.go.dev/github.com/buildkite/go-buildkite/v5) [![Build status](https://badge.buildkite.com/b16a0d730b8732a1cfba06068f8450aa7cc4b2cf40eb6e6717.svg?branch=master)](https://buildkite.com/buildkite/go-buildkite)
 
 A [Go](http://golang.org) library and client for the [Buildkite API](https://buildkite.com/docs/api). This project draws a lot of its structure and testing methods from [go-github](https://github.com/google/go-github).
 
@@ -7,14 +7,14 @@ A [Go](http://golang.org) library and client for the [Buildkite API](https://bui
 To get the package, execute:
 
 ```
-go get github.com/buildkite/go-buildkite/v4
+go get github.com/buildkite/go-buildkite/v5
 ```
 
 Simple shortened example for listing all pipelines:
 
 ```go
 import (
-    "github.com/buildkite/go-buildkite/v4"
+    "github.com/buildkite/go-buildkite/v5"
     "github.com/alecthomas/kingpin/v2"
 )
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,48 @@ if err != nil {
 pipelines, _, err := client.Pipelines.List(*org, nil)
 ```
 
+## Migrating to v5 update payloads
+
+Version 5 changes update request structs so PATCH requests can distinguish
+"leave this field unchanged" from "send this field with an empty value".
+
+Update fields that can be cleared now use `buildkite.Optional[T]`. The zero
+value omits the field. Wrap values with `buildkite.Some(...)` when the field
+should be sent, including empty strings, empty maps, empty slices, `0`, or
+`false`.
+
+```go
+_, _, err := client.Pipelines.Update(ctx, org, pipelineSlug, buildkite.UpdatePipeline{
+    Description:              buildkite.Some(""),
+    Tags:                     buildkite.Some([]string{}),
+    SkipQueuedBranchBuilds:   buildkite.Some(false),
+})
+```
+
+```go
+_, _, err := client.PipelineSchedules.Update(ctx, org, pipelineSlug, scheduleID, buildkite.UpdatePipelineSchedule{
+    Env:     buildkite.Some(map[string]string{}),
+    Enabled: buildkite.Some(false),
+})
+```
+
+Leaving an `Optional[T]` unset omits that field from the PATCH body:
+
+```go
+_, _, err := client.Clusters.Update(ctx, org, clusterID, buildkite.ClusterUpdate{
+    Name: buildkite.Some("macOS builders"),
+    // Description is unchanged.
+})
+```
+
+Some create/update request types were split so create calls keep plain required
+values while update calls use presence-aware fields:
+
+- `ClusterTokenCreateUpdate` is now `ClusterTokenCreate` and `ClusterTokenUpdate`.
+- `PipelineTemplateCreateUpdate` is now `PipelineTemplateCreate` and `PipelineTemplateUpdate`.
+- `CreateTeam` is still used for team creation; `UpdateTeam` is now used for team updates.
+- `TestSuitesService.Update` now takes `TestSuiteUpdate`.
+
 See the [examples](https://github.com/buildkite/go-buildkite/tree/master/examples) directory for additional examples.
 
 Note: not all API features are supported by `go-buildkite` just yet. If you need a feature, please make an [issue](https://github.com/buildkite/go-buildkite/issues) or submit a pull request.

--- a/buildkite.go
+++ b/buildkite.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/go-buildkite/v4/internal/bkmultipart"
+	"github.com/buildkite/go-buildkite/v5/internal/bkmultipart"
 	"github.com/cenkalti/backoff"
 	"github.com/google/go-querystring/query"
 )

--- a/cluster_queues.go
+++ b/cluster_queues.go
@@ -44,8 +44,8 @@ type ClusterQueueCreate struct {
 }
 
 type ClusterQueueUpdate struct {
-	Description        string             `json:"description,omitempty"`
-	RetryAgentAffinity RetryAgentAffinity `json:"retry_agent_affinity,omitempty"`
+	Description        Optional[string]             `json:"description,omitzero"`
+	RetryAgentAffinity Optional[RetryAgentAffinity] `json:"retry_agent_affinity,omitzero"`
 }
 
 type ClusterQueuePause struct {

--- a/cluster_queues.go
+++ b/cluster_queues.go
@@ -37,12 +37,14 @@ type ClusterQueue struct {
 	CreatedBy          ClusterCreator     `json:"created_by,omitempty"`
 }
 
+// ClusterQueueCreate represents the request body for creating a cluster queue.
 type ClusterQueueCreate struct {
 	Key                string             `json:"key,omitempty"`
 	Description        string             `json:"description,omitempty"`
 	RetryAgentAffinity RetryAgentAffinity `json:"retry_agent_affinity,omitempty"`
 }
 
+// ClusterQueueUpdate represents the request body for updating a cluster queue.
 type ClusterQueueUpdate struct {
 	Description        Optional[string]             `json:"description,omitzero"`
 	RetryAgentAffinity Optional[RetryAgentAffinity] `json:"retry_agent_affinity,omitzero"`

--- a/cluster_queues_test.go
+++ b/cluster_queues_test.go
@@ -266,13 +266,8 @@ func TestClusterQueuesService_Update(t *testing.T) {
 	t.Cleanup(teardown)
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/queues/1374ffd0-c5ed-49a5-aebe-67ce906e68ca", func(w http.ResponseWriter, r *http.Request) {
-		var v ClusterQueueUpdate
-		err := json.NewDecoder(r.Body).Decode(&v)
-		if err != nil {
-			t.Fatalf("Error parsing json body: %v", err)
-		}
-
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"description":"Development 1 Team queue"}`)
 
 		_, _ = fmt.Fprint(w,
 			`
@@ -284,7 +279,7 @@ func TestClusterQueuesService_Update(t *testing.T) {
 			}`)
 	})
 
-	queueUpdate := ClusterQueueUpdate{Description: "Development 1 Team queue"}
+	queueUpdate := ClusterQueueUpdate{Description: Some("Development 1 Team queue")}
 
 	got, _, err := client.ClusterQueues.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "1374ffd0-c5ed-49a5-aebe-67ce906e68ca", queueUpdate)
 	if err != nil {

--- a/cluster_secrets.go
+++ b/cluster_secrets.go
@@ -50,8 +50,8 @@ type ClusterSecretCreate struct {
 }
 
 type ClusterSecretUpdate struct {
-	Description string `json:"description,omitempty"`
-	Policy      string `json:"policy,omitempty"`
+	Description Optional[string] `json:"description,omitzero"`
+	Policy      Optional[string] `json:"policy,omitzero"`
 }
 
 type ClusterSecretValueUpdate struct {

--- a/cluster_secrets.go
+++ b/cluster_secrets.go
@@ -42,6 +42,7 @@ type ClusterSecretOrganization struct {
 	WebURL string `json:"web_url,omitempty"`
 }
 
+// ClusterSecretCreate represents the request body for creating a cluster secret.
 type ClusterSecretCreate struct {
 	Key         string `json:"key"`
 	Value       string `json:"value,omitempty"`
@@ -49,11 +50,13 @@ type ClusterSecretCreate struct {
 	Policy      string `json:"policy,omitempty"`
 }
 
+// ClusterSecretUpdate represents the request body for updating a cluster secret.
 type ClusterSecretUpdate struct {
 	Description Optional[string] `json:"description,omitzero"`
 	Policy      Optional[string] `json:"policy,omitzero"`
 }
 
+// ClusterSecretValueUpdate represents the request body for updating a cluster secret value.
 type ClusterSecretValueUpdate struct {
 	Value string `json:"value"`
 }

--- a/cluster_secrets_test.go
+++ b/cluster_secrets_test.go
@@ -258,13 +258,11 @@ func TestClusterSecretsService_Update(t *testing.T) {
 	t.Cleanup(teardown)
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/secrets/a1e2d345-6789-0abc-def1-234567890abc", func(w http.ResponseWriter, r *http.Request) {
-		var v ClusterSecretUpdate
-		err := json.NewDecoder(r.Body).Decode(&v)
-		if err != nil {
-			t.Fatalf("Error parsing json body: %v", err)
-		}
-
 		testMethod(t, r, "PUT")
+		assertRequestJSON(t, r, `{
+			"description": "Updated SSH key description",
+			"policy": "block"
+		}`)
 
 		_, _ = fmt.Fprint(w,
 			`
@@ -277,8 +275,8 @@ func TestClusterSecretsService_Update(t *testing.T) {
 	})
 
 	update := ClusterSecretUpdate{
-		Description: "Updated SSH key description",
-		Policy:      "block",
+		Description: Some("Updated SSH key description"),
+		Policy:      Some("block"),
 	}
 
 	got, _, err := client.ClusterSecrets.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "a1e2d345-6789-0abc-def1-234567890abc", update)

--- a/cluster_tokens.go
+++ b/cluster_tokens.go
@@ -13,6 +13,7 @@ type ClusterTokensService struct {
 	client *Client
 }
 
+// ClusterToken represents a token scoped to a cluster.
 type ClusterToken struct {
 	ID                 string         `json:"id,omitempty"`
 	GraphQLID          string         `json:"graphql_id,omitempty"`
@@ -25,11 +26,13 @@ type ClusterToken struct {
 	Token              string         `json:"token,omitempty"`
 }
 
+// ClusterTokenCreate represents the request body for creating a cluster token.
 type ClusterTokenCreate struct {
 	Description        string `json:"description,omitempty"`
 	AllowedIPAddresses string `json:"allowed_ip_addresses,omitempty"`
 }
 
+// ClusterTokenUpdate represents the request body for updating a cluster token.
 type ClusterTokenUpdate struct {
 	Description        Optional[string] `json:"description,omitzero"`
 	AllowedIPAddresses Optional[string] `json:"allowed_ip_addresses,omitzero"`

--- a/cluster_tokens.go
+++ b/cluster_tokens.go
@@ -25,9 +25,14 @@ type ClusterToken struct {
 	Token              string         `json:"token,omitempty"`
 }
 
-type ClusterTokenCreateUpdate struct {
+type ClusterTokenCreate struct {
 	Description        string `json:"description,omitempty"`
 	AllowedIPAddresses string `json:"allowed_ip_addresses,omitempty"`
+}
+
+type ClusterTokenUpdate struct {
+	Description        Optional[string] `json:"description,omitzero"`
+	AllowedIPAddresses Optional[string] `json:"allowed_ip_addresses,omitzero"`
 }
 
 type ClusterTokensListOptions struct {
@@ -71,7 +76,7 @@ func (cts *ClusterTokensService) Get(ctx context.Context, org, clusterID, tokenI
 	return token, resp, err
 }
 
-func (cts *ClusterTokensService) Create(ctx context.Context, org, clusterID string, ctc ClusterTokenCreateUpdate) (ClusterToken, *Response, error) {
+func (cts *ClusterTokensService) Create(ctx context.Context, org, clusterID string, ctc ClusterTokenCreate) (ClusterToken, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens", org, clusterID)
 	req, err := cts.client.NewRequest(ctx, "POST", u, ctc)
 	if err != nil {
@@ -87,7 +92,7 @@ func (cts *ClusterTokensService) Create(ctx context.Context, org, clusterID stri
 	return token, resp, err
 }
 
-func (cts *ClusterTokensService) Update(ctx context.Context, org, clusterID, tokenID string, ctc ClusterTokenCreateUpdate) (ClusterToken, *Response, error) {
+func (cts *ClusterTokensService) Update(ctx context.Context, org, clusterID, tokenID string, ctc ClusterTokenUpdate) (ClusterToken, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/clusters/%s/tokens/%s", org, clusterID, tokenID)
 	req, err := cts.client.NewRequest(ctx, "PATCH", u, ctc)
 	if err != nil {

--- a/cluster_tokens_test.go
+++ b/cluster_tokens_test.go
@@ -171,10 +171,10 @@ func TestClusterTokensService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := ClusterTokenCreateUpdate{Description: "Development 2 cluster token"}
+	input := ClusterTokenCreate{Description: "Development 2 cluster token"}
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens", func(w http.ResponseWriter, r *http.Request) {
-		var v ClusterTokenCreateUpdate
+		var v ClusterTokenCreate
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("Error parsing json body: %v", err)
@@ -211,13 +211,8 @@ func TestClusterTokensService_Update(t *testing.T) {
 	t.Cleanup(teardown)
 
 	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
-		var v ClusterTokenCreateUpdate
-		err := json.NewDecoder(r.Body).Decode(&v)
-		if err != nil {
-			t.Fatalf("Error parsing json body: %v", err)
-		}
-
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"description":"Development 1 agent token"}`)
 
 		_, _ = fmt.Fprint(w,
 			`
@@ -227,7 +222,7 @@ func TestClusterTokensService_Update(t *testing.T) {
 			}`)
 	})
 
-	tokenUpdate := ClusterTokenCreateUpdate{Description: "Development 1 agent token"}
+	tokenUpdate := ClusterTokenUpdate{Description: Some("Development 1 agent token")}
 
 	got, _, err := client.ClusterTokens.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054", tokenUpdate)
 	if err != nil {
@@ -241,6 +236,36 @@ func TestClusterTokensService_Update(t *testing.T) {
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("TestClusterTokens.Update diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestClusterTokensService_UpdateClearsAllowedIPAddresses(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/clusters/b7c9bc4f-526f-4c18-a3be-dc854ab75d57/tokens/9cb33339-1c4a-4020-9aeb-3319b2e1f054", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"allowed_ip_addresses":""}`)
+
+		_, _ = fmt.Fprint(w,
+			`
+			{
+				"id": "9cb33339-1c4a-4020-9aeb-3319b2e1f054",
+				"allowed_ip_addresses" : ""
+			}`)
+	})
+
+	got, _, err := client.ClusterTokens.Update(context.Background(), "my-great-org", "b7c9bc4f-526f-4c18-a3be-dc854ab75d57", "9cb33339-1c4a-4020-9aeb-3319b2e1f054", ClusterTokenUpdate{
+		AllowedIPAddresses: Some(""),
+	})
+	if err != nil {
+		t.Errorf("TestClusterTokens.Update returned error: %v", err)
+	}
+
+	if got.AllowedIPAddresses != "" {
+		t.Errorf("AllowedIPAddresses = %q, want empty string", got.AllowedIPAddresses)
 	}
 }
 

--- a/clusters.go
+++ b/clusters.go
@@ -22,11 +22,11 @@ type ClusterCreate struct {
 }
 
 type ClusterUpdate struct {
-	Name           string `json:"name,omitempty"`
-	Description    string `json:"description,omitempty"`
-	Emoji          string `json:"emoji,omitempty"`
-	Color          string `json:"color,omitempty"`
-	DefaultQueueID string `json:"default_queue_id,omitempty"`
+	Name           Optional[string] `json:"name,omitzero"`
+	Description    Optional[string] `json:"description,omitzero"`
+	Emoji          Optional[string] `json:"emoji,omitzero"`
+	Color          Optional[string] `json:"color,omitzero"`
+	DefaultQueueID Optional[string] `json:"default_queue_id,omitzero"`
 }
 
 type Cluster struct {

--- a/clusters.go
+++ b/clusters.go
@@ -13,6 +13,7 @@ type ClustersService struct {
 	client *Client
 }
 
+// ClusterCreate represents the request body for creating a cluster.
 type ClusterCreate struct {
 	Name        string              `json:"name,omitempty"`
 	Description string              `json:"description,omitempty"`
@@ -21,6 +22,7 @@ type ClusterCreate struct {
 	Maintainers []ClusterMaintainer `json:"maintainers,omitempty"`
 }
 
+// ClusterUpdate represents the request body for updating a cluster.
 type ClusterUpdate struct {
 	Name           Optional[string] `json:"name,omitzero"`
 	Description    Optional[string] `json:"description,omitzero"`

--- a/clusters_test.go
+++ b/clusters_test.go
@@ -407,13 +407,8 @@ func TestClustersService_Update(t *testing.T) {
 
 	clustersPutEndpoint := fmt.Sprintf("/v2/organizations/%s/clusters/%s", orgSlug, clusterID)
 	server.HandleFunc(clustersPutEndpoint, func(w http.ResponseWriter, r *http.Request) {
-		var v ClusterUpdate
-		err := json.NewDecoder(r.Body).Decode(&v)
-		if err != nil {
-			t.Fatalf("Error parsing json body: %v", err)
-		}
-
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"description":"A test cluster"}`)
 
 		_, _ = fmt.Fprint(w,
 			`
@@ -426,7 +421,7 @@ func TestClustersService_Update(t *testing.T) {
 			}`)
 	})
 
-	clusterUpdate := ClusterUpdate{Description: "A test cluster"}
+	clusterUpdate := ClusterUpdate{Description: Some("A test cluster")}
 	cluster, _, err := client.Clusters.Update(context.Background(), orgSlug, clusterID, clusterUpdate)
 	if err != nil {
 		t.Errorf("TestClusters.Update returned error: %v", err)

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,7 @@
 package buildkite_test
 
 import (
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 // Example_clientOptComposition demonstrates how to programmatically compose client options

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/annotations/create_for_job/main.go
+++ b/examples/annotations/create_for_job/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/annotations/list_by_job/main.go
+++ b/examples/annotations/list_by_job/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/build_tests/list/main.go
+++ b/examples/build_tests/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/builds/get/main.go
+++ b/examples/builds/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_queues/create/main.go
+++ b/examples/cluster_queues/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_queues/delete/main.go
+++ b/examples/cluster_queues/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_queues/get/main.go
+++ b/examples/cluster_queues/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_queues/list/main.go
+++ b/examples/cluster_queues/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_queues/pause/main.go
+++ b/examples/cluster_queues/pause/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_queues/resume/main.go
+++ b/examples/cluster_queues/resume/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_queues/update/main.go
+++ b/examples/cluster_queues/update/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_queues/update/main.go
+++ b/examples/cluster_queues/update/main.go
@@ -28,8 +28,8 @@ func main() {
 	}
 
 	clusterQueueUpdate := buildkite.ClusterQueueUpdate{
-		Description:        *newDescription,
-		RetryAgentAffinity: buildkite.RetryAgentAffinity(*newRetryAgentAffinity),
+		Description:        buildkite.Some(*newDescription),
+		RetryAgentAffinity: buildkite.Some(buildkite.RetryAgentAffinity(*newRetryAgentAffinity)),
 	}
 
 	cq, _, err := client.ClusterQueues.Update(context.Background(), *org, *clusterID, *queueID, clusterQueueUpdate)

--- a/examples/cluster_tokens/create/main.go
+++ b/examples/cluster_tokens/create/main.go
@@ -26,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterTokenCreate := buildkite.ClusterTokenCreateUpdate{Description: "Dev squad agent fleet token"}
+	clusterTokenCreate := buildkite.ClusterTokenCreate{Description: "Dev squad agent fleet token"}
 
 	token, _, err := client.ClusterTokens.Create(context.Background(), *org, *clusterID, clusterTokenCreate)
 	if err != nil {

--- a/examples/cluster_tokens/create/main.go
+++ b/examples/cluster_tokens/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_tokens/delete/main.go
+++ b/examples/cluster_tokens/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_tokens/get/main.go
+++ b/examples/cluster_tokens/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_tokens/list/main.go
+++ b/examples/cluster_tokens/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -26,7 +26,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterTokenUpdate := buildkite.ClusterTokenCreateUpdate{Description: *newDescription}
+	clusterTokenUpdate := buildkite.ClusterTokenUpdate{Description: buildkite.Some(*newDescription)}
 
 	token, _, err := client.ClusterTokens.Update(context.Background(), *org, *clusterID, *tokenID, clusterTokenUpdate)
 	if err != nil {

--- a/examples/clusters/create/main.go
+++ b/examples/clusters/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/clusters/delete/main.go
+++ b/examples/clusters/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/clusters/get/main.go
+++ b/examples/clusters/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/clusters/list/main.go
+++ b/examples/clusters/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	clusterUpdate := buildkite.ClusterUpdate{Description: *newDescription}
+	clusterUpdate := buildkite.ClusterUpdate{Description: buildkite.Some(*newDescription)}
 
 	cluster, _, err := client.Clusters.Update(context.Background(), *org, *clusterID, clusterUpdate)
 	if err != nil {

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/flaky_tests/list/main.go
+++ b/examples/flaky_tests/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/jobs/reprioritize/main.go
+++ b/examples/jobs/reprioritize/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/members/get/main.go
+++ b/examples/members/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/members/list/main.go
+++ b/examples/members/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/package_registries/create/main.go
+++ b/examples/package_registries/create/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/package_registries/delete/main.go
+++ b/examples/package_registries/delete/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/package_registries/get/main.go
+++ b/examples/package_registries/get/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/package_registries/list/main.go
+++ b/examples/package_registries/list/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/package_registries/list_packages/main.go
+++ b/examples/package_registries/list_packages/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/packages/create/main.go
+++ b/examples/packages/create/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/packages/create_presigned_upload/main.go
+++ b/examples/packages/create_presigned_upload/main.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/packages/delete/main.go
+++ b/examples/packages/delete/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/packages/get/main.go
+++ b/examples/packages/get/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_schedules/create/main.go
+++ b/examples/pipeline_schedules/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_schedules/delete/main.go
+++ b/examples/pipeline_schedules/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_schedules/get/main.go
+++ b/examples/pipeline_schedules/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_schedules/list/main.go
+++ b/examples/pipeline_schedules/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_schedules/update/main.go
+++ b/examples/pipeline_schedules/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_schedules/update/main.go
+++ b/examples/pipeline_schedules/update/main.go
@@ -25,10 +25,9 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	enabled := false
 	scheduleUpdate := buildkite.UpdatePipelineSchedule{
-		Label:   "Nightly build (paused)",
-		Enabled: &enabled,
+		Label:   buildkite.Some("Nightly build (paused)"),
+		Enabled: buildkite.Some(false),
 	}
 
 	schedule, _, err := client.PipelineSchedules.Update(context.Background(), *org, *pipeline, *scheduleID, scheduleUpdate)

--- a/examples/pipeline_templates/create/main.go
+++ b/examples/pipeline_templates/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_templates/create/main.go
+++ b/examples/pipeline_templates/create/main.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pipelineTemplateCreate := buildkite.PipelineTemplateCreateUpdate{
+	pipelineTemplateCreate := buildkite.PipelineTemplateCreate{
 		Name:          "Production Pipeline uploader",
 		Description:   "Production pipeline upload template",
 		Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n",

--- a/examples/pipeline_templates/delete/main.go
+++ b/examples/pipeline_templates/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_templates/get/main.go
+++ b/examples/pipeline_templates/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_templates/list/main.go
+++ b/examples/pipeline_templates/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -24,7 +24,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	pipelineTemplateUpdate := buildkite.PipelineTemplateCreateUpdate{Description: "Production pipeline template uploader"}
+	pipelineTemplateUpdate := buildkite.PipelineTemplateUpdate{Description: buildkite.Some("Production pipeline template uploader")}
 
 	cluster, _, err := client.PipelineTemplates.Update(context.Background(), *org, *templateUUID, pipelineTemplateUpdate)
 	if err != nil {

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipelines/list/main.go
+++ b/examples/pipelines/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	_, _, err = client.Pipelines.Update(context.Background(), *org, *pipelineSlug, buildkite.UpdatePipeline{Description: *newDescription})
+	_, _, err = client.Pipelines.Update(context.Background(), *org, *pipelineSlug, buildkite.UpdatePipeline{Description: buildkite.Some(*newDescription)})
 	if err != nil {
 		log.Fatalf("Updating pipeline failed: %s", err)
 	}

--- a/examples/rate_limits/get/main.go
+++ b/examples/rate_limits/get/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/test_runs/get/main.go
+++ b/examples/test_runs/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/test_runs/list/main.go
+++ b/examples/test_runs/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/test_suites/create/main.go
+++ b/examples/test_suites/create/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/test_suites/delete/main.go
+++ b/examples/test_suites/delete/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/test_suites/get/main.go
+++ b/examples/test_suites/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/test_suites/list/main.go
+++ b/examples/test_suites/list/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/test_suites/update/main.go
+++ b/examples/test_suites/update/main.go
@@ -25,7 +25,7 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	suiteUpdate := buildkite.TestSuite{DefaultBranch: *newDefaultBranch}
+	suiteUpdate := buildkite.TestSuiteUpdate{DefaultBranch: buildkite.Some(*newDefaultBranch)}
 
 	_, _, err = client.TestSuites.Update(context.Background(), *org, *suite, suiteUpdate)
 	if err != nil {

--- a/examples/test_suites/update/main.go
+++ b/examples/test_suites/update/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/examples/tests/get/main.go
+++ b/examples/tests/get/main.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v4"
+	"github.com/buildkite/go-buildkite/v5"
 
 	"github.com/alecthomas/kingpin/v2"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/buildkite/go-buildkite/v4
+module github.com/buildkite/go-buildkite/v5
 
 go 1.25
 

--- a/internal/bkmultipart/streamer_test.go
+++ b/internal/bkmultipart/streamer_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/buildkite/go-buildkite/v4/internal/bkmultipart"
+	"github.com/buildkite/go-buildkite/v5/internal/bkmultipart"
 )
 
 func TestEncodingFormFields(t *testing.T) {

--- a/optional.go
+++ b/optional.go
@@ -14,6 +14,9 @@ type Optional[T any] struct {
 }
 
 // Some returns an Optional that sends value in JSON.
+//
+// Nil slices and maps are encoded as null. Use an initialized empty slice or
+// map when the API expects [] or {}.
 func Some[T any](value T) Optional[T] {
 	return Optional[T]{
 		value: value,
@@ -34,10 +37,4 @@ func (o Optional[T]) Value() (T, bool) {
 // MarshalJSON encodes the wrapped value.
 func (o Optional[T]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(o.value)
-}
-
-// UnmarshalJSON records that the field was present and decodes its value.
-func (o *Optional[T]) UnmarshalJSON(data []byte) error {
-	o.set = true
-	return json.Unmarshal(data, &o.value)
 }

--- a/optional.go
+++ b/optional.go
@@ -1,0 +1,41 @@
+package buildkite
+
+import "encoding/json"
+
+// Optional marks whether a request field should be sent in JSON.
+//
+// The zero value is omitted when the field uses json:",omitzero". Use Some to
+// send a value, including the zero value for T.
+type Optional[T any] struct {
+	value T
+	set   bool
+}
+
+// Some returns an Optional that sends value in JSON.
+func Some[T any](value T) Optional[T] {
+	return Optional[T]{
+		value: value,
+		set:   true,
+	}
+}
+
+// IsZero reports whether the field should be omitted by json:",omitzero".
+func (o Optional[T]) IsZero() bool {
+	return !o.set
+}
+
+// Value returns the wrapped value and whether it was set.
+func (o Optional[T]) Value() (T, bool) {
+	return o.value, o.set
+}
+
+// MarshalJSON encodes the wrapped value.
+func (o Optional[T]) MarshalJSON() ([]byte, error) {
+	return json.Marshal(o.value)
+}
+
+// UnmarshalJSON records that the field was present and decodes its value.
+func (o *Optional[T]) UnmarshalJSON(data []byte) error {
+	o.set = true
+	return json.Unmarshal(data, &o.value)
+}

--- a/optional.go
+++ b/optional.go
@@ -4,8 +4,10 @@ import "encoding/json"
 
 // Optional marks whether a request field should be sent in JSON.
 //
-// The zero value is omitted when the field uses json:",omitzero". Use Some to
-// send a value, including the zero value for T.
+// Use Optional on struct fields tagged with json:",omitzero". The zero value is
+// omitted from the encoded object, and Some sends a value, including the zero
+// value for T. If an Optional field is not tagged with omitzero, an unset value
+// marshals as the zero value of T instead of being omitted.
 type Optional[T any] struct {
 	value T
 	set   bool

--- a/optional_test.go
+++ b/optional_test.go
@@ -60,6 +60,13 @@ func TestOptionalMarshalJSON(t *testing.T) {
 			},
 			want: `{"tags":null}`,
 		},
+		{
+			name: "nil map is sent as null when set",
+			in: payload{
+				Env: Some(map[string]string(nil)),
+			},
+			want: `{"env":null}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -72,27 +79,5 @@ func TestOptionalMarshalJSON(t *testing.T) {
 			}
 			assertJSONEqual(t, string(got), tt.want)
 		})
-	}
-}
-
-func TestOptionalUnmarshalJSON(t *testing.T) {
-	t.Parallel()
-
-	type payload struct {
-		Name Optional[string]   `json:"name,omitzero"`
-		Tags Optional[[]string] `json:"tags,omitzero"`
-	}
-
-	var got payload
-	if err := json.Unmarshal([]byte(`{"name":null,"tags":[]}`), &got); err != nil {
-		t.Fatalf("Unmarshal returned error: %v", err)
-	}
-
-	want := payload{
-		// Name should be unset
-		Tags: Some([]string{}),
-	}
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("Unmarshaled payload diff (-want +got):\n%s", diff)
 	}
 }

--- a/optional_test.go
+++ b/optional_test.go
@@ -1,0 +1,106 @@
+package buildkite
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOptionalMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Name    Optional[string]            `json:"name,omitzero"`
+		Tags    Optional[[]string]          `json:"tags,omitzero"`
+		Env     Optional[map[string]string] `json:"env,omitzero"`
+		Enabled Optional[bool]              `json:"enabled,omitzero"`
+	}
+
+	tests := []struct {
+		name string
+		in   payload
+		want string
+	}{
+		{
+			name: "unset fields omitted",
+			in:   payload{},
+			want: `{}`,
+		},
+		{
+			name: "empty string is sent",
+			in: payload{
+				Name: Some(""),
+			},
+			want: `{"name":""}`,
+		},
+		{
+			name: "false is sent",
+			in: payload{
+				Enabled: Some(false),
+			},
+			want: `{"enabled":false}`,
+		},
+		{
+			name: "empty slice is sent",
+			in: payload{
+				Tags: Some([]string{}),
+			},
+			want: `{"tags":[]}`,
+		},
+		{
+			name: "empty map is sent",
+			in: payload{
+				Env: Some(map[string]string{}),
+			},
+			want: `{"env":{}}`,
+		},
+		{
+			name: "nil slice is sent as null when set",
+			in: payload{
+				Tags: Some([]string(nil)),
+			},
+			want: `{"tags":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := json.Marshal(tt.in)
+			if err != nil {
+				t.Fatalf("Marshal returned error: %v", err)
+			}
+			assertJSONEqual(t, string(got), tt.want)
+		})
+	}
+}
+
+func TestOptionalUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	type payload struct {
+		Name Optional[string]   `json:"name,omitzero"`
+		Tags Optional[[]string] `json:"tags,omitzero"`
+	}
+
+	var got payload
+	if err := json.Unmarshal([]byte(`{"name":null,"tags":[]}`), &got); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	name, nameOK := got.Name.Value()
+	if !nameOK {
+		t.Fatal("Name was not marked set")
+	}
+	if name != "" {
+		t.Errorf("Name = %q, want empty string", name)
+	}
+
+	tags, tagsOK := got.Tags.Value()
+	if !tagsOK {
+		t.Fatal("Tags was not marked set")
+	}
+	if len(tags) != 0 {
+		t.Errorf("Tags length = %d, want 0", len(tags))
+	}
+}

--- a/optional_test.go
+++ b/optional_test.go
@@ -88,19 +88,11 @@ func TestOptionalUnmarshalJSON(t *testing.T) {
 		t.Fatalf("Unmarshal returned error: %v", err)
 	}
 
-	name, nameOK := got.Name.Value()
-	if !nameOK {
-		t.Fatal("Name was not marked set")
+	want := payload{
+		// Name should be unset
+		Tags: Some([]string{}),
 	}
-	if name != "" {
-		t.Errorf("Name = %q, want empty string", name)
-	}
-
-	tags, tagsOK := got.Tags.Value()
-	if !tagsOK {
-		t.Fatal("Tags was not marked set")
-	}
-	if len(tags) != 0 {
-		t.Errorf("Tags length = %d, want 0", len(tags))
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("Unmarshaled payload diff (-want +got):\n%s", diff)
 	}
 }

--- a/package_registries.go
+++ b/package_registries.go
@@ -37,14 +37,17 @@ type CreatePackageRegistryInput struct {
 	OIDCPolicy  PackageRegistryOIDCPolicy `json:"oidc_policy,omitempty"` // The OIDC policy for the package registry, as a YAML or JSON string
 }
 
+// PackageRegistryOIDCPolicy represents the OIDC policy statements for a package registry.
 type PackageRegistryOIDCPolicy []OIDCPolicyStatement
 
+// OIDCPolicyStatement represents one OIDC policy statement for a package registry.
 type OIDCPolicyStatement struct {
 	Issuer string               `json:"iss"`
 	Scopes []string             `json:"scopes,omitzero"`
 	Claims map[string]ClaimRule `json:"claims"`
 }
 
+// ClaimRule represents matching rules for an OIDC claim.
 type ClaimRule struct {
 	Equals    any      `json:"equals,omitempty"`
 	NotEquals any      `json:"not_equals,omitempty"`
@@ -70,6 +73,7 @@ func (rs *PackageRegistriesService) Create(ctx context.Context, organizationSlug
 	return pr, resp, err
 }
 
+// UpdatePackageRegistryInput represents the request body for updating a package registry.
 type UpdatePackageRegistryInput struct {
 	Name        Optional[string]                    `json:"name,omitzero"`        // The name of the package registry
 	Description Optional[string]                    `json:"description,omitzero"` // A description for the package registry

--- a/package_registries.go
+++ b/package_registries.go
@@ -71,11 +71,11 @@ func (rs *PackageRegistriesService) Create(ctx context.Context, organizationSlug
 }
 
 type UpdatePackageRegistryInput struct {
-	Name        string                    `json:"name,omitempty"`        // The name of the package registry
-	Description string                    `json:"description,omitempty"` // A description for the package registry
-	Emoji       string                    `json:"emoji,omitempty"`       // An emoji for the package registry, in buildkite format (eg ":rocket:")
-	Color       string                    `json:"color,omitempty"`       // A color for the package registry, in hex format (eg "#FF0000")
-	OIDCPolicy  PackageRegistryOIDCPolicy `json:"oidc_policy,omitempty"` // The OIDC policy for the package registry, as a YAML or JSON string
+	Name        Optional[string]                    `json:"name,omitzero"`        // The name of the package registry
+	Description Optional[string]                    `json:"description,omitzero"` // A description for the package registry
+	Emoji       Optional[string]                    `json:"emoji,omitzero"`       // An emoji for the package registry, in buildkite format (eg ":rocket:")
+	Color       Optional[string]                    `json:"color,omitzero"`       // A color for the package registry, in hex format (eg "#FF0000")
+	OIDCPolicy  Optional[PackageRegistryOIDCPolicy] `json:"oidc_policy,omitzero"` // The OIDC policy for the package registry, as a YAML or JSON string
 }
 
 // Update updates a package registry for an organization

--- a/package_registries_test.go
+++ b/package_registries_test.go
@@ -147,32 +147,25 @@ func TestPackageRegistryUpdate(t *testing.T) {
 	t.Cleanup(teardown)
 
 	wantInput := UpdatePackageRegistryInput{
-		Name:        "My Even Cooler Registry",
-		Description: "A registry so cool we had to rename it",
+		Name:        Some("My Even Cooler Registry"),
+		Description: Some("A registry so cool we had to rename it"),
 	}
 
 	want := registry
-	want.Name = wantInput.Name
-	want.Description = wantInput.Description
+	want.Name = "My Even Cooler Registry"
+	want.Description = "A registry so cool we had to rename it"
 
 	server.HandleFunc("/v2/packages/organizations/test-org/registries/my-cool-registry", func(w http.ResponseWriter, r *http.Request) {
 		defer func() { _ = r.Body.Close() }()
 
 		testMethod(t, r, "PATCH")
-
-		var gotInput UpdatePackageRegistryInput
-		err := json.NewDecoder(r.Body).Decode(&gotInput)
-		if err != nil {
-			t.Fatalf("parsing Update Package body: %v", err)
-		}
-
-		// ensure that the input survives a roundtrip through JSON
-		if diff := cmp.Diff(gotInput, wantInput); diff != "" {
-			t.Fatalf("update registry input diff: (-got +want)\n%s", diff)
-		}
+		assertRequestJSON(t, r, `{
+			"name": "My Even Cooler Registry",
+			"description": "A registry so cool we had to rename it"
+		}`)
 
 		// send back the registry
-		err = json.NewEncoder(w).Encode(want)
+		err := json.NewEncoder(w).Encode(want)
 		if err != nil {
 			t.Fatalf("encoding json response body: %v", err)
 		}

--- a/package_uploads.go
+++ b/package_uploads.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/buildkite/go-buildkite/v4/internal/bkmultipart"
+	"github.com/buildkite/go-buildkite/v5/internal/bkmultipart"
 )
 
 // CreatePackageInput specifies the input parameters for the Create method.

--- a/pipeline_schedules.go
+++ b/pipeline_schedules.go
@@ -46,13 +46,13 @@ type CreatePipelineSchedule struct {
 
 // UpdatePipelineSchedule represents the request body for updating a pipeline schedule.
 type UpdatePipelineSchedule struct {
-	Cronline string            `json:"cronline,omitempty"`
-	Label    string            `json:"label,omitempty"`
-	Message  string            `json:"message,omitempty"`
-	Commit   string            `json:"commit,omitempty"`
-	Branch   string            `json:"branch,omitempty"`
-	Env      map[string]string `json:"env,omitempty"`
-	Enabled  *bool             `json:"enabled,omitempty"`
+	Cronline Optional[string]            `json:"cronline,omitzero"`
+	Label    Optional[string]            `json:"label,omitzero"`
+	Message  Optional[string]            `json:"message,omitzero"`
+	Commit   Optional[string]            `json:"commit,omitzero"`
+	Branch   Optional[string]            `json:"branch,omitzero"`
+	Env      Optional[map[string]string] `json:"env,omitzero"`
+	Enabled  Optional[bool]              `json:"enabled,omitzero"`
 }
 
 // PipelineScheduleListOptions specifies the optional parameters to the

--- a/pipeline_schedules_test.go
+++ b/pipeline_schedules_test.go
@@ -162,8 +162,8 @@ func TestPipelineSchedulesService_Update(t *testing.T) {
 	t.Parallel()
 
 	in := UpdatePipelineSchedule{
-		Label:   "Updated label",
-		Enabled: boolPtr(true),
+		Label:   Some("Updated label"),
+		Enabled: Some(true),
 	}
 
 	server, client, teardown := newMockServerAndClient(t)
@@ -171,14 +171,10 @@ func TestPipelineSchedulesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-org/pipelines/my-pipeline/schedules/abc", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
-
-		var got UpdatePipelineSchedule
-		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
-			t.Fatalf("decoding request body: %v", err)
-		}
-		if diff := cmp.Diff(in, got); diff != "" {
-			t.Errorf("Update request body mismatch (-want +got):\n%s", diff)
-		}
+		assertRequestJSON(t, r, `{
+			"label": "Updated label",
+			"enabled": true
+		}`)
 
 		_, _ = fmt.Fprint(w, `{
 			"id": "abc",
@@ -197,6 +193,37 @@ func TestPipelineSchedulesService_Update(t *testing.T) {
 	}
 	if !got.Enabled {
 		t.Errorf("Update enabled = false, want true")
+	}
+}
+
+func TestPipelineSchedulesService_UpdateClearsEnv(t *testing.T) {
+	t.Parallel()
+
+	in := UpdatePipelineSchedule{
+		Env: Some(map[string]string{}),
+	}
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-org/pipelines/my-pipeline/schedules/abc", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"env":{}}`)
+
+		_, _ = fmt.Fprint(w, `{
+			"id": "abc",
+			"env": {},
+			"enabled": true
+		}`)
+	})
+
+	got, _, err := client.PipelineSchedules.Update(context.Background(), "my-org", "my-pipeline", "abc", in)
+	if err != nil {
+		t.Fatalf("Update returned error: %v", err)
+	}
+
+	if len(got.Env) != 0 {
+		t.Errorf("Update env length = %d, want 0", len(got.Env))
 	}
 }
 

--- a/pipeline_templates.go
+++ b/pipeline_templates.go
@@ -30,11 +30,18 @@ type PipelineTemplate struct {
 	UpdatedBy PipelineTemplateCreator `json:"updated_by,omitempty"`
 }
 
-type PipelineTemplateCreateUpdate struct {
+type PipelineTemplateCreate struct {
 	Name          string `json:"name,omitempty"`
 	Configuration string `json:"configuration,omitempty"`
 	Description   string `json:"description,omitempty"`
 	Available     bool   `json:"available"`
+}
+
+type PipelineTemplateUpdate struct {
+	Name          Optional[string] `json:"name,omitzero"`
+	Configuration Optional[string] `json:"configuration,omitzero"`
+	Description   Optional[string] `json:"description,omitzero"`
+	Available     Optional[bool]   `json:"available,omitzero"`
 }
 
 type PipelineTemplateCreator struct {
@@ -87,7 +94,7 @@ func (pts *PipelineTemplatesService) Get(ctx context.Context, org, templateUUID 
 	return template, resp, err
 }
 
-func (pts *PipelineTemplatesService) Create(ctx context.Context, org string, ptc PipelineTemplateCreateUpdate) (PipelineTemplate, *Response, error) {
+func (pts *PipelineTemplatesService) Create(ctx context.Context, org string, ptc PipelineTemplateCreate) (PipelineTemplate, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates", org)
 	req, err := pts.client.NewRequest(ctx, "POST", u, ptc)
 	if err != nil {
@@ -103,7 +110,7 @@ func (pts *PipelineTemplatesService) Create(ctx context.Context, org string, ptc
 	return template, resp, err
 }
 
-func (pts *PipelineTemplatesService) Update(ctx context.Context, org, templateUUID string, ptu PipelineTemplateCreateUpdate) (PipelineTemplate, *Response, error) {
+func (pts *PipelineTemplatesService) Update(ctx context.Context, org, templateUUID string, ptu PipelineTemplateUpdate) (PipelineTemplate, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/pipeline-templates/%s", org, templateUUID)
 	req, err := pts.client.NewRequest(ctx, "PATCH", u, ptu)
 	if err != nil {

--- a/pipeline_templates.go
+++ b/pipeline_templates.go
@@ -13,6 +13,7 @@ type PipelineTemplatesService struct {
 	client *Client
 }
 
+// PipelineTemplate represents a reusable pipeline template.
 type PipelineTemplate struct {
 	UUID          string `json:"uuid,omitempty"`
 	GraphQLID     string `json:"graphql_id,omitempty"`
@@ -30,6 +31,7 @@ type PipelineTemplate struct {
 	UpdatedBy PipelineTemplateCreator `json:"updated_by,omitempty"`
 }
 
+// PipelineTemplateCreate represents the request body for creating a pipeline template.
 type PipelineTemplateCreate struct {
 	Name          string `json:"name,omitempty"`
 	Configuration string `json:"configuration,omitempty"`
@@ -37,6 +39,7 @@ type PipelineTemplateCreate struct {
 	Available     bool   `json:"available"`
 }
 
+// PipelineTemplateUpdate represents the request body for updating a pipeline template.
 type PipelineTemplateUpdate struct {
 	Name          Optional[string] `json:"name,omitzero"`
 	Configuration Optional[string] `json:"configuration,omitzero"`

--- a/pipeline_templates_test.go
+++ b/pipeline_templates_test.go
@@ -218,7 +218,7 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
-	input := PipelineTemplateCreateUpdate{
+	input := PipelineTemplateCreate{
 		Name:          "Production Pipeline uploader",
 		Description:   "Production pipeline upload template",
 		Configuration: "steps:\n  - label: \":pipeline:\"\n    command: \"buildkite-agent pipeline upload .buildkite/pipeline-production.yml\"\n",
@@ -226,7 +226,7 @@ func TestPipelineTemplatesService_Create(t *testing.T) {
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates", func(w http.ResponseWriter, r *http.Request) {
-		var v PipelineTemplateCreateUpdate
+		var v PipelineTemplateCreate
 		err := json.NewDecoder(r.Body).Decode(&v)
 		if err != nil {
 			t.Fatalf("Error parsing json body: %v", err)
@@ -276,13 +276,8 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 	t.Cleanup(teardown)
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", func(w http.ResponseWriter, r *http.Request) {
-		var v PipelineTemplateCreateUpdate
-		err := json.NewDecoder(r.Body).Decode(&v)
-		if err != nil {
-			t.Fatalf("Error parsing json body: %v", err)
-		}
-
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"description":"A pipeline template for uploading a production pipeline YAML (pipeline-production.yml"}`)
 
 		_, _ = fmt.Fprint(w,
 			`
@@ -296,8 +291,8 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 			}`)
 	})
 
-	pipelineTemplateUpdate := PipelineTemplateCreateUpdate{
-		Description: "A pipeline template for uploading a production pipeline YAML (pipeline-production.yml",
+	pipelineTemplateUpdate := PipelineTemplateUpdate{
+		Description: Some("A pipeline template for uploading a production pipeline YAML (pipeline-production.yml"),
 	}
 
 	got, _, err := client.PipelineTemplates.Update(context.Background(), "my-great-org", "b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", pipelineTemplateUpdate)
@@ -316,6 +311,37 @@ func TestPipelineTemplatesService_Update(t *testing.T) {
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("TestPipelineTemplates.Update diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestPipelineTemplatesService_UpdateSetsAvailableFalse(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipeline-templates/b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"available":false}`)
+
+		_, _ = fmt.Fprint(w,
+			`
+			{
+				"uuid": "b8c2e171-1c7d-47a4-a4d1-a20d691f51d0",
+				"name" : "Production Pipeline template",
+				"available": false
+			}`)
+	})
+
+	got, _, err := client.PipelineTemplates.Update(context.Background(), "my-great-org", "b8c2e171-1c7d-47a4-a4d1-a20d691f51d0", PipelineTemplateUpdate{
+		Available: Some(false),
+	})
+	if err != nil {
+		t.Errorf("TestPipelineTemplates.Update returned error: %v", err)
+	}
+
+	if got.Available {
+		t.Error("Available = true, want false")
 	}
 }
 

--- a/pipelines.go
+++ b/pipelines.go
@@ -41,6 +41,7 @@ type CreatePipeline struct {
 	Tags                            []string          `json:"tags,omitempty"`
 }
 
+// UpdatePipeline represents the request body for updating a pipeline.
 type UpdatePipeline struct {
 	// Either configuration needs to be specified as a yaml string or steps (based on what the pipeline uses)
 	Configuration Optional[string] `json:"configuration,omitzero"`

--- a/pipelines.go
+++ b/pipelines.go
@@ -43,24 +43,24 @@ type CreatePipeline struct {
 
 type UpdatePipeline struct {
 	// Either configuration needs to be specified as a yaml string or steps (based on what the pipeline uses)
-	Configuration string `json:"configuration,omitempty"`
-	Steps         []Step `json:"steps,omitempty"`
+	Configuration Optional[string] `json:"configuration,omitzero"`
+	Steps         Optional[[]Step] `json:"steps,omitzero"`
 
-	Name                            string           `json:"name,omitempty"`
-	Repository                      string           `json:"repository,omitempty"`
-	DefaultBranch                   string           `json:"default_branch,omitempty"`
-	DefaultCommandStepTimeout       int              `json:"default_command_step_timeout,omitempty"`
-	Description                     string           `json:"description,omitempty"`
-	MaximumCommandStepTimeout       int              `json:"maximum_command_step_timeout,omitempty"`
-	ProviderSettings                ProviderSettings `json:"provider_settings,omitempty"`
-	BranchConfiguration             string           `json:"branch_configuration,omitempty"`
-	SkipQueuedBranchBuilds          bool             `json:"skip_queued_branch_builds"`
-	SkipQueuedBranchBuildsFilter    string           `json:"skip_queued_branch_builds_filter,omitempty"`
-	CancelRunningBranchBuilds       bool             `json:"cancel_running_branch_builds"`
-	CancelRunningBranchBuildsFilter string           `json:"cancel_running_branch_builds_filter,omitempty"`
-	ClusterID                       string           `json:"cluster_id,omitempty"`
-	Visibility                      string           `json:"visibility,omitempty"`
-	Tags                            []string         `json:"tags,omitempty"`
+	Name                            Optional[string]           `json:"name,omitzero"`
+	Repository                      Optional[string]           `json:"repository,omitzero"`
+	DefaultBranch                   Optional[string]           `json:"default_branch,omitzero"`
+	DefaultCommandStepTimeout       Optional[int]              `json:"default_command_step_timeout,omitzero"`
+	Description                     Optional[string]           `json:"description,omitzero"`
+	MaximumCommandStepTimeout       Optional[int]              `json:"maximum_command_step_timeout,omitzero"`
+	ProviderSettings                Optional[ProviderSettings] `json:"provider_settings,omitzero"`
+	BranchConfiguration             Optional[string]           `json:"branch_configuration,omitzero"`
+	SkipQueuedBranchBuilds          Optional[bool]             `json:"skip_queued_branch_builds,omitzero"`
+	SkipQueuedBranchBuildsFilter    Optional[string]           `json:"skip_queued_branch_builds_filter,omitzero"`
+	CancelRunningBranchBuilds       Optional[bool]             `json:"cancel_running_branch_builds,omitzero"`
+	CancelRunningBranchBuildsFilter Optional[string]           `json:"cancel_running_branch_builds_filter,omitzero"`
+	ClusterID                       Optional[string]           `json:"cluster_id,omitzero"`
+	Visibility                      Optional[string]           `json:"visibility,omitzero"`
+	Tags                            Optional[[]string]         `json:"tags,omitzero"`
 }
 
 // Pipeline represents a buildkite pipeline.

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -404,17 +404,8 @@ func TestPipelinesService_Update(t *testing.T) {
 	}
 
 	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-repo", func(w http.ResponseWriter, r *http.Request) {
-		var v UpdatePipeline
-		err := json.NewDecoder(r.Body).Decode(&v)
-		if err != nil {
-			t.Fatalf("Error parsing json body: %v", err)
-		}
-
-		if diff := cmp.Diff(v, UpdatePipeline{Name: "derp"}); diff != "" {
-			t.Errorf("Request body diff: (-got +want)\n%s", diff)
-		}
-
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"name":"derp"}`)
 
 		_, _ = fmt.Fprint(w, `{
 						"name":"derp",
@@ -439,7 +430,7 @@ func TestPipelinesService_Update(t *testing.T) {
 					}`)
 	})
 
-	got, _, err := client.Pipelines.Update(context.Background(), "my-great-org", "my-great-repo", UpdatePipeline{Name: "derp"})
+	got, _, err := client.Pipelines.Update(context.Background(), "my-great-org", "my-great-repo", UpdatePipeline{Name: Some("derp")})
 	if err != nil {
 		t.Errorf("Pipelines.Update returned error: %v", err)
 	}
@@ -468,6 +459,44 @@ func TestPipelinesService_Update(t *testing.T) {
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("Pipelines.Update diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestPipelinesService_UpdateClearsTagsAndSendsFalse(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/my-great-repo", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{
+			"tags": [],
+			"skip_queued_branch_builds": false
+		}`)
+
+		_, _ = fmt.Fprint(w, `{
+			"name": "my-great-repo",
+			"repository": "git@github.com:buildkite/my-great-repo.git",
+			"skip_queued_branch_builds": false,
+			"cancel_running_branch_builds": true,
+			"tags": []
+		}`)
+	})
+
+	got, _, err := client.Pipelines.Update(context.Background(), "my-great-org", "my-great-repo", UpdatePipeline{
+		Tags:                   Some([]string{}),
+		SkipQueuedBranchBuilds: Some(false),
+	})
+	if err != nil {
+		t.Errorf("Pipelines.Update returned error: %v", err)
+	}
+
+	if len(got.Tags) != 0 {
+		t.Errorf("Update tags length = %d, want 0", len(got.Tags))
+	}
+	if got.SkipQueuedBranchBuilds {
+		t.Error("Update skip_queued_branch_builds = true, want false")
 	}
 }
 

--- a/team_pipelines.go
+++ b/team_pipelines.go
@@ -21,11 +21,13 @@ type TeamPipeline struct {
 	CreatedAt   *Timestamp `json:"created_at,omitempty"`
 }
 
+// CreateTeamPipelines represents the request body for adding a pipeline to a team.
 type CreateTeamPipelines struct {
 	PipelineID  string `json:"pipeline_id,omitempty"`
 	AccessLevel string `json:"access_level,omitempty"`
 }
 
+// UpdateTeamPipelines represents the request body for updating a team's pipeline access.
 type UpdateTeamPipelines struct {
 	AccessLevel Optional[string] `json:"access_level,omitzero"`
 }

--- a/team_pipelines.go
+++ b/team_pipelines.go
@@ -27,7 +27,7 @@ type CreateTeamPipelines struct {
 }
 
 type UpdateTeamPipelines struct {
-	AccessLevel string `json:"access_level,omitempty"`
+	AccessLevel Optional[string] `json:"access_level,omitzero"`
 }
 
 type TeamPipelinesListOptions struct {

--- a/team_pipelines_test.go
+++ b/team_pipelines_test.go
@@ -160,6 +160,7 @@ func TestTeamPipelinesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-org/teams/c6fa9b07-efeb-4aea-b5ad-c4aa01e91038/pipelines/1239d7f9-394a-4d99-badf-7c3d8577a8ff", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"access_level":"build_and_read"}`)
 		_, _ = fmt.Fprint(w,
 			`
 			{
@@ -171,7 +172,7 @@ func TestTeamPipelinesService_Update(t *testing.T) {
 	})
 
 	wantUpdate := UpdateTeamPipelines{
-		AccessLevel: "build_and_read",
+		AccessLevel: Some("build_and_read"),
 	}
 
 	got, _, err := client.TeamPipelines.Update(context.Background(), "my-org", "c6fa9b07-efeb-4aea-b5ad-c4aa01e91038", "1239d7f9-394a-4d99-badf-7c3d8577a8ff", wantUpdate)

--- a/team_suites.go
+++ b/team_suites.go
@@ -21,11 +21,13 @@ type TeamSuites struct {
 	CreatedAt   *Timestamp `json:"created_at,omitempty"`
 }
 
+// CreateTeamSuites represents the request body for adding a suite to a team.
 type CreateTeamSuites struct {
 	SuiteID     string   `json:"suite_id,omitempty"`
 	AccessLevel []string `json:"access_level,omitempty"`
 }
 
+// UpdateTeamSuites represents the request body for updating a team's suite access.
 type UpdateTeamSuites struct {
 	AccessLevel Optional[[]string] `json:"access_level,omitzero"`
 }

--- a/team_suites.go
+++ b/team_suites.go
@@ -27,7 +27,7 @@ type CreateTeamSuites struct {
 }
 
 type UpdateTeamSuites struct {
-	AccessLevel []string `json:"access_level,omitempty"`
+	AccessLevel Optional[[]string] `json:"access_level,omitzero"`
 }
 
 type TeamSuitesListOptions struct {

--- a/team_suites_test.go
+++ b/team_suites_test.go
@@ -157,6 +157,7 @@ func TestTeamSuitesService_Update(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/testorg/teams/c6fa9b07-efeb-4aea-b5ad-c4aa01e91038/suites/1239d7f9-394a-4d99-badf-7c3d8577a8ff", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"access_level":["read","edit"]}`)
 		_, _ = fmt.Fprint(w,
 			`
 			{
@@ -168,7 +169,7 @@ func TestTeamSuitesService_Update(t *testing.T) {
 	})
 
 	wantUpdate := UpdateTeamSuites{
-		AccessLevel: []string{"read", "edit"},
+		AccessLevel: Some([]string{"read", "edit"}),
 	}
 
 	got, _, err := client.TeamSuites.Update(context.Background(), "testorg", "c6fa9b07-efeb-4aea-b5ad-c4aa01e91038", "1239d7f9-394a-4d99-badf-7c3d8577a8ff", wantUpdate)

--- a/teams.go
+++ b/teams.go
@@ -42,7 +42,7 @@ type TeamsListOptions struct {
 	UserID string `url:"user_id,omitempty"`
 }
 
-// CreateTeam represents a request to create or update a team.
+// CreateTeam represents a request to create a team.
 type CreateTeam struct {
 	Name                        string `json:"name,omitempty"`
 	Description                 string `json:"description,omitempty"`
@@ -54,6 +54,20 @@ type CreateTeam struct {
 	MembersCanCreateRegistries  bool   `json:"members_can_create_registries"`
 	MembersCanDestroyRegistries bool   `json:"members_can_destroy_registries"`
 	MembersCanDestroyPackages   bool   `json:"members_can_destroy_packages"`
+}
+
+// UpdateTeam represents a request to update a team.
+type UpdateTeam struct {
+	Name                        Optional[string] `json:"name,omitzero"`
+	Description                 Optional[string] `json:"description,omitzero"`
+	Privacy                     Optional[string] `json:"privacy,omitzero"`
+	IsDefaultTeam               Optional[bool]   `json:"is_default_team,omitzero"`
+	DefaultMemberRole           Optional[string] `json:"default_member_role,omitzero"`
+	MembersCanCreatePipelines   Optional[bool]   `json:"members_can_create_pipelines,omitzero"`
+	MembersCanCreateSuites      Optional[bool]   `json:"members_can_create_suites,omitzero"`
+	MembersCanCreateRegistries  Optional[bool]   `json:"members_can_create_registries,omitzero"`
+	MembersCanDestroyRegistries Optional[bool]   `json:"members_can_destroy_registries,omitzero"`
+	MembersCanDestroyPackages   Optional[bool]   `json:"members_can_destroy_packages,omitzero"`
 }
 
 // Get the teams for an org.
@@ -117,7 +131,7 @@ func (ts *TeamsService) CreateTeam(ctx context.Context, org string, t CreateTeam
 }
 
 // UpdateTeam updates a team.
-func (ts *TeamsService) UpdateTeam(ctx context.Context, org string, id string, t CreateTeam) (Team, *Response, error) {
+func (ts *TeamsService) UpdateTeam(ctx context.Context, org string, id string, t UpdateTeam) (Team, *Response, error) {
 	u := fmt.Sprintf("v2/organizations/%s/teams/%s", org, id)
 
 	req, err := ts.client.NewRequest(ctx, "PATCH", u, t)

--- a/teams_test.go
+++ b/teams_test.go
@@ -204,6 +204,14 @@ func TestTeamsService_UpdateTeam(t *testing.T) {
 
 	server.HandleFunc("/v2/organizations/my-great-org/teams/123", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{
+			"name": "updated-team",
+			"description": "Updated description",
+			"privacy": "secret",
+			"default_member_role": "maintainer",
+			"members_can_create_pipelines": true,
+			"members_can_create_registries": false
+		}`)
 		_, _ = fmt.Fprint(w, `{
 			"id": "123",
 			"graphql_id": "VGVhbS0tLTEyMw==",
@@ -221,12 +229,13 @@ func TestTeamsService_UpdateTeam(t *testing.T) {
 		}`)
 	})
 
-	team, _, err := client.Teams.UpdateTeam(context.Background(), "my-great-org", "123", CreateTeam{
-		Name:                      "updated-team",
-		Description:               "Updated description",
-		Privacy:                   "secret",
-		DefaultMemberRole:         "maintainer",
-		MembersCanCreatePipelines: true,
+	team, _, err := client.Teams.UpdateTeam(context.Background(), "my-great-org", "123", UpdateTeam{
+		Name:                       Some("updated-team"),
+		Description:                Some("Updated description"),
+		Privacy:                    Some("secret"),
+		DefaultMemberRole:          Some("maintainer"),
+		MembersCanCreatePipelines:  Some(true),
+		MembersCanCreateRegistries: Some(false),
 	})
 	if err != nil {
 		t.Errorf("Teams.UpdateTeam returned error: %v", err)

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -1,9 +1,34 @@
 package buildkite
 
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
 func must[T any](val T, err error) T {
 	if err != nil {
 		panic(err)
 	}
 
 	return val
+}
+
+func assertJSONEqual(t *testing.T, got, want string) {
+	t.Helper()
+
+	var gotJSON any
+	if err := json.Unmarshal([]byte(got), &gotJSON); err != nil {
+		t.Fatalf("got invalid JSON %q: %v", got, err)
+	}
+
+	var wantJSON any
+	if err := json.Unmarshal([]byte(want), &wantJSON); err != nil {
+		t.Fatalf("want invalid JSON %q: %v", want, err)
+	}
+
+	if diff := cmp.Diff(wantJSON, gotJSON); diff != "" {
+		t.Errorf("JSON mismatch (-want +got):\n%s", diff)
+	}
 }

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -2,6 +2,8 @@ package buildkite
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -31,4 +33,15 @@ func assertJSONEqual(t *testing.T, got, want string) {
 	if diff := cmp.Diff(wantJSON, gotJSON); diff != "" {
 		t.Errorf("JSON mismatch (-want +got):\n%s", diff)
 	}
+}
+
+func assertRequestJSON(t *testing.T, r *http.Request, want string) {
+	t.Helper()
+
+	got, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("reading request body: %v", err)
+	}
+
+	assertJSONEqual(t, string(got), want)
 }

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -22,12 +22,14 @@ func assertJSONEqual(t *testing.T, got, want string) {
 
 	var gotJSON any
 	if err := json.Unmarshal([]byte(got), &gotJSON); err != nil {
-		t.Fatalf("got invalid JSON %q: %v", got, err)
+		t.Errorf("got invalid JSON %q: %v", got, err)
+		return
 	}
 
 	var wantJSON any
 	if err := json.Unmarshal([]byte(want), &wantJSON); err != nil {
-		t.Fatalf("want invalid JSON %q: %v", want, err)
+		t.Errorf("want invalid JSON %q: %v", want, err)
+		return
 	}
 
 	if diff := cmp.Diff(wantJSON, gotJSON); diff != "" {
@@ -40,7 +42,8 @@ func assertRequestJSON(t *testing.T, r *http.Request, want string) {
 
 	got, err := io.ReadAll(r.Body)
 	if err != nil {
-		t.Fatalf("reading request body: %v", err)
+		t.Errorf("reading request body: %v", err)
+		return
 	}
 
 	assertJSONEqual(t, string(got), want)

--- a/test_suites.go
+++ b/test_suites.go
@@ -30,6 +30,11 @@ type TestSuite struct {
 	DefaultBranch string `json:"default_branch,omitempty"`
 }
 
+type TestSuiteUpdate struct {
+	Name          Optional[string] `json:"name,omitzero"`
+	DefaultBranch Optional[string] `json:"default_branch,omitzero"`
+}
+
 type TestSuiteListOptions struct{ ListOptions }
 
 func (tss *TestSuitesService) List(ctx context.Context, org string, opt *TestSuiteListOptions) ([]TestSuite, *Response, error) {
@@ -85,11 +90,11 @@ func (tss *TestSuitesService) Create(ctx context.Context, org string, ts TestSui
 	return testSuite, resp, err
 }
 
-func (tss *TestSuitesService) Update(ctx context.Context, org, slug string, ts TestSuite) (TestSuite, *Response, error) {
+func (tss *TestSuitesService) Update(ctx context.Context, org, slug string, ts TestSuiteUpdate) (TestSuite, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, slug)
 	req, err := tss.client.NewRequest(ctx, "PATCH", u, ts)
 	if err != nil {
-		return TestSuite{}, nil, nil
+		return TestSuite{}, nil, err
 	}
 
 	var out TestSuite

--- a/test_suites.go
+++ b/test_suites.go
@@ -13,6 +13,7 @@ type TestSuitesService struct {
 	client *Client
 }
 
+// TestSuiteCreate represents the request body for creating a test suite.
 type TestSuiteCreate struct {
 	Name          string   `json:"name"`
 	DefaultBranch string   `json:"default_branch,omitempty"`
@@ -20,6 +21,7 @@ type TestSuiteCreate struct {
 	TeamUUIDs     []string `json:"team_ids,omitempty"`
 }
 
+// TestSuite represents a Buildkite Test Analytics suite.
 type TestSuite struct {
 	ID            string `json:"id,omitempty"`
 	GraphQLID     string `json:"graphql_id,omitempty"`
@@ -30,6 +32,7 @@ type TestSuite struct {
 	DefaultBranch string `json:"default_branch,omitempty"`
 }
 
+// TestSuiteUpdate represents the request body for updating a test suite.
 type TestSuiteUpdate struct {
 	Name          Optional[string] `json:"name,omitzero"`
 	DefaultBranch Optional[string] `json:"default_branch,omitzero"`

--- a/test_suites_test.go
+++ b/test_suites_test.go
@@ -218,7 +218,7 @@ func TestTestSuitesService_Update(t *testing.T) {
 
 	got, _, err := client.TestSuites.Update(context.Background(), "my-great-org", suite.Slug, TestSuiteUpdate{DefaultBranch: Some("default")})
 	if err != nil {
-		t.Errorf("Pipelines.Update returned error: %v", err)
+		t.Errorf("TestSuites.Update returned error: %v", err)
 	}
 
 	want := TestSuite{

--- a/test_suites_test.go
+++ b/test_suites_test.go
@@ -203,13 +203,8 @@ func TestTestSuitesService_Update(t *testing.T) {
 	}
 
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-4", func(w http.ResponseWriter, r *http.Request) {
-		var v TestSuiteCreate
-		err := json.NewDecoder(r.Body).Decode(&v)
-		if err != nil {
-			t.Fatalf("Error parsing json body: %v", err)
-		}
-
 		testMethod(t, r, "PATCH")
+		assertRequestJSON(t, r, `{"default_branch":"default"}`)
 
 		_, _ = fmt.Fprint(w,
 			`
@@ -221,7 +216,7 @@ func TestTestSuitesService_Update(t *testing.T) {
 			}`)
 	})
 
-	got, _, err := client.TestSuites.Update(context.Background(), "my-great-org", suite.Slug, TestSuite{DefaultBranch: "default"})
+	got, _, err := client.TestSuites.Update(context.Background(), "my-great-org", suite.Slug, TestSuiteUpdate{DefaultBranch: Some("default")})
 	if err != nil {
 		t.Errorf("Pipelines.Update returned error: %v", err)
 	}

--- a/version.go
+++ b/version.go
@@ -14,14 +14,14 @@ var Version = func() string {
 	}
 
 	// For the main module
-	if info.Main.Path == "github.com/buildkite/go-buildkite/v4" && info.Main.Version != "(devel)" {
+	if info.Main.Path == "github.com/buildkite/go-buildkite/v5" && info.Main.Version != "(devel)" {
 		// Remove the 'v' prefix if present
 		return strings.TrimPrefix(info.Main.Version, "v")
 	}
 
 	// Try to find this module in the dependency list
 	for _, dep := range info.Deps {
-		if dep.Path == "github.com/buildkite/go-buildkite/v4" && dep.Version != "(devel)" {
+		if dep.Path == "github.com/buildkite/go-buildkite/v5" && dep.Version != "(devel)" {
 			return strings.TrimPrefix(dep.Version, "v")
 		}
 	}


### PR DESCRIPTION
Update request structs currently use `omitempty`, so callers cannot distinguish "leave this field unchanged" from "send this field with an empty value". That makes valid PATCH operations silently no-op when callers try to clear fields such as pipeline tags, schedule env, descriptions, IP allowlists, or explicit boolean settings.

This PR takes the v5 break and makes update payloads presence-aware with `Optional[T]` and `Some(...)`. Unset optionals are omitted from the PATCH body, while `Some("")`, `Some(false)`, `Some([]string{})`, and `Some(map[string]string{})` are sent exactly as requested.

Examples:

```go
_, _, err := client.Pipelines.Update(ctx, org, pipelineSlug, buildkite.UpdatePipeline{
    Description:            buildkite.Some(""),
    Tags:                   buildkite.Some([]string{}),
    SkipQueuedBranchBuilds: buildkite.Some(false),
})
```

```go
_, _, err := client.PipelineSchedules.Update(ctx, org, pipelineSlug, scheduleID, buildkite.UpdatePipelineSchedule{
    Env:     buildkite.Some(map[string]string{}),
    Enabled: buildkite.Some(false),
})
```

The change also splits shared create/update inputs where create payloads should keep plain values and update payloads need presence tracking: cluster tokens, pipeline templates, teams, and test suites. The module path and examples move to `github.com/buildkite/go-buildkite/v5`, and the README/changelog include migration notes.

Validation:

- `mise exec go@1.25 -- go test ./...`
- `mise exec go@1.25 -- make test`
