### PR TITLE
Match Job.Signal type to that of API

### DIFF
--- a/jobs.go
+++ b/jobs.go
@@ -32,7 +32,7 @@ type Job struct {
 	RawLogsURL         string          `json:"raw_log_url,omitempty"`
 	Command            string          `json:"command,omitempty"`
 	ExitStatus         *int            `json:"exit_status,omitempty"`
-	Signal             *int            `json:"signal,omitempty"`
+	Signal             string          `json:"signal,omitempty"`
 	SignalReason       string          `json:"signal_reason,omitempty"`
 	ArtifactPaths      string          `json:"artifact_paths,omitempty"`
 	ArtifactsURL       string          `json:"artifacts_url,omitempty"`

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -35,7 +35,7 @@ func TestJobsService_ListByBuild(t *testing.T) {
       "command": "scripts/build.sh",
       "soft_failed": false,
       "exit_status": 0,
-      "signal": 15,
+      "signal": "SIGTERM",
       "signal_reason": "terminated",
       "artifact_paths": "logs/**/*",
       "agent_query_rules": ["queue=default"],
@@ -61,7 +61,6 @@ func TestJobsService_ListByBuild(t *testing.T) {
 	}
 
 	exitStatus := 0
-	signal := 15
 	want := JobsList{
 		Items: []Job{{
 			ID:              "job-1",
@@ -77,7 +76,7 @@ func TestJobsService_ListByBuild(t *testing.T) {
 			Command:         "scripts/build.sh",
 			SoftFailed:      false,
 			ExitStatus:      &exitStatus,
-			Signal:          &signal,
+			Signal:          "SIGTERM",
 			SignalReason:    "terminated",
 			ArtifactPaths:   "logs/**/*",
 			AgentQueryRules: []string{"queue=default"},
@@ -179,7 +178,7 @@ func TestJobsService_GetJob(t *testing.T) {
   "command": "scripts/build.sh",
   "soft_failed": false,
   "exit_status": 0,
-  "signal": 15,
+  "signal": "SIGTERM",
   "signal_reason": "terminated",
   "expired_at": "2026-06-03T04:15:41.618Z",
   "matrix": {
@@ -200,7 +199,6 @@ func TestJobsService_GetJob(t *testing.T) {
 	}
 
 	exitStatus := 0
-	signal := 15
 	want := Job{
 		ID:           "job-1",
 		GraphQLID:    "Sm9iLS0tam9iLTE=",
@@ -215,7 +213,7 @@ func TestJobsService_GetJob(t *testing.T) {
 		Command:      "scripts/build.sh",
 		SoftFailed:   false,
 		ExitStatus:   &exitStatus,
-		Signal:       &signal,
+		Signal:       "SIGTERM",
 		SignalReason: "terminated",
 		ExpiredAt:    NewTimestamp(must(time.Parse(BuildKiteDateFormat, "2026-06-03T04:15:41.618Z"))),
 		Matrix:       map[string]any{"os": "linux", "go": "1.25"},


### PR DESCRIPTION
The Job.Signal was declared as *int, but the Buildkite REST API returns the job
signal field as a string. This PR matches the type correctly.

https://github.com/buildkite/go-buildkite/issues/349