### PR TITLE
feat: improve rate limit retry handling in go-buildkite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 * feat: improve rate-limit retry handling — retry all HTTP methods on 429 (not just GET), parse `RateLimit-Reset` header as delta-seconds, add `WithRateLimitNotify` callback, add `WithMaxRetries` option, use `github.com/buildkite/roko` for retry loop management [#319](https://github.com/buildkite/go-buildkite/pull/319) ([Megh03](https://github.com/Megh03))
 
+## [v5.1.0](https://github.com/buildkite/go-buildkite/compare/v5.0.1...v5.1.0) (2026-06-16)
+
+* PB-1933 Add promised exit status fields to Job [#323](https://github.com/buildkite/go-buildkite/pull/323) ([123sarahj123](https://github.com/123sarahj123))
+* SUP-6269: Add Copy capability to PackagesService [#321](https://github.com/buildkite/go-buildkite/pull/321) ([dahtey-bk](https://github.com/dahtey-bk))
+* chore(deps): update buildkite plugin mise to v1.1.4 [#322](https://github.com/buildkite/go-buildkite/pull/322) ([renovate[bot]](https://github.com/apps/renovate))
+* SUP-6268: Add Find test capability to TestsService [#320](https://github.com/buildkite/go-buildkite/pull/320) ([dahtey-bk](https://github.com/dahtey-bk))
+* chore(release): update changelog for v5.0.1 [#318](https://github.com/buildkite/go-buildkite/pull/318) ([mcncl](https://github.com/mcncl))
+
 ## [v5.0.1](https://github.com/buildkite/go-buildkite/compare/v5.0.0...v5.0.1) (2026-06-10)
 
 * chore: Add the include_paused param to builds list options [#317](https://github.com/buildkite/go-buildkite/pull/317) ([CerealBoy](https://github.com/CerealBoy))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+* feat: improve rate-limit retry handling — retry all HTTP methods on 429 (not just GET), parse `RateLimit-Reset` header as delta-seconds, add `WithRateLimitNotify` callback, add `WithMaxRetries` option, use `github.com/buildkite/roko` for retry loop management [#319](https://github.com/buildkite/go-buildkite/pull/319) ([Megh03](https://github.com/Megh03))
+
 ## [v5.0.1](https://github.com/buildkite/go-buildkite/compare/v5.0.0...v5.0.1) (2026-06-10)
 
 * chore: Add the include_paused param to builds list options [#317](https://github.com/buildkite/go-buildkite/pull/317) ([CerealBoy](https://github.com/CerealBoy))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 
 * feat: improve rate-limit retry handling — retry all HTTP methods on 429 (not just GET), parse `RateLimit-Reset` header as delta-seconds, add `WithRateLimitNotify` callback, add `WithMaxRetries` option, use `github.com/buildkite/roko` for retry loop management [#319](https://github.com/buildkite/go-buildkite/pull/319) ([Megh03](https://github.com/Megh03))
+* breaking: the implicit 15-minute wall-clock cap from `cenkalti/backoff` is removed; callers with high `WithMaxRetries` values and no context deadline may block significantly longer than before
 
 ## [v5.1.0](https://github.com/buildkite/go-buildkite/compare/v5.0.1...v5.1.0) (2026-06-16)
 

--- a/buildkite.go
+++ b/buildkite.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/buildkite/roko"
 	"github.com/buildkite/go-buildkite/v5/internal/bkmultipart"
+	"github.com/buildkite/roko"
 	"github.com/google/go-querystring/query"
 )
 
@@ -29,6 +29,10 @@ const (
 
 // DefaultUserAgent is the default user agent used for API requests
 var DefaultUserAgent = "go-buildkite/" + Version
+
+// errRateLimited is returned from the roko callback to signal a retryable 429.
+// It is never surfaced to callers — checkResponse produces the real *ErrorResponse.
+var errRateLimited = errors.New("rate limited")
 
 // Client - A Client manages communication with the buildkite API.
 type Client struct {
@@ -473,6 +477,9 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		delay := retryDelay(resp, rt.AttemptCount())
 		rt.SetNextInterval(delay)
 
+		// roko calls MarkAttempt() after this callback returns, so AttemptCount()
+		// here is still the 0-based index of the current attempt. The last allowed
+		// attempt is index c.maxRetries (= WithMaxAttempts(c.maxRetries+1) - 1).
 		if rt.AttemptCount() < c.maxRetries {
 			// More retries remaining — drain and close so the connection can be reused.
 			_, _ = io.Copy(io.Discard, resp.Body)
@@ -486,12 +493,15 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 				fmt.Printf("DEBUG rate limited, retry %d in %v\n", rt.AttemptCount()+1, delay)
 			}
 		}
-		// On the final attempt, resp is kept intact so checkResponse can produce
-		// a proper *ErrorResponse from the 429 body.
+		// On the final attempt resp is kept intact so checkResponse can produce
+		// a proper *ErrorResponse from the 429 body rather than returning errRateLimited.
 
-		return errors.New("rate limited")
+		return errRateLimited
 	})
 
+	// resp is nil only when a network error or body-rewind error caused an early
+	// exit via rt.Break(). For exhausted 429s, resp is kept so checkResponse below
+	// can return a proper *ErrorResponse.
 	if resp == nil {
 		return nil, rokoErr
 	}

--- a/buildkite.go
+++ b/buildkite.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand/v2"
@@ -16,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/buildkite/roko"
 	"github.com/buildkite/go-buildkite/v5/internal/bkmultipart"
 	"github.com/google/go-querystring/query"
 )
@@ -423,13 +425,21 @@ func retryDelay(resp *http.Response, attempt int) time.Duration {
 func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	var resp *http.Response
 
-	for attempt := 0; ; attempt++ {
+	// Constant(0) is used as the base strategy; the actual delay is always
+	// overridden via rt.SetNextInterval inside the callback.
+	retrier := roko.NewRetrier(
+		roko.WithMaxAttempts(c.maxRetries+1),
+		roko.WithStrategy(roko.Constant(0)),
+	)
+
+	rokoErr := retrier.DoWithContext(req.Context(), func(rt *roko.Retrier) error {
 		// Rewind body for retries. GetBody is set automatically by
 		// http.NewRequestWithContext for bytes.Buffer/bytes.Reader bodies.
-		if attempt > 0 && req.GetBody != nil {
+		if rt.AttemptCount() > 0 && req.GetBody != nil {
 			body, err := req.GetBody()
 			if err != nil {
-				return nil, fmt.Errorf("rewinding request body for retry: %w", err)
+				rt.Break()
+				return fmt.Errorf("rewinding request body for retry: %w", err)
 			}
 			req.Body = body
 		}
@@ -443,7 +453,8 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		var err error
 		resp, err = c.client.Do(req)
 		if err != nil {
-			return nil, err
+			rt.Break()
+			return err
 		}
 
 		if c.httpDebug {
@@ -455,29 +466,34 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		// canRewind is false for raw io.Reader bodies where GetBody is not set;
 		// those requests are not retried since the body cannot be replayed.
 		canRewind := req.Body == nil || req.GetBody != nil
-		if resp.StatusCode != http.StatusTooManyRequests || attempt >= c.maxRetries || !canRewind {
-			break
+		if resp.StatusCode != http.StatusTooManyRequests || !canRewind {
+			return nil
 		}
 
-		delay := retryDelay(resp, attempt)
+		delay := retryDelay(resp, rt.AttemptCount())
+		rt.SetNextInterval(delay)
 
-		// Drain and close before retrying so the connection can be reused.
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
+		if rt.AttemptCount() < c.maxRetries {
+			// More retries remaining — drain and close so the connection can be reused.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			resp = nil
 
-		// delay is the intended wait duration; actual wait may be shorter if the context is cancelled.
-		if c.rateLimitNotify != nil {
-			c.rateLimitNotify(attempt+1, delay)
+			if c.rateLimitNotify != nil {
+				c.rateLimitNotify(rt.AttemptCount()+1, delay)
+			}
+			if c.httpDebug {
+				fmt.Printf("DEBUG rate limited, retry %d in %v\n", rt.AttemptCount()+1, delay)
+			}
 		}
-		if c.httpDebug {
-			fmt.Printf("DEBUG rate limited, retry %d in %v\n", attempt+1, delay)
-		}
+		// On the final attempt, resp is kept intact so checkResponse can produce
+		// a proper *ErrorResponse from the 429 body.
 
-		select {
-		case <-req.Context().Done():
-			return nil, req.Context().Err()
-		case <-time.After(delay):
-		}
+		return errors.New("rate limited")
+	})
+
+	if resp == nil {
+		return nil, rokoErr
 	}
 
 	defer func() {

--- a/buildkite.go
+++ b/buildkite.go
@@ -405,7 +405,9 @@ func retryDelay(resp *http.Response, attempt int) time.Duration {
 				if secs > 120 {
 					secs = 120
 				}
-				return time.Duration(secs)*time.Second + 500*time.Millisecond + time.Duration(rand.N(time.Second))
+				// 500ms buffer ensures we don't hit the API again in the same window
+			// when the server sends RateLimit-Reset: 0.
+			return time.Duration(secs)*time.Second + 500*time.Millisecond + time.Duration(rand.N(time.Second))
 			}
 		}
 	}
@@ -469,6 +471,9 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 
 		// canRewind is false for raw io.Reader bodies where GetBody is not set;
 		// those requests are not retried since the body cannot be replayed.
+		// When canRewind is false and the response is 429, returning nil causes
+		// roko to treat the call as successful and exit the loop; execution then
+		// falls through to checkResponse which surfaces a proper *ErrorResponse.
 		canRewind := req.Body == nil || req.GetBody != nil
 		if resp.StatusCode != http.StatusTooManyRequests || !canRewind {
 			return nil

--- a/buildkite.go
+++ b/buildkite.go
@@ -406,8 +406,8 @@ func retryDelay(resp *http.Response, attempt int) time.Duration {
 					secs = 120
 				}
 				// 500ms buffer ensures we don't hit the API again in the same window
-			// when the server sends RateLimit-Reset: 0.
-			return time.Duration(secs)*time.Second + 500*time.Millisecond + time.Duration(rand.N(time.Second))
+				// when the server sends RateLimit-Reset: 0.
+				return time.Duration(secs)*time.Second + 500*time.Millisecond + time.Duration(rand.N(time.Second))
 			}
 		}
 	}

--- a/buildkite.go
+++ b/buildkite.go
@@ -85,8 +85,10 @@ type Client struct {
 	maxRetries      int
 }
 
-// RateLimitNotify is called each time a request is retried due to a 429 response.
-// attempt is 1-based; delay is how long the client will wait before the next attempt.
+// RateLimitNotify is called each time a 429 response is received, including on
+// the final exhausted attempt where no retry follows and when maxRetries is 0.
+// attempt is 1-based; delay is the computed back-off duration, which is not
+// slept on the final attempt.
 type RateLimitNotify func(attempt int, delay time.Duration)
 
 // ClientOpt is a function that configures a Client.

--- a/buildkite.go
+++ b/buildkite.go
@@ -5,9 +5,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -17,12 +17,12 @@ import (
 	"time"
 
 	"github.com/buildkite/go-buildkite/v5/internal/bkmultipart"
-	"github.com/cenkalti/backoff"
 	"github.com/google/go-querystring/query"
 )
 
 const (
-	DefaultBaseURL = "https://api.buildkite.com/"
+	DefaultBaseURL    = "https://api.buildkite.com/"
+	DefaultMaxRetries = 3
 )
 
 // DefaultUserAgent is the default user agent used for API requests
@@ -73,9 +73,15 @@ type Client struct {
 	TestRuns                 *TestRunsService
 	TestSuites               *TestSuitesService
 
-	authHeader string
-	httpDebug  bool
+	authHeader      string
+	httpDebug       bool
+	rateLimitNotify RateLimitNotify
+	maxRetries      int
 }
+
+// RateLimitNotify is called each time a request is retried due to a 429 response.
+// attempt is 1-based; delay is how long the client will wait before the next attempt.
+type RateLimitNotify func(attempt int, delay time.Duration)
 
 // ClientOpt is a function that configures a Client.
 type ClientOpt func(*Client) error
@@ -134,6 +140,28 @@ func WithHTTPDebug(debug bool) ClientOpt {
 	}
 }
 
+// WithRateLimitNotify registers a callback invoked each time a request is retried
+// due to a 429 response. Use it to log, display a message, or emit metrics.
+// Passing nil clears any previously registered callback.
+func WithRateLimitNotify(fn RateLimitNotify) ClientOpt {
+	return func(c *Client) error {
+		c.rateLimitNotify = fn
+		return nil
+	}
+}
+
+// WithMaxRetries sets the maximum number of retry attempts on rate-limited requests.
+// Defaults to DefaultMaxRetries (3). Use 0 to disable retries entirely.
+func WithMaxRetries(n int) ClientOpt {
+	return func(c *Client) error {
+		if n < 0 {
+			return fmt.Errorf("max retries must be >= 0, got %d", n)
+		}
+		c.maxRetries = n
+		return nil
+	}
+}
+
 // NewClient returns a new buildkite API client with the provided options.
 // Note that at [WithTokenAuth] must be provided for requests to the buildkite API to succeed.
 // Otherwise, sensible defaults are used.
@@ -141,9 +169,10 @@ func NewClient(opts ...ClientOpt) (*Client, error) {
 	baseURL, _ := url.Parse(DefaultBaseURL)
 
 	c := &Client{
-		client:    http.DefaultClient,
-		BaseURL:   baseURL,
-		UserAgent: DefaultUserAgent,
+		client:     http.DefaultClient,
+		BaseURL:    baseURL,
+		UserAgent:  DefaultUserAgent,
+		maxRetries: DefaultMaxRetries,
 	}
 
 	for _, opt := range opts {
@@ -357,24 +386,64 @@ func (r *Response) populatePageValues() {
 	}
 }
 
+// retryDelay returns how long to wait before the next attempt after a 429.
+// It checks RateLimit-Reset first, then Retry-After, then falls back to capped
+// exponential backoff. Both headers are interpreted as delta-seconds (time until
+// reset) per the Buildkite API spec — not Unix timestamps.
+// A random jitter of up to 1 second is added on all paths to spread out
+// concurrent clients that receive the same reset time.
+func retryDelay(resp *http.Response, attempt int) time.Duration {
+	for _, header := range []string{"RateLimit-Reset", "Retry-After"} {
+		if s := resp.Header.Get(header); s != "" {
+			if secs, err := strconv.Atoi(s); err == nil && secs >= 0 {
+				if secs > 120 {
+					secs = 120
+				}
+				return time.Duration(secs)*time.Second + 500*time.Millisecond + time.Duration(rand.N(time.Second))
+			}
+		}
+	}
+	// Cap the shift to prevent int64 overflow at high attempt counts.
+	shift := attempt
+	if shift > 5 {
+		shift = 5
+	}
+	d := time.Duration(1<<uint(shift)) * time.Second
+	if d > 30*time.Second {
+		d = 30 * time.Second
+	}
+	return d + time.Duration(rand.N(time.Second))
+}
+
 // Do sends an API request and returns the API response.  The API response is
 // JSON decoded and stored in the value pointed to by v, or returned as an
 // error if an API error has occurred.  If v implements the io.Writer
 // interface, the raw response body will be written to v, without attempting to
 // first decode it.
 func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
-	respCh := make(chan *http.Response, 1)
+	var resp *http.Response
 
-	op := func() error {
+	for attempt := 0; ; attempt++ {
+		// Rewind body for retries. GetBody is set automatically by
+		// http.NewRequestWithContext for bytes.Buffer/bytes.Reader bodies.
+		if attempt > 0 && req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, fmt.Errorf("rewinding request body for retry: %w", err)
+			}
+			req.Body = body
+		}
+
 		if c.httpDebug {
 			if dump, err := httputil.DumpRequest(req, true); err == nil {
 				fmt.Printf("DEBUG request uri=%s\n%s\n", req.URL, dump)
 			}
 		}
 
-		resp, err := c.client.Do(req)
+		var err error
+		resp, err = c.client.Do(req)
 		if err != nil {
-			return backoff.Permanent(err)
+			return nil, err
 		}
 
 		if c.httpDebug {
@@ -383,33 +452,38 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 			}
 		}
 
-		// Check for rate limiting response on idempotent requests
-		if req.Method == http.MethodGet && resp.StatusCode == http.StatusTooManyRequests {
-			errMsg := resp.Header.Get("Rate-Limit-Warning")
-			if errMsg == "" {
-				errMsg = "Too many requests, retry"
-			}
-			return errors.New(errMsg)
+		// canRewind is false for raw io.Reader bodies where GetBody is not set;
+		// those requests are not retried since the body cannot be replayed.
+		canRewind := req.Body == nil || req.GetBody != nil
+		if resp.StatusCode != http.StatusTooManyRequests || attempt >= c.maxRetries || !canRewind {
+			break
 		}
 
-		respCh <- resp
-		return nil
-	}
+		delay := retryDelay(resp, attempt)
 
-	notify := func(err error, delay time.Duration) {
+		// Drain and close before retrying so the connection can be reused.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		// delay is the intended wait duration; actual wait may be shorter if the context is cancelled.
+		if c.rateLimitNotify != nil {
+			c.rateLimitNotify(attempt+1, delay)
+		}
 		if c.httpDebug {
-			fmt.Printf("DEBUG error %v, retry in %v\n", err, delay)
+			fmt.Printf("DEBUG rate limited, retry %d in %v\n", attempt+1, delay)
+		}
+
+		select {
+		case <-req.Context().Done():
+			return nil, req.Context().Err()
+		case <-time.After(delay):
 		}
 	}
 
-	if err := backoff.RetryNotify(op, backoff.NewExponentialBackOff(), notify); err != nil {
-		return nil, err
-	}
-
-	resp := <-respCh
-
-	defer func() { _ = resp.Body.Close() }()
-	defer func() { _, _ = io.Copy(io.Discard, resp.Body) }()
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 
 	response := newResponse(resp)
 

--- a/buildkite.go
+++ b/buildkite.go
@@ -146,8 +146,11 @@ func WithHTTPDebug(debug bool) ClientOpt {
 	}
 }
 
-// WithRateLimitNotify registers a callback invoked each time a request is retried
-// due to a 429 response. Use it to log, display a message, or emit metrics.
+// WithRateLimitNotify registers a callback invoked on every 429 response,
+// including when retries are exhausted or disabled (maxRetries=0). Use it to
+// log, emit metrics, or display progress. The callback is not invoked when the
+// request body is a raw io.Reader without GetBody set, since those requests
+// cannot be retried and the 429 is surfaced directly as an *ErrorResponse.
 // Passing nil clears any previously registered callback.
 func WithRateLimitNotify(fn RateLimitNotify) ClientOpt {
 	return func(c *Client) error {
@@ -441,16 +444,17 @@ func retryDelay(resp *http.Response, attempt int) time.Duration {
 func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	var resp *http.Response
 
-	// Constant(0) is used as the base strategy; the actual delay is always
-	// overridden via rt.SetNextInterval inside the callback.
+	// roko requires a strategy, but the real delay is always driven by the
+	// server response (RateLimit-Reset header or exponential fallback), so
+	// Constant(0) is a required placeholder that is always overridden.
 	retrier := roko.NewRetrier(
 		roko.WithMaxAttempts(c.maxRetries+1),
 		roko.WithStrategy(roko.Constant(0)),
 	)
 
 	rokoErr := retrier.DoWithContext(req.Context(), func(rt *roko.Retrier) error {
-		// Rewind body for retries. GetBody is set automatically by
-		// http.NewRequestWithContext for bytes.Buffer/bytes.Reader bodies.
+		// GetBody is set automatically by http.NewRequestWithContext for
+		// bytes.Buffer/bytes.Reader bodies, enabling body replay on retry.
 		if rt.AttemptCount() > 0 && req.GetBody != nil {
 			body, err := req.GetBody()
 			if err != nil {

--- a/buildkite.go
+++ b/buildkite.go
@@ -83,12 +83,13 @@ type Client struct {
 	httpDebug       bool
 	rateLimitNotify RateLimitNotify
 	maxRetries      int
+	sleepFunc       func(time.Duration) // test-only override for retry backoff; nil uses roko's default
 }
 
 // RateLimitNotify is called each time a 429 response is received, including on
 // the final exhausted attempt where no retry follows and when maxRetries is 0.
-// attempt is 1-based; delay is the computed back-off duration, which is not
-// slept on the final attempt.
+// attempt is 1-based; delay is the back-off before the next retry, or 0 if
+// this is the final attempt and no sleep will follow.
 type RateLimitNotify func(attempt int, delay time.Duration)
 
 // ClientOpt is a function that configures a Client.
@@ -408,22 +409,19 @@ func (r *Response) populatePageValues() {
 }
 
 // retryDelay returns how long to wait before the next attempt after a 429.
-// It checks RateLimit-Reset first, then Retry-After, then falls back to capped
-// exponential backoff. Both headers are interpreted as delta-seconds (time until
-// reset) per the Buildkite API spec — not Unix timestamps.
+// RateLimit-Reset is interpreted as delta-seconds per the Buildkite API spec.
+// Falls back to capped exponential backoff when the header is absent or invalid.
 // A random jitter of up to 1 second is added on all paths to spread out
 // concurrent clients that receive the same reset time.
 func retryDelay(resp *http.Response, attempt int) time.Duration {
-	for _, header := range []string{"RateLimit-Reset", "Retry-After"} {
-		if s := resp.Header.Get(header); s != "" {
-			if secs, err := strconv.Atoi(s); err == nil && secs >= 0 {
-				if secs > 120 {
-					secs = 120
-				}
-				// 500ms buffer ensures we don't hit the API again in the same window
-				// when the server sends RateLimit-Reset: 0.
-				return time.Duration(secs)*time.Second + 500*time.Millisecond + time.Duration(rand.N(time.Second))
+	if s := resp.Header.Get("RateLimit-Reset"); s != "" {
+		if secs, err := strconv.Atoi(s); err == nil && secs >= 0 {
+			if secs > 120 {
+				secs = 120
 			}
+			// 500ms buffer ensures we don't hit the API again in the same window
+			// when the server sends RateLimit-Reset: 0.
+			return time.Duration(secs)*time.Second + 500*time.Millisecond + time.Duration(rand.N(time.Second))
 		}
 	}
 	// Cap the shift to prevent int64 overflow at high attempt counts.
@@ -449,10 +447,14 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 	// roko requires a strategy, but the real delay is always driven by the
 	// server response (RateLimit-Reset header or exponential fallback), so
 	// Constant(0) is a required placeholder that is always overridden.
-	retrier := roko.NewRetrier(
-		roko.WithMaxAttempts(c.maxRetries+1),
+	retrierOpts := []roko.RetrierOpt{
+		roko.WithMaxAttempts(c.maxRetries + 1),
 		roko.WithStrategy(roko.Constant(0)),
-	)
+	}
+	if c.sleepFunc != nil {
+		retrierOpts = append(retrierOpts, roko.WithSleepFunc(c.sleepFunc))
+	}
+	retrier := roko.NewRetrier(retrierOpts...)
 
 	rokoErr := retrier.DoWithContext(req.Context(), func(rt *roko.Retrier) error {
 		// GetBody is set automatically by http.NewRequestWithContext for
@@ -498,24 +500,25 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 			return nil
 		}
 
-		delay := retryDelay(resp, rt.AttemptCount())
-		rt.SetNextInterval(delay)
-
+		// roko calls MarkAttempt() after this callback returns, so AttemptCount()
+		// here is still the 0-based index of the current attempt. The last allowed
+		// attempt is index c.maxRetries (= WithMaxAttempts(c.maxRetries+1) - 1).
+		var delay time.Duration
+		if rt.AttemptCount() < c.maxRetries {
+			delay = retryDelay(resp, rt.AttemptCount())
+			rt.SetNextInterval(delay)
+			// More retries remaining — drain and close so the connection can be reused.
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			resp = nil
+		}
+		// delay is 0 on the final attempt; the callback can use this to distinguish
+		// "rate limited and will retry" from "rate limited and giving up".
 		if c.rateLimitNotify != nil {
 			c.rateLimitNotify(rt.AttemptCount()+1, delay)
 		}
 		if c.httpDebug {
 			fmt.Printf("DEBUG rate limited, retry %d in %v\n", rt.AttemptCount()+1, delay)
-		}
-
-		// roko calls MarkAttempt() after this callback returns, so AttemptCount()
-		// here is still the 0-based index of the current attempt. The last allowed
-		// attempt is index c.maxRetries (= WithMaxAttempts(c.maxRetries+1) - 1).
-		if rt.AttemptCount() < c.maxRetries {
-			// More retries remaining — drain and close so the connection can be reused.
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-			resp = nil
 		}
 
 		return errRateLimited

--- a/buildkite.go
+++ b/buildkite.go
@@ -159,6 +159,10 @@ func WithRateLimitNotify(fn RateLimitNotify) ClientOpt {
 // WithMaxRetries sets the maximum number of retry attempts on rate-limited requests.
 // Defaults to DefaultMaxRetries (3). Use 0 to disable retries entirely.
 //
+// There is no internal wall-clock time limit. With a high retry count and a
+// server consistently returning RateLimit-Reset: 120, Do() can block for many
+// minutes. Callers should set a context deadline to bound total wait time.
+//
 // All HTTP methods are retried, including POST, PUT, and DELETE, provided the
 // request body is rewindable (i.e. created via NewRequest with a struct or
 // bytes.Buffer body). Callers that cannot tolerate duplicate side-effects on
@@ -481,6 +485,8 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		// When canRewind is false and the response is 429, returning nil causes
 		// roko to treat the call as successful and exit the loop; execution then
 		// falls through to checkResponse which surfaces a proper *ErrorResponse.
+		// The caller receives a 429 *ErrorResponse with no WithRateLimitNotify
+		// signal and no indication that the retry budget was unused.
 		canRewind := req.Body == nil || req.GetBody != nil
 		if resp.StatusCode != http.StatusTooManyRequests || !canRewind {
 			return nil

--- a/buildkite.go
+++ b/buildkite.go
@@ -158,6 +158,12 @@ func WithRateLimitNotify(fn RateLimitNotify) ClientOpt {
 
 // WithMaxRetries sets the maximum number of retry attempts on rate-limited requests.
 // Defaults to DefaultMaxRetries (3). Use 0 to disable retries entirely.
+//
+// All HTTP methods are retried, including POST, PUT, and DELETE, provided the
+// request body is rewindable (i.e. created via NewRequest with a struct or
+// bytes.Buffer body). Callers that cannot tolerate duplicate side-effects on
+// non-idempotent requests should pass a context with an appropriate deadline
+// or set WithMaxRetries(0) for those specific calls.
 func WithMaxRetries(n int) ClientOpt {
 	return func(c *Client) error {
 		if n < 0 {
@@ -459,6 +465,7 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		var err error
 		resp, err = c.client.Do(req)
 		if err != nil {
+			resp = nil
 			rt.Break()
 			return err
 		}
@@ -482,6 +489,13 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 		delay := retryDelay(resp, rt.AttemptCount())
 		rt.SetNextInterval(delay)
 
+		if c.rateLimitNotify != nil {
+			c.rateLimitNotify(rt.AttemptCount()+1, delay)
+		}
+		if c.httpDebug {
+			fmt.Printf("DEBUG rate limited, retry %d in %v\n", rt.AttemptCount()+1, delay)
+		}
+
 		// roko calls MarkAttempt() after this callback returns, so AttemptCount()
 		// here is still the 0-based index of the current attempt. The last allowed
 		// attempt is index c.maxRetries (= WithMaxAttempts(c.maxRetries+1) - 1).
@@ -490,23 +504,11 @@ func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 			resp = nil
-
-			if c.rateLimitNotify != nil {
-				c.rateLimitNotify(rt.AttemptCount()+1, delay)
-			}
-			if c.httpDebug {
-				fmt.Printf("DEBUG rate limited, retry %d in %v\n", rt.AttemptCount()+1, delay)
-			}
 		}
-		// On the final attempt resp is kept intact so checkResponse can produce
-		// a proper *ErrorResponse from the 429 body rather than returning errRateLimited.
 
 		return errRateLimited
 	})
 
-	// resp is nil only when a network error or body-rewind error caused an early
-	// exit via rt.Break(). For exhausted 429s, resp is kept so checkResponse below
-	// can return a proper *ErrorResponse.
 	if resp == nil {
 		return nil, rokoErr
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.2.0
 	github.com/google/uuid v1.6.0
@@ -14,5 +13,4 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
-	golang.org/x/net v0.38.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
+	github.com/buildkite/roko v1.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/go-querystring v1.2.0
 	github.com/google/uuid v1.6.0
@@ -11,7 +12,6 @@ require (
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
-	github.com/buildkite/roko v1.4.0 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 
 require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
+	github.com/buildkite/roko v1.4.0 // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/xhit/go-str2duration/v2 v2.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,3 +26,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
+gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjH
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
+github.com/buildkite/roko v1.4.0 h1:DxixoCdpNqxu4/1lXrXbfsKbJSd7r1qoxtef/TT2J80=
+github.com/buildkite/roko v1.4.0/go.mod h1:0vbODqUFEcVf4v2xVXRfZZRsqJVsCCHTG/TBRByGK4E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/alecthomas/kingpin/v2 v2.4.0 h1:f48lwail6p8zpO1bC4TxtqACaGqHYA22qkHjH
 github.com/alecthomas/kingpin/v2 v2.4.0/go.mod h1:0gyi0zQnjuFk8xrkNKamJoyUo382HRL7ATRpFZCw6tE=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAuRjVTiNNhvNRfY2Wxp9nhfyel4rklc=
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
-github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf h1:yxlp0s+Sge9UsKEK0Bsvjiopb9XRk+vxylmZ9eGBfm8=
-github.com/cenkalti/backoff v1.1.1-0.20171020064038-309aa717adbf/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -22,8 +20,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xhit/go-str2duration/v2 v2.1.0 h1:lxklc02Drh6ynqX+DdPyp5pCKLUQpRT8bp8Ydu2Bstc=
 github.com/xhit/go-str2duration/v2 v2.1.0/go.mod h1:ohY8p+0f07DiV6Em5LKB0s2YpLtXVyJfNt1+BlmyAsU=
-golang.org/x/net v0.38.0 h1:vRMAPTMaeGqVhG5QyLJHqNDwecKTomGeqbnfZyKlBI8=
-golang.org/x/net v0.38.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/retry_test.go
+++ b/retry_test.go
@@ -9,8 +9,9 @@ import (
 	"time"
 )
 
-// TestDo_POST_IsRetriedOn429 reproduces Bug #1: the GET-only guard in the
-// current Do() means POST requests that hit 429 fail immediately.
+// TestDo_POST_IsRetriedOn429 verifies that POST requests are retried on 429.
+// The old Do() only retried GET requests; this confirms all methods are retried.
+// Intentionally omits RateLimit-Reset to exercise the exponential fallback path.
 func TestDo_POST_IsRetriedOn429(t *testing.T) {
 	callCount := 0
 
@@ -20,7 +21,6 @@ func TestDo_POST_IsRetriedOn429(t *testing.T) {
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		if callCount == 1 {
-			w.Header().Set("RateLimit-Reset", "0")
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
@@ -48,6 +48,45 @@ func TestWithMaxRetries_Negative(t *testing.T) {
 
 	if err := WithMaxRetries(-1)(client); err == nil {
 		t.Error("expected error for negative maxRetries, got nil")
+	}
+}
+
+// TestWithRateLimitNotify_NilClears verifies that passing nil to WithRateLimitNotify
+// clears any previously registered callback and does not panic on a retried request.
+func TestWithRateLimitNotify_NilClears(t *testing.T) {
+	callCount := 0
+
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.Header().Set("RateLimit-Reset", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Register a callback, then clear it with nil.
+	if err := WithRateLimitNotify(func(_ int, _ time.Duration) {
+		t.Error("notify should not fire after being cleared with nil")
+	})(client); err != nil {
+		t.Fatalf("WithRateLimitNotify: %v", err)
+	}
+	if err := WithRateLimitNotify(nil)(client); err != nil {
+		t.Fatalf("WithRateLimitNotify(nil): %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	// Should retry and succeed without panicking.
+	if _, err = client.Do(req, nil); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -11,13 +11,23 @@ import (
 	"time"
 )
 
+// newRetryTestClient is like newMockServerAndClient but stubs the retry backoff
+// sleep to a no-op so retry tests run instantly. Use it for all retry tests
+// except TestDo_ContextCancelledDuringRetryWait, which needs a real sleep.
+func newRetryTestClient(t *testing.T) (*mockServer, *Client, func()) {
+	t.Helper()
+	ms, client, teardown := newMockServerAndClient(t)
+	client.sleepFunc = func(time.Duration) {}
+	return ms, client, teardown
+}
+
 // TestDo_POST_IsRetriedOn429 verifies that POST requests are retried on 429.
 // The old Do() only retried GET requests; this confirms all methods are retried.
 // Intentionally omits RateLimit-Reset to exercise the exponential fallback path.
 func TestDo_POST_IsRetriedOn429(t *testing.T) {
 	callCount := 0
 
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -58,7 +68,7 @@ func TestWithMaxRetries_Negative(t *testing.T) {
 func TestWithRateLimitNotify_NilClears(t *testing.T) {
 	callCount := 0
 
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +108,7 @@ func TestWithMaxRetries_Zero(t *testing.T) {
 	callCount := 0
 	var notifyAttempts []int
 
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -135,7 +145,7 @@ func TestWithMaxRetries_Zero(t *testing.T) {
 func TestWithMaxRetries_LimitsRetries(t *testing.T) {
 	callCount := 0
 
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -172,7 +182,7 @@ func TestDo_POST_BodyIntactOnRetry(t *testing.T) {
 	callCount := 0
 	var receivedBodies []string
 
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -212,7 +222,7 @@ func TestDo_POST_BodyIntactOnRetry(t *testing.T) {
 // TestDo_GetBodyError verifies that if GetBody returns an error on a retry attempt,
 // the client stops immediately and surfaces that error rather than panicking or retrying.
 func TestDo_GetBodyError(t *testing.T) {
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -282,7 +292,7 @@ func TestDo_ContextCancelledDuringRetryWait(t *testing.T) {
 // TestDo_ExhaustedRetries_ReturnsFinal429AsErrorResponse verifies the final 429
 // flows through as a proper *ErrorResponse, not a generic string error.
 func TestDo_ExhaustedRetries_ReturnsFinal429AsErrorResponse(t *testing.T) {
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -322,7 +332,7 @@ func TestDo_ExhaustedRetries_ReturnsFinal429AsErrorResponse(t *testing.T) {
 func TestWithRateLimitNotify_AttemptNumbers(t *testing.T) {
 	callCount := 0
 
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -364,7 +374,7 @@ func TestWithRateLimitNotify_AttemptNumbers(t *testing.T) {
 // TestWithRateLimitNotify_FiresOnExhaustedAttempt verifies the callback fires on
 // the final exhausted 429, not just on attempts that result in a retry sleep.
 func TestWithRateLimitNotify_FiresOnExhaustedAttempt(t *testing.T) {
-	ms, client, teardown := newMockServerAndClient(t)
+	ms, client, teardown := newRetryTestClient(t)
 	defer teardown()
 
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -439,18 +449,11 @@ func TestRetryDelay(t *testing.T) {
 			wantMax: 2 * time.Second,
 		},
 		{
-			name:    "Retry-After used when RateLimit-Reset absent",
+			name:    "Retry-After alone falls back to exponential (not a Buildkite header)",
 			headers: map[string]string{"Retry-After": "0"},
 			attempt: 0,
-			wantMin: 500 * time.Millisecond,
-			wantMax: 1500 * time.Millisecond,
-		},
-		{
-			name:    "RateLimit-Reset takes precedence over Retry-After",
-			headers: map[string]string{"RateLimit-Reset": "0", "Retry-After": "60"},
-			attempt: 0,
-			wantMin: 500 * time.Millisecond,
-			wantMax: 1500 * time.Millisecond,
+			wantMin: 1 * time.Second,
+			wantMax: 2 * time.Second,
 		},
 		{
 			name:    "exponential backoff at attempt 0 (no header)",

--- a/retry_test.go
+++ b/retry_test.go
@@ -351,6 +351,46 @@ func TestWithRateLimitNotify_AttemptNumbers(t *testing.T) {
 	}
 }
 
+// TestWithRateLimitNotify_FiresOnExhaustedAttempt verifies the callback fires on
+// the final exhausted 429, not just on attempts that result in a retry sleep.
+func TestWithRateLimitNotify_FiresOnExhaustedAttempt(t *testing.T) {
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("RateLimit-Reset", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	if err := WithMaxRetries(2)(client); err != nil {
+		t.Fatalf("WithMaxRetries(2): %v", err)
+	}
+
+	var notifyAttempts []int
+	if err := WithRateLimitNotify(func(attempt int, _ time.Duration) {
+		notifyAttempts = append(notifyAttempts, attempt)
+	})(client); err != nil {
+		t.Fatalf("WithRateLimitNotify: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	_, _ = client.Do(req, nil)
+
+	// 1 initial + 2 retries = 3 total 429s; notify must fire for all 3.
+	if len(notifyAttempts) != 3 {
+		t.Errorf("expected notify called 3 times (including exhausted attempt), got %d", len(notifyAttempts))
+	}
+	for i, attempt := range notifyAttempts {
+		if want := i + 1; attempt != want {
+			t.Errorf("notifyAttempts[%d] = %d, want %d", i, attempt, want)
+		}
+	}
+}
+
 // TestRetryDelay covers all branches of the retryDelay helper.
 func TestRetryDelay(t *testing.T) {
 	tests := []struct {

--- a/retry_test.go
+++ b/retry_test.go
@@ -92,9 +92,11 @@ func TestWithRateLimitNotify_NilClears(t *testing.T) {
 	}
 }
 
-// TestWithMaxRetries_Zero verifies that WithMaxRetries(0) disables retries entirely.
+// TestWithMaxRetries_Zero verifies that WithMaxRetries(0) disables retries entirely
+// and that the notify callback still fires once (attempt=1) even though no retry follows.
 func TestWithMaxRetries_Zero(t *testing.T) {
 	callCount := 0
+	var notifyAttempts []int
 
 	ms, client, teardown := newMockServerAndClient(t)
 	defer teardown()
@@ -108,6 +110,11 @@ func TestWithMaxRetries_Zero(t *testing.T) {
 	if err := WithMaxRetries(0)(client); err != nil {
 		t.Fatalf("WithMaxRetries(0): %v", err)
 	}
+	if err := WithRateLimitNotify(func(attempt int, _ time.Duration) {
+		notifyAttempts = append(notifyAttempts, attempt)
+	})(client); err != nil {
+		t.Fatalf("WithRateLimitNotify: %v", err)
+	}
 
 	req, err := client.NewRequest(context.Background(), http.MethodGet, "/test", nil)
 	if err != nil {
@@ -117,7 +124,10 @@ func TestWithMaxRetries_Zero(t *testing.T) {
 	_, _ = client.Do(req, nil)
 
 	if callCount != 1 {
-		t.Errorf("expected exactly 1 call (no retries when maxRetries=0), got %d", callCount)
+		t.Errorf("expected exactly 1 HTTP call (no retries when maxRetries=0), got %d", callCount)
+	}
+	if len(notifyAttempts) != 1 || notifyAttempts[0] != 1 {
+		t.Errorf("expected notify called once with attempt=1, got %v", notifyAttempts)
 	}
 }
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,0 +1,353 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// TestDo_POST_IsRetriedOn429 reproduces Bug #1: the GET-only guard in the
+// current Do() means POST requests that hit 429 fail immediately.
+func TestDo_POST_IsRetriedOn429(t *testing.T) {
+	callCount := 0
+
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req, err := client.NewRequest(context.Background(), http.MethodPost, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	_, err = client.Do(req, nil)
+	if err != nil {
+		t.Errorf("expected POST to be retried after 429, got error: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 server calls (initial + 1 retry), got %d", callCount)
+	}
+}
+
+// TestWithMaxRetries_Zero verifies that WithMaxRetries(0) disables retries entirely.
+func TestWithMaxRetries_Zero(t *testing.T) {
+	callCount := 0
+
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("RateLimit-Reset", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	if err := WithMaxRetries(0)(client); err != nil {
+		t.Fatalf("WithMaxRetries(0): %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	_, _ = client.Do(req, nil)
+
+	if callCount != 1 {
+		t.Errorf("expected exactly 1 call (no retries when maxRetries=0), got %d", callCount)
+	}
+}
+
+// TestWithMaxRetries_LimitsRetries verifies the client stops retrying after the configured limit.
+func TestWithMaxRetries_LimitsRetries(t *testing.T) {
+	callCount := 0
+
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("RateLimit-Reset", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	if err := WithMaxRetries(2)(client); err != nil {
+		t.Fatalf("WithMaxRetries(2): %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	_, err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries, got nil")
+	}
+	// 1 initial + 2 retries = 3 total
+	if callCount != 3 {
+		t.Errorf("expected 3 server calls (1 initial + 2 retries), got %d", callCount)
+	}
+}
+
+// TestDo_POST_BodyIntactOnRetry verifies the request body is fully replayed on each retry.
+func TestDo_POST_BodyIntactOnRetry(t *testing.T) {
+	type payload struct {
+		Name string `json:"name"`
+	}
+
+	callCount := 0
+	var receivedBodies []string
+
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		body, _ := io.ReadAll(r.Body)
+		receivedBodies = append(receivedBodies, string(body))
+		if callCount == 1 {
+			w.Header().Set("RateLimit-Reset", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req, err := client.NewRequest(context.Background(), http.MethodPost, "/test", payload{Name: "my-pipeline"})
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	_, err = client.Do(req, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 2 {
+		t.Fatalf("expected 2 server calls, got %d", callCount)
+	}
+	for i, body := range receivedBodies {
+		if body == "" {
+			t.Errorf("call %d received empty body — request body was not replayed on retry", i+1)
+		}
+		if receivedBodies[0] != body {
+			t.Errorf("call %d body %q differs from call 1 body %q", i+1, body, receivedBodies[0])
+		}
+	}
+}
+
+// TestDo_ContextCancelledDuringRetryWait verifies a cancelled context interrupts
+// the retry sleep promptly.
+func TestDo_ContextCancelledDuringRetryWait(t *testing.T) {
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("RateLimit-Reset", "60")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	req, err := client.NewRequest(ctx, http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	start := time.Now()
+	_, err = client.Do(req, nil)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected error after context cancellation, got nil")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("expected prompt return on context cancel, took %v", elapsed)
+	}
+}
+
+// TestDo_ExhaustedRetries_ReturnsFinal429AsErrorResponse verifies the final 429
+// flows through as a proper *ErrorResponse, not a generic string error.
+func TestDo_ExhaustedRetries_ReturnsFinal429AsErrorResponse(t *testing.T) {
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("RateLimit-Reset", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = fmt.Fprint(w, `{"message":"rate limit exceeded"}`)
+	})
+
+	if err := WithMaxRetries(1)(client); err != nil {
+		t.Fatalf("WithMaxRetries(1): %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	resp, err := client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error after retry exhaustion, got nil")
+	}
+	errResp, ok := err.(*ErrorResponse)
+	if !ok {
+		t.Fatalf("expected *ErrorResponse, got %T: %v", err, err)
+	}
+	if errResp.Response.StatusCode != http.StatusTooManyRequests {
+		t.Errorf("expected 429 status in ErrorResponse, got %d", errResp.Response.StatusCode)
+	}
+	if resp == nil {
+		t.Error("expected non-nil Response returned alongside error")
+	}
+}
+
+// TestWithRateLimitNotify_AttemptNumbers verifies the callback fires on each retry
+// with 1-based sequential attempt numbers.
+func TestWithRateLimitNotify_AttemptNumbers(t *testing.T) {
+	callCount := 0
+
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount < 3 {
+			w.Header().Set("RateLimit-Reset", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	var notifyAttempts []int
+	if err := WithRateLimitNotify(func(attempt int, _ time.Duration) {
+		notifyAttempts = append(notifyAttempts, attempt)
+	})(client); err != nil {
+		t.Fatalf("WithRateLimitNotify: %v", err)
+	}
+
+	req, err := client.NewRequest(context.Background(), http.MethodGet, "/test", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	_, err = client.Do(req, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(notifyAttempts) != 2 {
+		t.Errorf("expected notify called twice (2 retries), got %d times", len(notifyAttempts))
+	}
+	for i, attempt := range notifyAttempts {
+		if want := i + 1; attempt != want {
+			t.Errorf("notifyAttempts[%d] = %d, want %d", i, attempt, want)
+		}
+	}
+}
+
+// TestRetryDelay covers all branches of the retryDelay helper.
+func TestRetryDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		headers map[string]string
+		attempt int
+		wantMin time.Duration
+		wantMax time.Duration
+	}{
+		{
+			name:    "RateLimit-Reset:0 gives 500ms buffer + jitter",
+			headers: map[string]string{"RateLimit-Reset": "0"},
+			attempt: 0,
+			wantMin: 500 * time.Millisecond,
+			wantMax: 1500 * time.Millisecond,
+		},
+		{
+			name:    "RateLimit-Reset:5 gives 5.5s + jitter",
+			headers: map[string]string{"RateLimit-Reset": "5"},
+			attempt: 0,
+			wantMin: 5500 * time.Millisecond,
+			wantMax: 6500 * time.Millisecond,
+		},
+		{
+			name:    "RateLimit-Reset > 120 is clamped to 120s",
+			headers: map[string]string{"RateLimit-Reset": "999"},
+			attempt: 0,
+			wantMin: 120*time.Second + 500*time.Millisecond,
+			wantMax: 120*time.Second + 1500*time.Millisecond,
+		},
+		{
+			name:    "negative RateLimit-Reset falls back to exponential",
+			headers: map[string]string{"RateLimit-Reset": "-1"},
+			attempt: 0,
+			wantMin: 1 * time.Second,
+			wantMax: 2 * time.Second,
+		},
+		{
+			name:    "Retry-After used when RateLimit-Reset absent",
+			headers: map[string]string{"Retry-After": "0"},
+			attempt: 0,
+			wantMin: 500 * time.Millisecond,
+			wantMax: 1500 * time.Millisecond,
+		},
+		{
+			name:    "RateLimit-Reset takes precedence over Retry-After",
+			headers: map[string]string{"RateLimit-Reset": "0", "Retry-After": "60"},
+			attempt: 0,
+			wantMin: 500 * time.Millisecond,
+			wantMax: 1500 * time.Millisecond,
+		},
+		{
+			name:    "exponential backoff at attempt 0 (no header)",
+			headers: map[string]string{},
+			attempt: 0,
+			wantMin: 1 * time.Second,
+			wantMax: 2 * time.Second,
+		},
+		{
+			name:    "exponential backoff capped at 30s (attempt 10)",
+			headers: map[string]string{},
+			attempt: 10,
+			wantMin: 30 * time.Second,
+			wantMax: 31 * time.Second,
+		},
+		{
+			name:    "no overflow at high attempt count (attempt 100)",
+			headers: map[string]string{},
+			attempt: 100,
+			wantMin: 30 * time.Second,
+			wantMax: 31 * time.Second,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := &http.Response{Header: make(http.Header)}
+			for k, v := range tt.headers {
+				resp.Header.Set(k, v)
+			}
+			got := retryDelay(resp, tt.attempt)
+			if got < tt.wantMin || got >= tt.wantMax {
+				t.Errorf("retryDelay() = %v, want in [%v, %v)", got, tt.wantMin, tt.wantMax)
+			}
+		})
+	}
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -2,9 +2,11 @@ package buildkite
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -194,6 +196,41 @@ func TestDo_POST_BodyIntactOnRetry(t *testing.T) {
 		if receivedBodies[0] != body {
 			t.Errorf("call %d body %q differs from call 1 body %q", i+1, body, receivedBodies[0])
 		}
+	}
+}
+
+// TestDo_GetBodyError verifies that if GetBody returns an error on a retry attempt,
+// the client stops immediately and surfaces that error rather than panicking or retrying.
+func TestDo_GetBodyError(t *testing.T) {
+	ms, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("RateLimit-Reset", "0")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	req, err := client.NewRequest(context.Background(), http.MethodPost, "/test", strings.NewReader("body"))
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+
+	// Override GetBody to fail on the second call (i.e. the first retry).
+	calls := 0
+	req.GetBody = func() (io.ReadCloser, error) {
+		calls++
+		if calls > 1 {
+			return nil, errors.New("simulated GetBody failure")
+		}
+		return io.NopCloser(strings.NewReader("body")), nil
+	}
+
+	_, err = client.Do(req, nil)
+	if err == nil {
+		t.Fatal("expected error from GetBody failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "rewinding request body for retry") {
+		t.Errorf("expected rewind error, got: %v", err)
 	}
 }
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -20,6 +20,7 @@ func TestDo_POST_IsRetriedOn429(t *testing.T) {
 	ms.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
 		callCount++
 		if callCount == 1 {
+			w.Header().Set("RateLimit-Reset", "0")
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}
@@ -37,6 +38,16 @@ func TestDo_POST_IsRetriedOn429(t *testing.T) {
 	}
 	if callCount != 2 {
 		t.Errorf("expected 2 server calls (initial + 1 retry), got %d", callCount)
+	}
+}
+
+// TestWithMaxRetries_Negative verifies that WithMaxRetries rejects negative values.
+func TestWithMaxRetries_Negative(t *testing.T) {
+	_, client, teardown := newMockServerAndClient(t)
+	defer teardown()
+
+	if err := WithMaxRetries(-1)(client); err == nil {
+		t.Error("expected error for negative maxRetries, got nil")
 	}
 }
 


### PR DESCRIPTION
  - Retry all HTTP methods on 429 (not just GET)
  - Read RateLimit-Reset header for wait duration, fall back to Retry-After, then exponential backoff
  - Add WithRateLimitNotify callback so consumers can observe retries
  - Add WithMaxRetries to make retry limit configurable (default 3)
  - Replace cenkalti/backoff with github.com/buildkite/roko for retry loop management