### PR TITLE
PB-1933 Add `JobsService.ListByBuild` for the jobs index endpoint

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -245,3 +245,40 @@ func (js *JobsService) DeleteJobLog(ctx context.Context, org, pipeline, buildNum
 
 	return js.client.Do(req, nil)
 }
+
+// JobsListOptions specifies optional parameters for listing the jobs of a build.
+type JobsListOptions struct {
+	// State filters jobs by state, e.g. "failed", "running", "passed". A job is
+	// returned if it matches any of the supplied states. Default is "".
+	State []string `url:"state,brackets,omitempty"`
+
+	// IncludeRetriedJobs includes retried (superseded) jobs in the results.
+	IncludeRetriedJobs bool `url:"include_retried_jobs,omitempty"`
+
+	ListOptions
+}
+
+// ListByBuild lists the jobs of a build.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs
+func (js *JobsService) ListByBuild(ctx context.Context, org, pipeline, buildNumber string, opt *JobsListOptions) ([]Job, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs", org, pipeline, buildNumber)
+
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := js.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var jobs []Job
+	resp, err := js.client.Do(req, &jobs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return jobs, resp, err
+}

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -236,3 +236,35 @@ func TestJob_PromisedExitStatusJSON(t *testing.T) {
 		t.Errorf("expected nil promised fields, got %v / %v", empty.PromisedExitStatus, empty.PromisedExitStatusAt)
 	}
 }
+
+func TestJobsService_ListByBuild(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/jobs", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValuesList(t, r, valuesList{
+			{"state[]", "failed"},
+		})
+		_, _ = fmt.Fprint(w, `[
+  {"id": "job-1", "type": "script", "state": "failed"},
+  {"id": "job-2", "type": "script", "state": "running", "promised_exit_status": 1}
+]`)
+	})
+
+	jobs, _, err := client.Jobs.ListByBuild(context.Background(), "my-great-org", "sup-keith", "123", &JobsListOptions{
+		State: []string{"failed"},
+	})
+	if err != nil {
+		t.Fatalf("Jobs.ListByBuild returned error: %v", err)
+	}
+
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(jobs))
+	}
+	if jobs[1].PromisedExitStatus == nil || *jobs[1].PromisedExitStatus != 1 {
+		t.Errorf("expected job-2 PromisedExitStatus 1, got %v", jobs[1].PromisedExitStatus)
+	}
+}


### PR DESCRIPTION
### Description

Adds a client method for the REST jobs index endpoint:

`GET /v2/organizations/:org/pipelines/:pipeline/builds/:build/jobs`

This lets API consumers fetch a build's jobs with server-side `state` filtering, rather than pulling the whole build and filtering client-side.


### Changes

- `jobs.go`: add `JobsService.ListByBuild(ctx, org, pipeline, buildNumber, opt)`
  and a `JobsListOptions` struct supporting:
  - `State []string` (e.g. `state=failed`; matches any supplied state)
  - `IncludeRetriedJobs bool`
  - embedded `ListOptions` (page / per_page)
- `jobs_test.go`: mock-server test asserting the `state[]=failed` query param is
  sent and that the response (including `promised_exit_status`) decodes onto
  `Job`.

Purely additive. no changes to existing methods or structs.

### Testing

- `go test ./...` passes.
- `go fmt ./...` clean.
