### PR TITLE
PB-1933 Add promised exit status fields to Job

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -55,6 +55,14 @@ type Job struct {
 	TriggeredBuild     *TriggeredBuild `json:"triggered_build,omitempty"`
 	Priority           *JobPriority    `json:"priority"`
 	Step               *StepInfo       `json:"step,omitempty"`
+
+	// PromisedExitStatus is the exit status a running job has declared it will
+	// finish with, as part of an early failure declaration. Nil until the job
+	// promises a final exit status.
+	PromisedExitStatus *int `json:"promised_exit_status,omitempty"`
+	// PromisedExitStatusAt is the time the job declared its PromisedExitStatus.
+	// Nil until the job promises a final exit status.
+	PromisedExitStatusAt *Timestamp `json:"promised_exit_status_at,omitempty"`
 }
 
 // JobRetrySource represents what triggered this retry.

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -201,3 +201,38 @@ func TestJobsService_Delete(t *testing.T) {
 		t.Errorf("Jobs.DeleteJobLog returned error: %v", err)
 	}
 }
+
+func TestJob_PromisedExitStatusJSON(t *testing.T) {
+	t.Parallel()
+
+	const payload = `{
+  "id": "awesome-job-id",
+  "state": "running",
+  "promised_exit_status": 1,
+  "promised_exit_status_at": "2026-06-03T04:15:41.618Z"
+}`
+
+	var job Job
+	if err := json.Unmarshal([]byte(payload), &job); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+
+	if job.PromisedExitStatus == nil || *job.PromisedExitStatus != 1 {
+		t.Errorf("PromisedExitStatus = %v, want 1", job.PromisedExitStatus)
+	}
+	if job.PromisedExitStatusAt == nil {
+		t.Fatal("PromisedExitStatusAt = nil, want a timestamp")
+	}
+	if got := job.PromisedExitStatusAt.UTC().Format("2006-01-02T15:04:05Z"); got != "2026-06-03T04:15:41Z" {
+		t.Errorf("PromisedExitStatusAt = %s, want 2026-06-03T04:15:41Z", got)
+	}
+
+	// Absent fields must stay nil (omitempty round-trip).
+	var empty Job
+	if err := json.Unmarshal([]byte(`{"id":"x","state":"passed"}`), &empty); err != nil {
+		t.Fatalf("Unmarshal returned error: %v", err)
+	}
+	if empty.PromisedExitStatus != nil || empty.PromisedExitStatusAt != nil {
+		t.Errorf("expected nil promised fields, got %v / %v", empty.PromisedExitStatus, empty.PromisedExitStatusAt)
+	}
+}


### PR DESCRIPTION
### Description

Adds two fields to the `Job` struct so API consumers can read a running job's early failure declaration:

- `PromisedExitStatus *int` → `promised_exit_status`
- `PromisedExitStatusAt *Timestamp` → `promised_exit_status_at`

Both are `nil` until the job promises a final exit status. The Buildkite REST job payload already serialises these fields (via `API::JobPresenter`, emitted only when a promised status is present), so this is a purely additive struct change to expose data the API already returns.

Context: this is the first dependency for teaching `bk preflight` to surface early ("promised") job failures while a build is still running, ahead of the build cascading to failing.

### Changes

- `jobs.go`: add `PromisedExitStatus` and `PromisedExitStatusAt` to `Job`.
- `jobs_test.go`: add a decode test asserting the JSON tags populate the fields,
  and that absent fields stay `nil`.

### Testing

- `go test ./...` passes.
- `go fmt ./...` clean.

### Disclosures / Credits

Implemented with the assistance of Amp (AI). I reviewed and verified the change and tests locally.