### PR TITLE
Add job step and group key filters

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -142,6 +142,8 @@ type StepInfo struct {
 // JobsListOptions specifies the optional parameters to the JobsService.ListByBuild method.
 type JobsListOptions struct {
 	State              []string `url:"state,brackets,omitempty"`
+	StepKey            string   `url:"step_key,omitempty"`
+	GroupKey           string   `url:"group_key,omitempty"`
 	IncludeRetriedJobs *bool    `url:"include_retried_jobs,omitempty"`
 	PerPage            int      `url:"per_page,omitempty"`
 	After              string   `url:"after,omitempty"`
@@ -159,9 +161,11 @@ func (l JobsListLink) ToOptions() (*JobsListOptions, error) {
 	q := u.Query()
 
 	opts := &JobsListOptions{
-		State:  q["state[]"],
-		After:  q.Get("after"),
-		Before: q.Get("before"),
+		State:    q["state[]"],
+		StepKey:  q.Get("step_key"),
+		GroupKey: q.Get("group_key"),
+		After:    q.Get("after"),
+		Before:   q.Get("before"),
 	}
 
 	if perPage := q.Get("per_page"); perPage != "" {

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -110,6 +110,8 @@ func TestJobsService_ListByBuild_WithOptions(t *testing.T) {
 		testFormValuesList(t, r, valuesList{
 			{"state[]", "passed"},
 			{"state[]", "failed"},
+			{"step_key", "test"},
+			{"group_key", "tests"},
 			{"include_retried_jobs", "false"},
 			{"per_page", "100"},
 			{"after", "cursor-1"},
@@ -120,6 +122,8 @@ func TestJobsService_ListByBuild_WithOptions(t *testing.T) {
 	includeRetriedJobs := false
 	opt := &JobsListOptions{
 		State:              []string{"passed", "failed"},
+		StepKey:            "test",
+		GroupKey:           "tests",
 		IncludeRetriedJobs: &includeRetriedJobs,
 		PerPage:            100,
 		After:              "cursor-1",
@@ -133,7 +137,7 @@ func TestJobsService_ListByBuild_WithOptions(t *testing.T) {
 func TestJobsListLink_ToOptions(t *testing.T) {
 	t.Parallel()
 
-	link := JobsListLink("https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/jobs?state[]=passed&state[]=failed&include_retried_jobs=false&after=cursor-1&per_page=100")
+	link := JobsListLink("https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/jobs?state[]=passed&state[]=failed&step_key=test&group_key=tests&include_retried_jobs=false&after=cursor-1&per_page=100")
 	opt, err := link.ToOptions()
 	if err != nil {
 		t.Fatalf("ToOptions returned error: %v", err)
@@ -142,6 +146,8 @@ func TestJobsListLink_ToOptions(t *testing.T) {
 	includeRetriedJobs := false
 	want := &JobsListOptions{
 		State:              []string{"passed", "failed"},
+		StepKey:            "test",
+		GroupKey:           "tests",
 		IncludeRetriedJobs: &includeRetriedJobs,
 		PerPage:            100,
 		After:              "cursor-1",


### PR DESCRIPTION
## Description

Add `step_key` and `group_key` filters to `JobsListOptions`, including preservation when converting cursor links back into options. This exposes the new List Jobs filtering behavior without broadening the jobs API.

## Deployment

Merge and release this only after the server-side filters are deployed. Downstream [CLI support](https://github.com/buildkite/cli/pull/915) and [MCP support](https://github.com/buildkite/buildkite-mcp-server/pull/318) require a tagged go-buildkite release.

## Rollback

Revert this PR if the client options cause compatibility issues; the server behavior is independent.
