### PR TITLE
feat(tests): add List Tests support

### DIFF
--- a/examples/tests/list/main.go
+++ b/examples/tests/list/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Organization slug").Required().String()
+	slug     = kingpin.Flag("slug", "Test suite slug").Required().String()
+	period   = kingpin.Flag("period", "Aggregation period").Default("7days").String()
+	branch   = kingpin.Flag("branch", "Branch filter expression").String()
+	sortBy   = kingpin.Flag("sort-by", "Metric used to sort tests").Default("reliability").String()
+	order    = kingpin.Flag("order", "Sort direction").Default("asc").String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	tests, _, err := client.Tests.List(context.Background(), *org, *slug, &buildkite.TestsListOptions{
+		Period: *period,
+		Branch: *branch,
+		SortBy: *sortBy,
+		Order:  *order,
+	})
+	if err != nil {
+		log.Fatalf("listing tests for suite %s failed: %s", *slug, err)
+	}
+
+	data, err := json.MarshalIndent(tests, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/tests.go
+++ b/tests.go
@@ -3,6 +3,7 @@ package buildkite
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 // TestsService handles communication with test related
@@ -13,19 +14,134 @@ type TestsService struct {
 	client *Client
 }
 
+const testsListAPIVersion = "2026-08-01"
+
+// Test represents a test in a Buildkite Test Engine suite.
 type Test struct {
-	ID       string `json:"id,omitempty"`
-	URL      string `json:"url,omitempty"`
-	WebURL   string `json:"web_url,omitempty"`
-	Scope    string `json:"scope,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Location string `json:"location,omitempty"`
-	FileName string `json:"file_name,omitempty"`
+	ID       string   `json:"id,omitempty"`
+	URL      string   `json:"url,omitempty"`
+	WebURL   string   `json:"web_url,omitempty"`
+	Scope    string   `json:"scope,omitempty"`
+	Name     string   `json:"name,omitempty"`
+	Location string   `json:"location,omitempty"`
+	FileName string   `json:"file_name,omitempty"`
+	Labels   []string `json:"labels,omitempty"`
+}
+
+// TestWithMetrics represents a test and its execution metrics aggregated over
+// the time window requested from [TestsService.List].
+type TestWithMetrics struct {
+	Test
+
+	// Reliability is the ratio of passed executions to passed and failed
+	// executions. It is nil when there are no passed or failed executions.
+	Reliability *float64 `json:"reliability"`
+
+	// DurationAverage is the average execution duration in seconds.
+	DurationAverage float64 `json:"duration_avg"`
+
+	// DurationTotal is the total execution duration in seconds.
+	DurationTotal float64 `json:"duration_sum"`
+
+	// DurationMinimum is the shortest execution duration in seconds.
+	DurationMinimum float64 `json:"duration_min"`
+
+	// DurationMaximum is the longest execution duration in seconds.
+	DurationMaximum float64 `json:"duration_max"`
+
+	// ExecutionsCount is the number of executions in the aggregation window.
+	ExecutionsCount int `json:"executions_count"`
+
+	// ExecutionsCountByResult contains execution counts grouped by result.
+	// Passed and failed are always present; skipped, pending, and unknown are
+	// present only when non-zero.
+	ExecutionsCountByResult map[string]int `json:"executions_count_by_result"`
+}
+
+// TestsListOptions specifies optional parameters for [TestsService.List].
+// Invalid values and incompatible combinations are validated by the API.
+type TestsListOptions struct {
+	ListOptions
+
+	// Period sets a relative aggregation window, such as "7days" or "28days".
+	// Available periods depend on the organization's maximum time window. Period
+	// cannot be combined with MinTimestamp or MaxTimestamp.
+	Period string `url:"period,omitempty"`
+
+	// MinTimestamp sets the start of the aggregation window. When omitted, it
+	// defaults to the organization's default period before the current time.
+	MinTimestamp time.Time `url:"min_timestamp,omitempty"`
+
+	// MaxTimestamp sets the end of the aggregation window. It defaults to the
+	// current time when omitted.
+	MaxTimestamp time.Time `url:"max_timestamp,omitempty"`
+
+	// Labels filters by comma-separated test labels. Prefix a label with "!" to
+	// exclude it, for example "flaky,!slow".
+	Labels string `url:"labels,omitempty"`
+
+	// Branch filters the executions included in the aggregation. Prefix the
+	// value with "!" to exclude an exact branch, or suffix it with "*" to match
+	// branches by prefix; for example "!main" or "feature*". Use at most one
+	// operator.
+	Branch string `url:"branch,omitempty"`
+
+	// Owners filters by comma-separated test owner slugs. Prefix an owner with
+	// "!" to exclude it, for example "payments,!platform".
+	Owners string `url:"owners,omitempty"`
+
+	// State filters by test state: "enabled", "muted", or "skipped".
+	State string `url:"state,omitempty"`
+
+	// Tags filters by comma-separated execution tags in key:value form. Prefix a
+	// value with "!" to exclude an exact value, or suffix it with "*" to match
+	// by prefix. For the result tag, prefix the value with "~" to return tests
+	// with at least one execution in the aggregation window having that result,
+	// or "^" to return tests for which every execution in the window has that
+	// result. Use at most one operator per value and specify result at most once;
+	// for example
+	// "framework:!rspec,scm.branch:feature*,result:^passed".
+	Tags string `url:"tags,omitempty"`
+
+	// SortBy specifies the metric used to sort results: "duration_avg",
+	// "duration_sum", "duration_min", "duration_max", or "reliability". It
+	// defaults to "duration_avg".
+	SortBy string `url:"sort_by,omitempty"`
+
+	// Order specifies the sort direction: "asc" or "desc". It defaults to
+	// "desc".
+	Order string `url:"order,omitempty"`
 }
 
 type FindTestOptions struct {
 	Scope string `json:"scope"`
 	Name  string `json:"name"`
+}
+
+// List returns tests with execution metrics aggregated over the requested time
+// window. It opts in to the versioned metrics response, which includes only
+// tests with executions in that window. Pagination is available through the
+// returned Response.
+func (ts *TestsService) List(ctx context.Context, org, slug string, opt *TestsListOptions) ([]TestWithMetrics, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests", org, slug)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := ts.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	req.Header.Set("Buildkite-Version", testsListAPIVersion)
+
+	var tests []TestWithMetrics
+	resp, err := ts.client.Do(req, &tests)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tests, resp, err
 }
 
 func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (Test, *Response, error) {

--- a/tests_test.go
+++ b/tests_test.go
@@ -3,12 +3,223 @@ package buildkite
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func TestTestsService_List(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	const linkHeader = `<https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests?page=3>; rel="next", <https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests?page=4>; rel="last"`
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if got, want := r.Header.Get("Buildkite-Version"), testsListAPIVersion; got != want {
+			t.Errorf("Buildkite-Version header = %q, want %q", got, want)
+		}
+		testFormValues(t, r, values{
+			"page":          "2",
+			"per_page":      "50",
+			"min_timestamp": "2026-07-01T00:00:00Z",
+			"max_timestamp": "2026-07-23T00:00:00Z",
+			"labels":        "flaky,!slow",
+			"branch":        "main*",
+			"owners":        "payments,!platform",
+			"state":         "enabled",
+			"tags":          "framework:rspec,result:^failed",
+			"sort_by":       "reliability",
+			"order":         "asc",
+		})
+
+		w.Header().Set("Link", linkHeader)
+		_, _ = fmt.Fprint(w, `[
+			{
+				"id": "01867216-8478-7fde-a55a-0300f88bb49b",
+				"url": "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/01867216-8478-7fde-a55a-0300f88bb49b",
+				"web_url": "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/tests/01867216-8478-7fde-a55a-0300f88bb49b",
+				"scope": "User#email",
+				"name": "is correctly formatted",
+				"location": "./spec/models/user_spec.rb:42",
+				"file_name": "./spec/models/user_spec.rb",
+				"labels": ["flaky"],
+				"reliability": 0.9821,
+				"duration_avg": 0.213,
+				"duration_sum": 23.856,
+				"duration_min": 0.108,
+				"duration_max": 1.942,
+				"executions_count": 113,
+				"executions_count_by_result": {
+					"passed": 110,
+					"failed": 2,
+					"skipped": 1
+				}
+			}
+		]`)
+	})
+
+	reliability := 0.9821
+	got, resp, err := client.Tests.List(context.Background(), "my-great-org", "suite-example", &TestsListOptions{
+		ListOptions: ListOptions{Page: 2, PerPage: 50},
+		MinTimestamp: time.Date(
+			2026, time.July, 1, 0, 0, 0, 0, time.UTC,
+		),
+		MaxTimestamp: time.Date(2026, time.July, 23, 0, 0, 0, 0, time.UTC),
+		Labels:       "flaky,!slow",
+		Branch:       "main*",
+		Owners:       "payments,!platform",
+		State:        "enabled",
+		Tags:         "framework:rspec,result:^failed",
+		SortBy:       "reliability",
+		Order:        "asc",
+	})
+	if err != nil {
+		t.Fatalf("TestsService.List returned error: %v", err)
+	}
+
+	want := []TestWithMetrics{
+		{
+			Test: Test{
+				ID:       "01867216-8478-7fde-a55a-0300f88bb49b",
+				URL:      "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/01867216-8478-7fde-a55a-0300f88bb49b",
+				WebURL:   "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/tests/01867216-8478-7fde-a55a-0300f88bb49b",
+				Scope:    "User#email",
+				Name:     "is correctly formatted",
+				Location: "./spec/models/user_spec.rb:42",
+				FileName: "./spec/models/user_spec.rb",
+				Labels:   []string{"flaky"},
+			},
+			Reliability:     &reliability,
+			DurationAverage: 0.213,
+			DurationTotal:   23.856,
+			DurationMinimum: 0.108,
+			DurationMaximum: 1.942,
+			ExecutionsCount: 113,
+			ExecutionsCountByResult: map[string]int{
+				"passed":  110,
+				"failed":  2,
+				"skipped": 1,
+			},
+		},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("TestsService.List diff: (-got +want)\n%s", diff)
+	}
+	if got, want := resp.NextPage, 3; got != want {
+		t.Errorf("response.NextPage = %d, want %d", got, want)
+	}
+	if got, want := resp.LastPage, 4; got != want {
+		t.Errorf("response.LastPage = %d, want %d", got, want)
+	}
+	if got := resp.Header.Get("Link"); got != linkHeader {
+		t.Errorf("response Link header = %q, want %q", got, linkHeader)
+	}
+}
+
+func TestTestsService_List_Period(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests", func(w http.ResponseWriter, r *http.Request) {
+		testFormValues(t, r, values{"period": "28days"})
+		_, _ = fmt.Fprint(w, `[]`)
+	})
+
+	got, _, err := client.Tests.List(context.Background(), "my-great-org", "suite-example", &TestsListOptions{Period: "28days"})
+	if err != nil {
+		t.Fatalf("TestsService.List returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("TestsService.List returned %d items, want 0", len(got))
+	}
+}
+
+func TestTestsService_List_NilOptionsAndReliability(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.RawQuery; got != "" {
+			t.Errorf("request query = %q, want empty", got)
+		}
+		if got, want := r.Header.Get("Buildkite-Version"), testsListAPIVersion; got != want {
+			t.Errorf("Buildkite-Version header = %q, want %q", got, want)
+		}
+		_, _ = fmt.Fprint(w, `[
+			{
+				"id": "01867216-8478-7fde-a55a-0300f88bb49b",
+				"reliability": null,
+				"executions_count": 1,
+				"executions_count_by_result": {
+					"passed": 0,
+					"failed": 0,
+					"skipped": 1
+				}
+			}
+		]`)
+	})
+
+	got, _, err := client.Tests.List(context.Background(), "my-great-org", "suite-example", nil)
+	if err != nil {
+		t.Fatalf("TestsService.List returned error: %v", err)
+	}
+
+	want := []TestWithMetrics{
+		{
+			Test:            Test{ID: "01867216-8478-7fde-a55a-0300f88bb49b"},
+			Reliability:     nil,
+			ExecutionsCount: 1,
+			ExecutionsCountByResult: map[string]int{
+				"passed":  0,
+				"failed":  0,
+				"skipped": 1,
+			},
+		},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("TestsService.List diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestTestsService_List_ServerError(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, "{\"message\":\"period cannot be combined with min_timestamp\"}")
+	})
+
+	got, resp, err := client.Tests.List(context.Background(), "my-great-org", "suite-example", nil)
+	if err == nil {
+		t.Fatal("TestsService.List returned nil error, want API error")
+	}
+	if got != nil {
+		t.Errorf("TestsService.List returned items %v, want nil", got)
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("TestsService.List response = %#v, want status %d", resp, http.StatusUnprocessableEntity)
+	}
+	var apiErr *ErrorResponse
+	if !errors.As(err, &apiErr) {
+		t.Errorf("TestsService.List error type = %T, want *ErrorResponse", err)
+	} else if got, want := apiErr.Message, "period cannot be combined with min_timestamp"; got != want {
+		t.Errorf("TestsService.List error message = %q, want %q", got, want)
+	}
+}
 
 func TestTestsService_Get(t *testing.T) {
 	t.Parallel()
@@ -27,7 +238,8 @@ func TestTestsService_Get(t *testing.T) {
 				"name": "TestExample1_Create",
 				"scope": "User#email",
 				"location": "./resources/test_example_test.go:123",
-				"file_name": "./resources/test_example_test.go"
+				"file_name": "./resources/test_example_test.go",
+				"labels": ["flaky"]
 			}`)
 	})
 
@@ -44,6 +256,7 @@ func TestTestsService_Get(t *testing.T) {
 		Scope:    "User#email",
 		Location: "./resources/test_example_test.go:123",
 		FileName: "./resources/test_example_test.go",
+		Labels:   []string{"flaky"},
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {


### PR DESCRIPTION
## Summary

- add `TestsService.List` for the versioned Test Engine List Tests endpoint
- expose pagination, time-window, filter, and sorting options
- model labels and aggregated reliability, duration, and execution metrics
- preserve nullable reliability and pagination links
- add request, response, error, and pagination coverage
- add a runnable List Tests example

## Verification

- `go test -timeout=3s ./...`
- `golangci-lint run`
- `git diff --check`

## PR checklist

- [x] tests added
- [x] List example added under `examples/tests/list`
- [x] changelog entry generated through the standard release process

## Deployment and rollback

This is an additive SDK change with no migrations. The List method always requests the dated `2026-08-01` response contract. Roll back by reverting this PR; existing `TestsService.Get` and `TestsService.Find` callers are unaffected.
