### PR TITLE
chore(release): add v5.5.0 and missing v3.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
 * chore: uplift golangci-lint to 2.12.2 and clear findings [#338](https://github.com/buildkite/go-buildkite/pull/338) ([wolfeidau](https://github.com/wolfeidau))
 * chore(deps): update dependency lefthook to v2.1.10 [#337](https://github.com/buildkite/go-buildkite/pull/337) ([renovate[bot]](https://github.com/apps/renovate))
 
-## [v5.3.1](https://github.com/buildkite/go-buildkite/compare/v5.3.0...v5.3.1) (2026-06-29)
+## [v5.3.1](https://github.com/buildkite/go-buildkite/compare/v5.3.0...v5.3.1) (2026-07-06)
 
-* feat: add missing documented fields to Agent struct by ([wolfeidau](https://github.com/buildkite/go-buildkite/pull/334))
+* feat: add missing documented fields to Agent struct [#335](https://github.com/buildkite/go-buildkite/pull/335) ([wolfeidau](https://github.com/wolfeidau))
 
 ## [v5.3.0](https://github.com/buildkite/go-buildkite/compare/v5.2.0...v5.3.0) (2026-06-29)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,18 @@
+## [v5.5.0](https://github.com/buildkite/go-buildkite/compare/v5.4.0...v5.5.0) (2026-07-16)
+
+* feat(api): annotation scope and omit body [#342](https://github.com/buildkite/go-buildkite/pull/342) ([mcncl](https://github.com/mcncl))
+* chore(deps): update dependency go to v1.26.5 [#336](https://github.com/buildkite/go-buildkite/pull/336) ([renovate[bot]](https://github.com/apps/renovate))
+
 ## [v5.4.0](https://github.com/buildkite/go-buildkite/compare/v5.3.1...v5.4.0) (2026-07-14)
 
 * Document exclude_jobs support for build lookups [#340](https://github.com/buildkite/go-buildkite/pull/340) ([mitchbne](https://github.com/mitchbne))
 * feat: add signal fields to jobs [#339](https://github.com/buildkite/go-buildkite/pull/339) ([wolfeidau](https://github.com/wolfeidau))
 * chore: uplift golangci-lint to 2.12.2 and clear findings [#338](https://github.com/buildkite/go-buildkite/pull/338) ([wolfeidau](https://github.com/wolfeidau))
 * chore(deps): update dependency lefthook to v2.1.10 [#337](https://github.com/buildkite/go-buildkite/pull/337) ([renovate[bot]](https://github.com/apps/renovate))
+
+## [v5.3.1](https://github.com/buildkite/go-buildkite/compare/v5.3.0...v5.3.1) (2026-06-29)
+
+* feat: add missing documented fields to Agent struct by ([wolfeidau](https://github.com/buildkite/go-buildkite/pull/334))
 
 ## [v5.3.0](https://github.com/buildkite/go-buildkite/compare/v5.2.0...v5.3.0) (2026-06-29)
 


### PR DESCRIPTION
## Description

Adds a CHANGELOG entry for v5.5.0, as well as a missing entry for v5.3.1
