### PR TITLE
feat: add job log existence check

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -324,6 +324,29 @@ func (js *JobsService) GetJobLog(ctx context.Context, org string, pipeline strin
 	return jobLog, resp, err
 }
 
+// JobLogExists checks whether a log exists for the given job without fetching
+// its body. The response headers include the log size in Content-Length and
+// range support in Accept-Ranges.
+//
+// buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-log-output-get-log-size-without-downloading
+func (js *JobsService) JobLogExists(ctx context.Context, org, pipeline, buildNumber, jobID string) (bool, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/jobs/%s/log", org, pipeline, buildNumber, jobID)
+	req, err := js.client.NewRequest(ctx, http.MethodHead, u, nil)
+	if err != nil {
+		return false, nil, err
+	}
+
+	resp, err := js.client.Do(req, nil)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return false, resp, nil
+		}
+		return false, resp, err
+	}
+
+	return true, resp, nil
+}
+
 // GetJobEnvironmentVariables - get a job’s environment variables
 //
 // buildkite API docs: https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-environment-variables

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -349,6 +349,79 @@ func TestJobsService_GetJobLog(t *testing.T) {
 	}
 }
 
+func TestJobsService_JobLogExists(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/log", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodHead)
+		w.Header().Set("Content-Length", "28")
+		w.Header().Set("Accept-Ranges", "bytes")
+	})
+
+	exists, resp, err := client.Jobs.JobLogExists(context.Background(), "my-great-org", "sup-keith", "awesome-build", "awesome-job-id")
+	if err != nil {
+		t.Fatalf("JobLogExists returned error: %v", err)
+	}
+	if !exists {
+		t.Error("JobLogExists returned false, want true")
+	}
+	if got := resp.Header.Get("Content-Length"); got != "28" {
+		t.Errorf("Content-Length = %q, want %q", got, "28")
+	}
+	if got := resp.Header.Get("Accept-Ranges"); got != "bytes" {
+		t.Errorf("Accept-Ranges = %q, want %q", got, "bytes")
+	}
+}
+
+func TestJobsService_JobLogExists_NotFound(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/missing-job-id/log", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodHead)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	exists, resp, err := client.Jobs.JobLogExists(context.Background(), "my-great-org", "sup-keith", "awesome-build", "missing-job-id")
+	if err != nil {
+		t.Fatalf("JobLogExists returned error: %v", err)
+	}
+	if exists {
+		t.Error("JobLogExists returned true, want false")
+	}
+	if resp == nil || resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("response = %#v, want status %d", resp, http.StatusNotFound)
+	}
+}
+
+func TestJobsService_JobLogExists_ServerError(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/awesome-build/jobs/awesome-job-id/log", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, http.MethodHead)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	exists, resp, err := client.Jobs.JobLogExists(context.Background(), "my-great-org", "sup-keith", "awesome-build", "awesome-job-id")
+	if err == nil {
+		t.Fatal("JobLogExists returned nil error, want an error")
+	}
+	if exists {
+		t.Error("JobLogExists returned true, want false")
+	}
+	if resp == nil || resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("response = %#v, want status %d", resp, http.StatusInternalServerError)
+	}
+}
+
 func TestJobsService_GetJobEnvironmentVariables(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Add JobsService.JobLogExists using a HEAD request.
- Return a non-error result when the log is not found.
- Preserve response headers for log size and byte-range support.
- Cover success, not-found, and server-error responses.

API docs: https://buildkite.com/docs/apis/rest-api/jobs#get-a-jobs-log-output-get-log-size-without-downloading
