### PR TITLE
chore(config): delete codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @buildkite/technical-services


### PR DESCRIPTION
## Description

We don't need a codeowners file; we have branch protection in place.
