### PR TITLE
Document exclude_jobs support for build lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,7 +167,7 @@
 
 ## [v4.3.0](https://github.com/buildkite/go-buildkite/compare/v4.2.0...v4.3.0) (2025-06-04)
 
-* Add support for excluding jobs and pipeline data from List Builds [#225](https://github.com/buildkite/go-buildkite/pull/225) ([blaknite](https://github.com/blaknite))
+* Add support for excluding jobs and pipeline data from build list and get operations [#225](https://github.com/buildkite/go-buildkite/pull/225) ([blaknite](https://github.com/blaknite))
 
 ## [v4.2.0](https://github.com/buildkite/go-buildkite/compare/v4.1.1...v4.2.0) (2025-06-03)
 

--- a/builds.go
+++ b/builds.go
@@ -199,6 +199,9 @@ type BuildsListOptions struct {
 	ListOptions
 }
 
+// BuildGetOptions specifies the optional parameters to the BuildsService.Get
+// method. Embedded BuildsListOptions that control response expansions, such as
+// ExcludeJobs and ExcludePipeline, also apply to build lookups.
 type BuildGetOptions struct {
 	BuildsListOptions
 

--- a/builds_test.go
+++ b/builds_test.go
@@ -89,6 +89,31 @@ func TestBuildsService_Get(t *testing.T) {
 		}
 	})
 
+	t.Run("excludes jobs when option is set", func(t *testing.T) {
+		t.Parallel()
+
+		server, client, teardown := newMockServerAndClient(t)
+		t.Cleanup(teardown)
+
+		server.HandleFunc(requestSlug, func(w http.ResponseWriter, r *http.Request) {
+			testMethod(t, r, "GET")
+			if got, want := r.URL.RawQuery, "exclude_jobs=true"; got != want {
+				t.Errorf("query = %q, want %q", got, want)
+			}
+			_, _ = fmt.Fprintf(w, `{"id":"%s"}`, buildNumber)
+		})
+
+		opt := &BuildGetOptions{
+			BuildsListOptions: BuildsListOptions{
+				ExcludeJobs: true,
+			},
+		}
+		_, _, err := client.Builds.Get(context.Background(), orgName, pipelineName, buildNumber, opt)
+		if err != nil {
+			t.Errorf("Builds.Get (exclude jobs) returned error: %v", err)
+		}
+	})
+
 	t.Run("returns a build struct with expected job containing a group key", func(t *testing.T) {
 		t.Parallel()
 

--- a/examples/builds/get/main.go
+++ b/examples/builds/get/main.go
@@ -26,7 +26,12 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	build, _, err := client.Builds.Get(context.Background(), *org, *slug, *number, nil)
+	build, _, err := client.Builds.Get(context.Background(), *org, *slug, *number, &buildkite.BuildGetOptions{
+		BuildsListOptions: buildkite.BuildsListOptions{
+			ExcludeJobs:     true,
+			ExcludePipeline: true,
+		},
+	})
 	if err != nil {
 		log.Fatalf("Getting build %s of pipeline %s failed: %s", *number, *slug, err)
 	}


### PR DESCRIPTION
## Description

Document that `BuildGetOptions` inherits `ExcludeJobs` and `ExcludePipeline`, and show metadata-only build retrieval in the Get example. A Get-specific HTTP test records the existing `exclude_jobs=true` request behavior.

This is a discoverability-only change: it does not change API behavior or public types.

## Compatibility and deployment

Risk is minimal because only documentation, an example, and test coverage change. No dependency, runtime, or deployment changes are required.

## Rollback

Revert this PR if the documented API behavior changes; no data or runtime rollback is needed.