### PR TITLE
chore: uplift golangci-lint to 2.12.2 and clear findings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,54 @@
+version: "2"
+linters:
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - gosec
+    - gocritic
+    - testifylint
+  settings:
+    gosec:
+      excludes:
+        - G117
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+    gofmt:
+      rewrite-rules:
+        - pattern: "interface{}"
+          replacement: "any"
+        - pattern: "a[b:len(a)]"
+          replacement: "a[b:]"
+    testifylint:
+      disable-all: true
+      enable:
+        - require-error
+        - useless-assert
+        - len
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,12 @@ linters:
     gosec:
       excludes:
         - G117
+    testifylint:
+      disable-all: true
+      enable:
+        - require-error
+        - useless-assert
+        - len
   exclusions:
     generated: lax
     presets:
@@ -39,16 +45,9 @@ formatters:
           replacement: "any"
         - pattern: "a[b:len(a)]"
           replacement: "a[b:]"
-    testifylint:
-      disable-all: true
-      enable:
-        - require-error
-        - useless-assert
-        - len
   exclusions:
     generated: lax
     paths:
       - third_party$
       - builtin$
       - examples$
-

--- a/buildkite.go
+++ b/buildkite.go
@@ -293,7 +293,7 @@ func (c *Client) resolveURL(relPath string) (*url.URL, error) {
 // Relative URLs should always be specified without a preceding slash.  If
 // specified, the value pointed to by body is JSON encoded and included as the
 // request body.
-func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body interface{}) (*http.Request, error) {
+func (c *Client) NewRequest(ctx context.Context, method, urlStr string, body any) (*http.Request, error) {
 	u, err := c.resolveURL(urlStr)
 	if err != nil {
 		return nil, err
@@ -423,6 +423,7 @@ func retryDelay(resp *http.Response, attempt int) time.Duration {
 			}
 			// 500ms buffer ensures we don't hit the API again in the same window
 			// when the server sends RateLimit-Reset: 0.
+			//nolint:gosec // G404: jitter for retry backoff, not cryptographic
 			return time.Duration(secs)*time.Second + 500*time.Millisecond + time.Duration(rand.N(time.Second))
 		}
 	}
@@ -435,6 +436,7 @@ func retryDelay(resp *http.Response, attempt int) time.Duration {
 	if d > 30*time.Second {
 		d = 30 * time.Second
 	}
+	//nolint:gosec // G404: jitter for retry backoff, not cryptographic
 	return d + time.Duration(rand.N(time.Second))
 }
 
@@ -443,7 +445,7 @@ func retryDelay(resp *http.Response, attempt int) time.Duration {
 // error if an API error has occurred.  If v implements the io.Writer
 // interface, the raw response body will be written to v, without attempting to
 // first decode it.
-func (c *Client) Do(req *http.Request, v interface{}) (*Response, error) {
+func (c *Client) Do(req *http.Request, v any) (*Response, error) {
 	var resp *http.Response
 
 	// roko requires a strategy, but the real delay is always driven by the
@@ -591,9 +593,9 @@ func checkResponse(r *http.Response) error {
 
 // addOptions adds the parameters in opt as URL query parameters to s.  opt
 // must be a struct whose fields may contain "url" tags.
-func addOptions(s string, opt interface{}) (string, error) {
+func addOptions(s string, opt any) (string, error) {
 	v := reflect.ValueOf(opt)
-	if v.Kind() == reflect.Ptr && v.IsNil() {
+	if v.Kind() == reflect.Pointer && v.IsNil() {
 		return s, nil
 	}
 

--- a/builds.go
+++ b/builds.go
@@ -99,25 +99,25 @@ type TestEngineProperty struct {
 
 // Build represents a build which has run in buildkite
 type Build struct {
-	ID          string                 `json:"id,omitempty"`
-	GraphQLID   string                 `json:"graphql_id,omitempty"`
-	URL         string                 `json:"url,omitempty"`
-	WebURL      string                 `json:"web_url,omitempty"`
-	Number      int                    `json:"number,omitempty"`
-	State       string                 `json:"state,omitempty"`
-	Blocked     bool                   `json:"blocked"`
-	Message     string                 `json:"message,omitempty"`
-	Commit      string                 `json:"commit,omitempty"`
-	Branch      string                 `json:"branch,omitempty"`
-	Author      Author                 `json:"author,omitempty"`
-	Env         map[string]interface{} `json:"env,omitempty"`
-	CreatedAt   *Timestamp             `json:"created_at,omitempty"`
-	ScheduledAt *Timestamp             `json:"scheduled_at,omitempty"`
-	StartedAt   *Timestamp             `json:"started_at,omitempty"`
-	FinishedAt  *Timestamp             `json:"finished_at,omitempty"`
-	MetaData    map[string]string      `json:"meta_data,omitempty"`
-	Creator     Creator                `json:"creator,omitempty"`
-	Source      string                 `json:"source,omitempty"`
+	ID          string            `json:"id,omitempty"`
+	GraphQLID   string            `json:"graphql_id,omitempty"`
+	URL         string            `json:"url,omitempty"`
+	WebURL      string            `json:"web_url,omitempty"`
+	Number      int               `json:"number,omitempty"`
+	State       string            `json:"state,omitempty"`
+	Blocked     bool              `json:"blocked"`
+	Message     string            `json:"message,omitempty"`
+	Commit      string            `json:"commit,omitempty"`
+	Branch      string            `json:"branch,omitempty"`
+	Author      Author            `json:"author,omitempty"`
+	Env         map[string]any    `json:"env,omitempty"`
+	CreatedAt   *Timestamp        `json:"created_at,omitempty"`
+	ScheduledAt *Timestamp        `json:"scheduled_at,omitempty"`
+	StartedAt   *Timestamp        `json:"started_at,omitempty"`
+	FinishedAt  *Timestamp        `json:"finished_at,omitempty"`
+	MetaData    map[string]string `json:"meta_data,omitempty"`
+	Creator     Creator           `json:"creator,omitempty"`
+	Source      string            `json:"source,omitempty"`
 
 	// jobs run during the build
 	Jobs []Job `json:"jobs,omitempty"`

--- a/examples/annotations/create/main.go
+++ b/examples/annotations/create/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/annotations/create_for_job/main.go
+++ b/examples/annotations/create_for_job/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/annotations/list_by_build/main.go
+++ b/examples/annotations/list_by_build/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/annotations/list_by_job/main.go
+++ b/examples/annotations/list_by_job/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/artifacts/main.go
+++ b/examples/artifacts/main.go
@@ -33,21 +33,20 @@ func main() {
 	}
 
 	for _, artifact := range artifacts {
-		if *artifactName == "" {
+		switch *artifactName {
+		case "":
 			data, err := json.MarshalIndent(artifact, "", "\t")
 			if err != nil {
 				log.Fatalf("json encode failed: %s", err)
 			}
 
 			_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(data))
-		} else {
-			if *artifactName == artifact.Filename || *artifactName == artifact.ID {
-				_, err := client.Artifacts.DownloadArtifactByURL(context.Background(), artifact.DownloadURL, os.Stdout)
-				if err != nil {
-					log.Fatalf("DownloadArtifactByURL failed: %s", err)
-				}
-				os.Exit(0)
+		case artifact.Filename, artifact.ID:
+			_, err := client.Artifacts.DownloadArtifactByURL(context.Background(), artifact.DownloadURL, os.Stdout)
+			if err != nil {
+				log.Fatalf("DownloadArtifactByURL failed: %s", err)
 			}
+			os.Exit(0)
 		}
 	}
 }

--- a/examples/build_tests/list/main.go
+++ b/examples/build_tests/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/builds/get/main.go
+++ b/examples/builds/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_queues/create/main.go
+++ b/examples/cluster_queues/create/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_queues/delete/main.go
+++ b/examples/cluster_queues/delete/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_queues/get/main.go
+++ b/examples/cluster_queues/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_queues/list/main.go
+++ b/examples/cluster_queues/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_queues/pause/main.go
+++ b/examples/cluster_queues/pause/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_queues/resume/main.go
+++ b/examples/cluster_queues/resume/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_tokens/create/main.go
+++ b/examples/cluster_tokens/create/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_tokens/delete/main.go
+++ b/examples/cluster_tokens/delete/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_tokens/get/main.go
+++ b/examples/cluster_tokens/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_tokens/list/main.go
+++ b/examples/cluster_tokens/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/cluster_tokens/update/main.go
+++ b/examples/cluster_tokens/update/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/clusters/create/main.go
+++ b/examples/clusters/create/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/clusters/delete/main.go
+++ b/examples/clusters/delete/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/clusters/get/main.go
+++ b/examples/clusters/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/clusters/list/main.go
+++ b/examples/clusters/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/clusters/update/main.go
+++ b/examples/clusters/update/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/flaky_tests/list/main.go
+++ b/examples/flaky_tests/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/jobs/reprioritize/main.go
+++ b/examples/jobs/reprioritize/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/members/get/main.go
+++ b/examples/members/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/members/list/main.go
+++ b/examples/members/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/package_registries/create/main.go
+++ b/examples/package_registries/create/main.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/package_registries/delete/main.go
+++ b/examples/package_registries/delete/main.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/package_registries/get/main.go
+++ b/examples/package_registries/get/main.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/package_registries/list/main.go
+++ b/examples/package_registries/list/main.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/package_registries/list_packages/main.go
+++ b/examples/package_registries/list_packages/main.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/packages/create/main.go
+++ b/examples/packages/create/main.go
@@ -6,9 +6,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/packages/delete/main.go
+++ b/examples/packages/delete/main.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/packages/get/main.go
+++ b/examples/packages/get/main.go
@@ -5,9 +5,8 @@ import (
 	"encoding/json"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_schedules/create/main.go
+++ b/examples/pipeline_schedules/create/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_schedules/delete/main.go
+++ b/examples/pipeline_schedules/delete/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_schedules/get/main.go
+++ b/examples/pipeline_schedules/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_schedules/list/main.go
+++ b/examples/pipeline_schedules/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_schedules/update/main.go
+++ b/examples/pipeline_schedules/update/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_templates/create/main.go
+++ b/examples/pipeline_templates/create/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_templates/delete/main.go
+++ b/examples/pipeline_templates/delete/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_templates/get/main.go
+++ b/examples/pipeline_templates/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_templates/list/main.go
+++ b/examples/pipeline_templates/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipeline_templates/update/main.go
+++ b/examples/pipeline_templates/update/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipelines/create/main.go
+++ b/examples/pipelines/create/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipelines/list/main.go
+++ b/examples/pipelines/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/pipelines/update/main.go
+++ b/examples/pipelines/update/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/rate_limits/get/main.go
+++ b/examples/rate_limits/get/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/test_runs/failed_executions/main.go
+++ b/examples/test_runs/failed_executions/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 type failedExecutionsForRun struct {

--- a/examples/test_runs/get/main.go
+++ b/examples/test_runs/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/test_runs/list/main.go
+++ b/examples/test_runs/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/test_suites/create/main.go
+++ b/examples/test_suites/create/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/test_suites/delete/main.go
+++ b/examples/test_suites/delete/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/test_suites/get/main.go
+++ b/examples/test_suites/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/test_suites/list/main.go
+++ b/examples/test_suites/list/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/test_suites/update/main.go
+++ b/examples/test_suites/update/main.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/examples/tests/get/main.go
+++ b/examples/tests/get/main.go
@@ -7,9 +7,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/buildkite/go-buildkite/v5"
-
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
 )
 
 var (

--- a/mise.lock
+++ b/mise.lock
@@ -33,43 +33,8 @@ checksum = "sha256:ca37af2dadd8544464f1a9ca7c3886499d1cdfcb263855d0a1d71f194b2bd
 url = "https://dl.google.com/go/go1.25.10.windows-amd64.zip"
 
 [[tools.golangci-lint]]
-version = "2.8.0"
+version = "2.12.2"
 backend = "aqua:golangci/golangci-lint"
-
-[tools.golangci-lint."platforms.linux-arm64"]
-checksum = "sha256:2a58388db8af5ab9330791cea0ebdd4100723cd05ad7185d92febaaee272ec9a"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.8.0/golangci-lint-2.8.0-linux-arm64.tar.gz"
-provenance = "github-attestations"
-
-[tools.golangci-lint."platforms.linux-arm64-musl"]
-checksum = "sha256:2a58388db8af5ab9330791cea0ebdd4100723cd05ad7185d92febaaee272ec9a"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.8.0/golangci-lint-2.8.0-linux-arm64.tar.gz"
-provenance = "github-attestations"
-
-[tools.golangci-lint."platforms.linux-x64"]
-checksum = "sha256:7048bc6b25c9515ed092c83f9fa8709ca97937ead52d9ff317a143299ee97a50"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.8.0/golangci-lint-2.8.0-linux-amd64.tar.gz"
-provenance = "github-attestations"
-
-[tools.golangci-lint."platforms.linux-x64-musl"]
-checksum = "sha256:7048bc6b25c9515ed092c83f9fa8709ca97937ead52d9ff317a143299ee97a50"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.8.0/golangci-lint-2.8.0-linux-amd64.tar.gz"
-provenance = "github-attestations"
-
-[tools.golangci-lint."platforms.macos-arm64"]
-checksum = "sha256:6f8979a83117e0607d4b85ff486382ef0404440bbf54f0e6f003ceab6ccf641e"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.8.0/golangci-lint-2.8.0-darwin-arm64.tar.gz"
-provenance = "github-attestations"
-
-[tools.golangci-lint."platforms.macos-x64"]
-checksum = "sha256:164c72806d0e31ab19da4f08fff748a3fdc57e241851279b666c945ed9b91830"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.8.0/golangci-lint-2.8.0-darwin-amd64.tar.gz"
-provenance = "github-attestations"
-
-[tools.golangci-lint."platforms.windows-x64"]
-checksum = "sha256:22428168a9406f79853bf9a198b66e88ded9faa57cf85e5d225361f457f33513"
-url = "https://github.com/golangci/golangci-lint/releases/download/v2.8.0/golangci-lint-2.8.0-windows-amd64.zip"
-provenance = "github-attestations"
 
 [[tools.lefthook]]
 version = "2.1.10"

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ lockfile = true
 
 [tools]
 go = "1.25.10"
-golangci-lint = "2.8.0"
+golangci-lint = "2.12.2"
 lefthook = "2.1.10"
 
 [tasks.format]

--- a/pipelines.go
+++ b/pipelines.go
@@ -151,7 +151,7 @@ func (p *Plugins) UnmarshalJSON(bs []byte) error {
 
 // This is kept vague (map of string to whatever) as there are a lot of custom
 // plugins out there.
-type Plugin map[string]interface{}
+type Plugin map[string]any
 
 // PipelineListOptions specifies the optional parameters to the
 // PipelinesService.List method.

--- a/timestamp.go
+++ b/timestamp.go
@@ -30,12 +30,12 @@ func (ts Timestamp) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (ts *Timestamp) UnmarshalJSON(data []byte) (err error) {
-	(*ts).Time, err = time.Parse(`"`+BuildKiteDateFormat+`"`, string(data))
+	ts.Time, err = time.Parse(`"`+BuildKiteDateFormat+`"`, string(data))
 	if err != nil {
 		// try the webhook format too; avoid clobbering the error if both fail
 		t, err2 := time.Parse(`"`+BuildKiteEventDateFormat+`"`, string(data))
 		if err2 == nil {
-			(*ts).Time = t
+			ts.Time = t
 			err = err2
 		}
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -18,6 +18,7 @@ const (
 	// SignatureHeader is the Buildkite header key used to pass the HMAC hexdigest.
 	SignatureHeader = "X-Buildkite-Signature"
 	// TokenHeader is the Buildkite header key used to pass the webhook token.
+	//nolint:gosec // G101: header name, not a credential
 	TokenHeader = "X-Buildkite-Token"
 )
 
@@ -50,7 +51,7 @@ func WebHookType(r *http.Request) string {
 // value of the corresponding struct type will be returned (as returned
 // by Event.ParsePayload()). An error will be returned for unrecognized event
 // types.
-func ParseWebHook(messageType string, payload []byte) (interface{}, error) {
+func ParseWebHook(messageType string, payload []byte) (any, error) {
 	eventType, ok := eventTypeMapping[messageType]
 	if !ok {
 		return nil, fmt.Errorf("unknown X-Buildkite-Event in message: %v", messageType)
@@ -169,7 +170,7 @@ type Event struct {
 // An error will be returned for unrecognized event types.
 //
 // Example usage:
-func (e *Event) ParsePayload() (payload interface{}, err error) {
+func (e *Event) ParsePayload() (payload any, err error) {
 	switch e.Type {
 	case "AgentConnectedEvent":
 		payload = &AgentConnectedEvent{}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestParseWebHook(t *testing.T) {
 	tests := []struct {
-		payload      interface{}
+		payload      any
 		messageType  string
 		errorMessage string
 	}{
@@ -105,11 +105,13 @@ func TestParseWebHook(t *testing.T) {
 func TestValidatePayload(t *testing.T) {
 	const defaultBody = `{"event":"ping","service":{"id":"c9f8372d-c0cd-43dc-9274-768a875cf6ca","provider":"webhook","settings":{"url":"https://server.com/webhooks"}},"organization":{"id":"49801950-1df0-474f-bb56-ad6a930c5cb9","graphql_id":"T3JnYW5pemF0aW9uLS0tZTBmMzk3MgsTksGkxOWYtZTZjNzczZTJiYjEy","url":"https://api.buildkite.com/v2/organizations/acme-inc","web_url":"https://buildkite.com/acme-inc","name":"ACME Inc","slug":"acme-inc","agents_url":"https://api.buildkite.com/v2/organizations/acme-inc/agents","emojis_url":"https://api.buildkite.com/v2/organizations/acme-inc/emojis","created_at":"2021-02-03T20:34:10.486Z","pipelines_url":"https://api.buildkite.com/v2/organizations/acme-inc/pipelines"},"sender":{"id":"c9f8372d-c0cd-43dc-9269-bcbb7f308e3f","name":"ACME Man"}}`
 	const defaultSignature = "timestamp=1642080837,signature=582d496ac2d869dd97a3101c4cda346288c49a742592daf582ec64c86449f79c"
+	//nolint:gosec // G101: test fixture, not a real credential
 	const defaultToken = "29b1ff5779c76bd48ba6705eb99ff970"
 	const errorDecodingSignature = "error decoding signature"
 	const invalidSignatureHeader = "X-Buildkite-Signature format is incorrect"
 	const missingAuthHeader = "no X-Buildkite-Signature or X-Buildkite-Token header present on request"
 	const payloadSignatureError = "payload signature check failed"
+	//nolint:gosec // G101: error message string, not a credential
 	const tokenValidationError = "webhook token validation failed"
 	secretKey := []byte("29b1ff5779c76bd48ba6705eb99ff970")
 


### PR DESCRIPTION
Add a shared .golangci.yml, bump the mise pin, and fix formatting, style, and false-positive gosec issues so lint runs clean.
