### PR TITLE
SUP-6268: Add Find test capability to TestsService

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -23,6 +23,11 @@ type Test struct {
 	FileName string `json:"file_name,omitempty"`
 }
 
+type FindTest struct {
+	Scope string `json:"scope"`
+	Name  string `json:"name"`
+}
+
 func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (Test, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/%s", org, slug, testID)
 	req, err := ts.client.NewRequest(ctx, "GET", u, nil)
@@ -36,5 +41,19 @@ func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (Test
 		return Test{}, resp, err
 	}
 
+	return t, resp, err
+}
+
+func (ts *TestsService) Find(ctx context.Context, org, slug string, find FindTest) (Test, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/find", org, slug)
+	req, err := ts.client.NewRequest(ctx, "POST", u, find)
+	if err != nil {
+		return Test{}, nil, err
+	}
+	var t Test
+	resp, err := ts.client.Do(req, &t)
+	if err != nil {
+		return Test{}, resp, err
+	}
 	return t, resp, err
 }

--- a/tests.go
+++ b/tests.go
@@ -23,7 +23,7 @@ type Test struct {
 	FileName string `json:"file_name,omitempty"`
 }
 
-type FindTest struct {
+type FindTestOptions struct {
 	Scope string `json:"scope"`
 	Name  string `json:"name"`
 }
@@ -44,7 +44,7 @@ func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (Test
 	return t, resp, err
 }
 
-func (ts *TestsService) Find(ctx context.Context, org, slug string, find FindTest) (Test, *Response, error) {
+func (ts *TestsService) Find(ctx context.Context, org, slug string, find FindTestOptions) (Test, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/find", org, slug)
 	req, err := ts.client.NewRequest(ctx, "POST", u, find)
 	if err != nil {

--- a/tests_test.go
+++ b/tests_test.go
@@ -2,6 +2,7 @@ package buildkite
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"testing"
@@ -47,5 +48,55 @@ func TestTestsService_Get(t *testing.T) {
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("TestsService.Get diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestTestsService_Find(t *testing.T) {
+	t.Parallel()
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/find", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+
+		var body FindTest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("TestsService.Find failed to decode request body: %v", err)
+		}
+		want := FindTest{Scope: "User#email", Name: "TestExample1_Create"}
+		if diff := cmp.Diff(body, want); diff != "" {
+			t.Errorf("TestsService.Find request body diff: (-got +want)\n%s", diff)
+		}
+
+		_, _ = fmt.Fprint(w,
+			`
+			{
+				"id": "b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+				"url": "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+				"web_url": "https://buildkite.com/organizations/my-great-org/analytics/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+				"name": "TestExample1_Create",
+				"scope": "User#email",
+				"location": "./resources/test_example_test.go:123",
+				"file_name": "./resources/test_example_test.go"
+			}`)
+	})
+
+	got, _, err := client.Tests.Find(context.Background(), "my-great-org", "suite-example",
+		FindTest{Scope: "User#email", Name: "TestExample1_Create"})
+	if err != nil {
+		t.Errorf("TestsService.Find returned error: %v", err)
+	}
+
+	want := Test{
+		ID:       "b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+		URL:      "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+		WebURL:   "https://buildkite.com/organizations/my-great-org/analytics/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+		Name:     "TestExample1_Create",
+		Scope:    "User#email",
+		Location: "./resources/test_example_test.go:123",
+		FileName: "./resources/test_example_test.go",
+	}
+
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("TestsService.Find diff: (-got +want)\n%s", diff)
 	}
 }

--- a/tests_test.go
+++ b/tests_test.go
@@ -58,11 +58,11 @@ func TestTestsService_Find(t *testing.T) {
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/find", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "POST")
 
-		var body FindTest
+		var body FindTestOptions
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Errorf("TestsService.Find failed to decode request body: %v", err)
 		}
-		want := FindTest{Scope: "User#email", Name: "TestExample1_Create"}
+		want := FindTestOptions{Scope: "User#email", Name: "TestExample1_Create"}
 		if diff := cmp.Diff(body, want); diff != "" {
 			t.Errorf("TestsService.Find request body diff: (-got +want)\n%s", diff)
 		}
@@ -81,7 +81,7 @@ func TestTestsService_Find(t *testing.T) {
 	})
 
 	got, _, err := client.Tests.Find(context.Background(), "my-great-org", "suite-example",
-		FindTest{Scope: "User#email", Name: "TestExample1_Create"})
+		FindTestOptions{Scope: "User#email", Name: "TestExample1_Create"})
 	if err != nil {
 		t.Errorf("TestsService.Find returned error: %v", err)
 	}


### PR DESCRIPTION
As per https://linear.app/buildkite/issue/SUP-6268/add-list-and-find-to-testsservice , this PR is to add the capability to utilise the Find a Test REST API as per our docs: https://buildkite.com/docs/apis/rest-api/test-engine/tests#find-a-test-with-scope-and-name

Test case has been added and ran successfully.