### PR TITLE
SUP-6269: Add Copy capability to PackagesService

### DIFF
--- a/packages.go
+++ b/packages.go
@@ -42,10 +42,6 @@ func (ps *PackagesService) Get(ctx context.Context, organizationSlug, registrySl
 	return p, resp, err
 }
 
-// Copy copies a package from a source registry to a destination registry within
-// the same organization. Only some package ecosystems support copying.
-//
-// Buildkite API docs: https://buildkite.com/docs/apis/rest-api/package-registries/packages#copy-a-package
 func (ps *PackagesService) Copy(ctx context.Context, organizationSlug, sourceRegistrySlug, packageID, destinationRegistrySlug string) (Package, *Response, error) {
 	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages/%s/copy", organizationSlug, sourceRegistrySlug, packageID)
 	u += "?" + url.Values{"to": {destinationRegistrySlug}}.Encode()

--- a/packages.go
+++ b/packages.go
@@ -3,7 +3,6 @@ package buildkite
 import (
 	"context"
 	"fmt"
-	"net/url"
 )
 
 const fileFormKey = "file"
@@ -43,9 +42,7 @@ func (ps *PackagesService) Get(ctx context.Context, organizationSlug, registrySl
 }
 
 func (ps *PackagesService) Copy(ctx context.Context, organizationSlug, sourceRegistrySlug, packageID, destinationRegistrySlug string) (Package, *Response, error) {
-	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages/%s/copy", organizationSlug, sourceRegistrySlug, packageID)
-	u += "?" + url.Values{"to": {destinationRegistrySlug}}.Encode()
-
+	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages/%s/copy?to=%s", organizationSlug, sourceRegistrySlug, packageID, destinationRegistrySlug)
 	req, err := ps.client.NewRequest(ctx, "POST", u, nil)
 	if err != nil {
 		return Package{}, nil, fmt.Errorf("creating POST copy package request: %w", err)

--- a/packages.go
+++ b/packages.go
@@ -3,6 +3,7 @@ package buildkite
 import (
 	"context"
 	"fmt"
+	"net/url"
 )
 
 const fileFormKey = "file"
@@ -36,6 +37,28 @@ func (ps *PackagesService) Get(ctx context.Context, organizationSlug, registrySl
 	resp, err := ps.client.Do(req, &p)
 	if err != nil {
 		return Package{}, resp, fmt.Errorf("executing GET package request: %w", err)
+	}
+
+	return p, resp, err
+}
+
+// Copy copies a package from a source registry to a destination registry within
+// the same organization. Only some package ecosystems support copying.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/rest-api/package-registries/packages#copy-a-package
+func (ps *PackagesService) Copy(ctx context.Context, organizationSlug, sourceRegistrySlug, packageID, destinationRegistrySlug string) (Package, *Response, error) {
+	u := fmt.Sprintf("v2/packages/organizations/%s/registries/%s/packages/%s/copy", organizationSlug, sourceRegistrySlug, packageID)
+	u += "?" + url.Values{"to": {destinationRegistrySlug}}.Encode()
+
+	req, err := ps.client.NewRequest(ctx, "POST", u, nil)
+	if err != nil {
+		return Package{}, nil, fmt.Errorf("creating POST copy package request: %w", err)
+	}
+
+	var p Package
+	resp, err := ps.client.Do(req, &p)
+	if err != nil {
+		return Package{}, resp, fmt.Errorf("executing POST copy package request: %w", err)
 	}
 
 	return p, resp, err

--- a/packages_test.go
+++ b/packages_test.go
@@ -49,3 +49,31 @@ func TestGetPackage(t *testing.T) {
 		t.Fatalf("client.PackagesService.Get(context.Background(),%q, %q, %q) diff: (-got +want)\n%s", "test-org", "my-cool-registry", pkg.ID, diff)
 	}
 }
+
+func TestCopyPackage(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	want := pkg
+	endpoint := fmt.Sprintf("/v2/packages/organizations/my-org/registries/source-registry/packages/%s/copy", pkg.ID)
+	server.HandleFunc(endpoint, func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "POST")
+		testFormValues(t, r, values{"to": "dest-registry"})
+
+		err := json.NewEncoder(w).Encode(pkg)
+		if err != nil {
+			t.Fatalf("marshalling package to json: %v", err)
+		}
+	})
+
+	p, _, err := client.PackagesService.Copy(context.Background(), "my-org", "source-registry", pkg.ID, "dest-registry")
+	if err != nil {
+		t.Fatalf("Packages.Copy returned error: %v", err)
+	}
+
+	if diff := cmp.Diff(p, want); diff != "" {
+		t.Fatalf("client.PackagesService.Copy(context.Background(), %q, %q, %q, %q) diff: (-got +want)\n%s", "my-org", "source-registry", pkg.ID, "dest-registry", diff)
+	}
+}


### PR DESCRIPTION
As per https://linear.app/buildkite/issue/SUP-6269/add-copy-to-packagesservice , creating this PR to add Copy capability so that consumers can use Buildkite Go SDK to perform this REST API: https://buildkite.com/docs/apis/rest-api/package-registries/packages#copy-a-package