### PR TITLE
feat: add missing documented fields to Agent struct

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -26,7 +26,14 @@ type Agent struct {
 	IPAddress         string     `json:"ip_address,omitempty"`
 	UserAgent         string     `json:"user_agent,omitempty"`
 	Version           string     `json:"version,omitempty"`
+	OSID              string     `json:"os_id,omitempty"`
+	Arch              string     `json:"arch,omitempty"`
+	Queue             string     `json:"queue,omitempty"`
 	CreatedAt         *Timestamp `json:"created_at,omitempty"`
+	ConnectedAt       *Timestamp `json:"connected_at,omitempty"`
+	DisconnectedAt    *Timestamp `json:"disconnected_at,omitempty"`
+	LostAt            *Timestamp `json:"lost_at,omitempty"`
+	StoppedAt         *Timestamp `json:"stopped_at,omitempty"`
 	LastJobFinishedAt *Timestamp `json:"last_job_finished_at,omitempty"`
 	Priority          *int       `json:"priority,omitempty"`
 	Metadata          []string   `json:"meta_data,omitempty"`


### PR DESCRIPTION
Add os_id, arch, queue, connected_at, disconnected_at, and lost_at, stopped_at fields to match the current Buildkite agents REST API docs (https://buildkite.com/docs/apis/rest-api/agents), which were previously missing from the Go struct.
