### PR TITLE
Add StepUploadsService for a build's dynamic pipeline uploads

### DIFF
--- a/buildkite.go
+++ b/buildkite.go
@@ -72,6 +72,7 @@ type Client struct {
 	PipelineTemplates            *PipelineTemplatesService
 	RateLimit                    *RateLimitService
 	Rules                        *RulesService
+	StepUploads                  *StepUploadsService
 	User                         *UserService
 	Teams                        *TeamsService
 	TeamMember                   *TeamMemberService
@@ -242,6 +243,7 @@ func (c *Client) populateDefaultServices() {
 	c.PipelineTemplates = &PipelineTemplatesService{c}
 	c.RateLimit = &RateLimitService{c}
 	c.Rules = &RulesService{c}
+	c.StepUploads = &StepUploadsService{c}
 	c.User = &UserService{c}
 	c.Teams = &TeamsService{c}
 	c.TeamMember = &TeamMemberService{c}

--- a/step_uploads.go
+++ b/step_uploads.go
@@ -27,28 +27,26 @@ type StepUploadsService struct {
 // The 'DefinitionXXXX' fields are only populated by Get: DefinitionYAML carries
 // the uploaded configuration re-rendered as YAML, unless the definition
 // exceeds the API's render limit, in which case DefinitionYAML is nil and
-// DefinitionYAMLOmitted is true. DefinitionStoredBytes is the compressed
-// stored size; DefinitionBytes (Get only) is the exact serialized size.
+// DefinitionYAMLOmitted is true. DefinitionBytes is the exact serialized
+// size of the stored definition.
 type StepUpload struct {
-	UUID                  string     `json:"uuid,omitempty"`
-	GraphQLID             string     `json:"graphql_id,omitempty"`
-	State                 string     `json:"state,omitempty"`
-	Source                string     `json:"source,omitempty"`
-	SourceJobID           string     `json:"source_job_id,omitempty"`
-	ReplaceExistingSteps  bool       `json:"replace_existing_steps"`
-	CreatedJobsCount      *int       `json:"created_jobs_count,omitempty"`
-	RejectionType         *string    `json:"rejection_type,omitempty"`
-	Message               *string    `json:"message,omitempty"`
-	URL                   string     `json:"url,omitempty"`
-	CreatedAt             *Timestamp `json:"created_at,omitempty"`
-	ProcessedAt           *Timestamp `json:"processed_at,omitempty"`
-	DefinitionStoredBytes int        `json:"definition_stored_bytes,omitempty"`
+	UUID                 string     `json:"uuid,omitempty"`
+	GraphQLID            string     `json:"graphql_id,omitempty"`
+	State                string     `json:"state,omitempty"`
+	Source               string     `json:"source,omitempty"`
+	SourceJobID          string     `json:"source_job_id,omitempty"`
+	ReplaceExistingSteps bool       `json:"replace_existing_steps"`
+	CreatedJobsCount     *int       `json:"created_jobs_count,omitempty"`
+	RejectionType        *string    `json:"rejection_type,omitempty"`
+	Message              *string    `json:"message,omitempty"`
+	URL                  string     `json:"url,omitempty"`
+	CreatedAt            *Timestamp `json:"created_at,omitempty"`
+	ProcessedAt          *Timestamp `json:"processed_at,omitempty"`
 
 	// Present on Get only.
-	CreatedJobUUIDs       []string `json:"created_job_uuids,omitempty"`
-	DefinitionBytes       *int     `json:"definition_bytes,omitempty"`
-	DefinitionYAML        *string  `json:"definition_yaml,omitempty"`
-	DefinitionYAMLOmitted *bool    `json:"definition_yaml_omitted,omitempty"`
+	DefinitionBytes       *int    `json:"definition_bytes,omitempty"`
+	DefinitionYAML        *string `json:"definition_yaml,omitempty"`
+	DefinitionYAMLOmitted *bool   `json:"definition_yaml_omitted,omitempty"`
 }
 
 // StepUploadsListOptions specifies the optional parameters to the

--- a/step_uploads.go
+++ b/step_uploads.go
@@ -1,0 +1,142 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// StepUploadsService handles communication with the step upload related
+// methods of the buildkite API. Step uploads are the dynamic pipeline
+// configurations uploaded by `buildkite-agent pipeline upload` while a
+// build runs.
+//
+// Step uploads retrieval are only available while the build is within its maximum
+// lifetime; older builds return 410 Gone.
+type StepUploadsService struct {
+	client *Client
+}
+
+// StepUpload represents one `buildkite-agent pipeline upload` performed
+// during a build.
+//
+// CreatedJobsCount is nil until the upload has been applied; 0 means the
+// upload was applied but created no jobs.
+//
+// The 'DefinitionXXXX' fields are only populated by Get: DefinitionYAML carries
+// the uploaded configuration re-rendered as YAML, unless the definition
+// exceeds the API's render limit, in which case DefinitionYAML is nil and
+// DefinitionYAMLOmitted is true. DefinitionStoredBytes is the compressed
+// stored size; DefinitionBytes (Get only) is the exact serialized size.
+type StepUpload struct {
+	UUID                  string     `json:"uuid,omitempty"`
+	GraphQLID             string     `json:"graphql_id,omitempty"`
+	State                 string     `json:"state,omitempty"`
+	Source                string     `json:"source,omitempty"`
+	SourceJobID           string     `json:"source_job_id,omitempty"`
+	ReplaceExistingSteps  bool       `json:"replace_existing_steps"`
+	CreatedJobsCount      *int       `json:"created_jobs_count,omitempty"`
+	RejectionType         *string    `json:"rejection_type,omitempty"`
+	Message               *string    `json:"message,omitempty"`
+	URL                   string     `json:"url,omitempty"`
+	CreatedAt             *Timestamp `json:"created_at,omitempty"`
+	ProcessedAt           *Timestamp `json:"processed_at,omitempty"`
+	DefinitionStoredBytes int        `json:"definition_stored_bytes,omitempty"`
+
+	// Present on Get only.
+	CreatedJobUUIDs       []string `json:"created_job_uuids,omitempty"`
+	DefinitionBytes       *int     `json:"definition_bytes,omitempty"`
+	DefinitionYAML        *string  `json:"definition_yaml,omitempty"`
+	DefinitionYAMLOmitted *bool    `json:"definition_yaml_omitted,omitempty"`
+}
+
+// StepUploadsListOptions specifies the optional parameters to the
+// StepUploadsService.ListByBuild method.
+type StepUploadsListOptions struct {
+	// SourceJobID filters to uploads performed by one job (a job UUID).
+	SourceJobID string `url:"filter[source_job_id],omitempty"`
+
+	PerPage int    `url:"per_page,omitempty"`
+	After   string `url:"after,omitempty"`
+	Before  string `url:"before,omitempty"`
+}
+
+type StepUploadsListLink string
+
+func (l StepUploadsListLink) ToOptions() (*StepUploadsListOptions, error) {
+	u, err := url.Parse(string(l))
+	if err != nil {
+		return nil, fmt.Errorf("parsing link: %w", err)
+	}
+
+	q := u.Query()
+
+	opts := &StepUploadsListOptions{
+		SourceJobID: q.Get("filter[source_job_id]"),
+		After:       q.Get("after"),
+		Before:      q.Get("before"),
+	}
+
+	if perPage := q.Get("per_page"); perPage != "" {
+		opts.PerPage, err = strconv.Atoi(perPage)
+		if err != nil {
+			return nil, fmt.Errorf("parsing per_page: %w", err)
+		}
+	}
+
+	return opts, nil
+}
+
+type StepUploadsListLinks struct {
+	First    StepUploadsListLink `json:"first,omitempty"`
+	Previous StepUploadsListLink `json:"prev,omitempty"`
+	Self     StepUploadsListLink `json:"self,omitempty"`
+	Next     StepUploadsListLink `json:"next,omitempty"`
+}
+
+type StepUploadsList struct {
+	Items []StepUpload         `json:"items"`
+	Links StepUploadsListLinks `json:"links"`
+}
+
+// ListByBuild lists a build's step uploads, newest first, without their
+// definitions.
+func (s *StepUploadsService) ListByBuild(ctx context.Context, org, pipeline, buildNumber string, opt *StepUploadsListOptions) (StepUploadsList, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/step-uploads", org, pipeline, buildNumber)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return StepUploadsList{}, nil, err
+	}
+
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return StepUploadsList{}, nil, err
+	}
+
+	var uploads StepUploadsList
+	resp, err := s.client.Do(req, &uploads)
+	if err != nil {
+		return StepUploadsList{}, resp, err
+	}
+
+	return uploads, resp, err
+}
+
+// Get returns a single step upload, including its uploaded definition
+// rendered as YAML (subject to the API's render limit — see StepUpload).
+func (s *StepUploadsService) Get(ctx context.Context, org, pipeline, buildNumber, uploadUUID string) (StepUpload, *Response, error) {
+	u := fmt.Sprintf("v2/organizations/%s/pipelines/%s/builds/%s/step-uploads/%s", org, pipeline, buildNumber, uploadUUID)
+	req, err := s.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return StepUpload{}, nil, err
+	}
+
+	var upload StepUpload
+	resp, err := s.client.Do(req, &upload)
+	if err != nil {
+		return StepUpload{}, resp, err
+	}
+
+	return upload, resp, err
+}

--- a/step_uploads_test.go
+++ b/step_uploads_test.go
@@ -37,8 +37,7 @@ func TestStepUploadsService_ListByBuild(t *testing.T) {
       "message": null,
       "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
       "created_at": "2026-08-01T04:00:00Z",
-      "processed_at": "2026-08-01T04:00:02Z",
-      "definition_stored_bytes": 1024
+      "processed_at": "2026-08-01T04:00:02Z"
     },
     {
       "uuid": "2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
@@ -51,8 +50,7 @@ func TestStepUploadsService_ListByBuild(t *testing.T) {
       "message": "The step upload was rejected. Check the pipeline upload command output for details.",
       "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
       "created_at": "2026-08-01T04:01:00Z",
-      "processed_at": "2026-08-01T04:01:02Z",
-      "definition_stored_bytes": 2048
+      "processed_at": "2026-08-01T04:01:02Z"
     }
   ],
   "links": {
@@ -78,30 +76,28 @@ func TestStepUploadsService_ListByBuild(t *testing.T) {
 	want := StepUploadsList{
 		Items: []StepUpload{
 			{
-				UUID:                  "1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
-				GraphQLID:             "QnVpbGRTdGVwVXBsb2Fk",
-				State:                 "applied",
-				Source:                "job",
-				SourceJobID:           "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
-				ReplaceExistingSteps:  false,
-				CreatedJobsCount:      &createdJobsCount,
-				URL:                   "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
-				CreatedAt:             NewTimestamp(time.Date(2026, 8, 1, 4, 0, 0, 0, time.UTC)),
-				ProcessedAt:           NewTimestamp(time.Date(2026, 8, 1, 4, 0, 2, 0, time.UTC)),
-				DefinitionStoredBytes: 1024,
+				UUID:                 "1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+				GraphQLID:            "QnVpbGRTdGVwVXBsb2Fk",
+				State:                "applied",
+				Source:               "job",
+				SourceJobID:          "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+				ReplaceExistingSteps: false,
+				CreatedJobsCount:     &createdJobsCount,
+				URL:                  "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+				CreatedAt:            NewTimestamp(time.Date(2026, 8, 1, 4, 0, 0, 0, time.UTC)),
+				ProcessedAt:          NewTimestamp(time.Date(2026, 8, 1, 4, 0, 2, 0, time.UTC)),
 			},
 			{
-				UUID:                  "2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
-				State:                 "rejected",
-				Source:                "job",
-				SourceJobID:           "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
-				ReplaceExistingSteps:  true,
-				RejectionType:         &rejectionType,
-				Message:               &message,
-				URL:                   "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
-				CreatedAt:             NewTimestamp(time.Date(2026, 8, 1, 4, 1, 0, 0, time.UTC)),
-				ProcessedAt:           NewTimestamp(time.Date(2026, 8, 1, 4, 1, 2, 0, time.UTC)),
-				DefinitionStoredBytes: 2048,
+				UUID:                 "2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
+				State:                "rejected",
+				Source:               "job",
+				SourceJobID:          "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+				ReplaceExistingSteps: true,
+				RejectionType:        &rejectionType,
+				Message:              &message,
+				URL:                  "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
+				CreatedAt:            NewTimestamp(time.Date(2026, 8, 1, 4, 1, 0, 0, time.UTC)),
+				ProcessedAt:          NewTimestamp(time.Date(2026, 8, 1, 4, 1, 2, 0, time.UTC)),
 			},
 		},
 		Links: StepUploadsListLinks{
@@ -135,8 +131,6 @@ func TestStepUploadsService_Get(t *testing.T) {
   "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
   "created_at": "2026-08-01T04:00:00Z",
   "processed_at": "2026-08-01T04:00:02Z",
-  "definition_stored_bytes": 1024,
-  "created_job_uuids": ["9d9d9d9d-9c3b-4b0a-8a51-b1e59a0e5b3a"],
   "definition_bytes": 4096,
   "definition_yaml": "steps:\n- command: echo hello\n",
   "definition_yaml_omitted": false
@@ -166,8 +160,6 @@ func TestStepUploadsService_Get(t *testing.T) {
 		URL:                   "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
 		CreatedAt:             NewTimestamp(time.Date(2026, 8, 1, 4, 0, 0, 0, time.UTC)),
 		ProcessedAt:           NewTimestamp(time.Date(2026, 8, 1, 4, 0, 2, 0, time.UTC)),
-		DefinitionStoredBytes: 1024,
-		CreatedJobUUIDs:       []string{"9d9d9d9d-9c3b-4b0a-8a51-b1e59a0e5b3a"},
 		DefinitionBytes:       &definitionBytes,
 		DefinitionYAML:        &definitionYAML,
 		DefinitionYAMLOmitted: &definitionYAMLOmitted,

--- a/step_uploads_test.go
+++ b/step_uploads_test.go
@@ -1,0 +1,211 @@
+package buildkite
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStepUploadsService_ListByBuild(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+
+		if got, want := r.URL.Query().Get("filter[source_job_id]"), "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba"; got != want {
+			t.Errorf("filter[source_job_id] query param = %q, want %q", got, want)
+		}
+
+		_, _ = fmt.Fprint(w, `{
+  "items": [
+    {
+      "uuid": "1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+      "graphql_id": "QnVpbGRTdGVwVXBsb2Fk",
+      "state": "applied",
+      "source": "job",
+      "source_job_id": "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+      "replace_existing_steps": false,
+      "created_jobs_count": 2,
+      "rejection_type": null,
+      "message": null,
+      "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+      "created_at": "2026-08-01T04:00:00Z",
+      "processed_at": "2026-08-01T04:00:02Z",
+      "definition_stored_bytes": 1024
+    },
+    {
+      "uuid": "2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
+      "state": "rejected",
+      "source": "job",
+      "source_job_id": "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+      "replace_existing_steps": true,
+      "created_jobs_count": null,
+      "rejection_type": "validation_error",
+      "message": "The step upload was rejected. Check the pipeline upload command output for details.",
+      "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
+      "created_at": "2026-08-01T04:01:00Z",
+      "processed_at": "2026-08-01T04:01:02Z",
+      "definition_stored_bytes": 2048
+    }
+  ],
+  "links": {
+    "self": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads?filter[source_job_id]=48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+    "next": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads?after=abc123&filter[source_job_id]=48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba&per_page=2"
+  }
+}`)
+	})
+
+	uploads, _, err := client.StepUploads.ListByBuild(
+		context.Background(),
+		"my-great-org", "sup-keith", "123",
+		&StepUploadsListOptions{SourceJobID: "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba"},
+	)
+	if err != nil {
+		t.Errorf("StepUploads.ListByBuild returned error: %v", err)
+	}
+
+	createdJobsCount := 2
+	rejectionType := "validation_error"
+	message := "The step upload was rejected. Check the pipeline upload command output for details."
+
+	want := StepUploadsList{
+		Items: []StepUpload{
+			{
+				UUID:                  "1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+				GraphQLID:             "QnVpbGRTdGVwVXBsb2Fk",
+				State:                 "applied",
+				Source:                "job",
+				SourceJobID:           "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+				ReplaceExistingSteps:  false,
+				CreatedJobsCount:      &createdJobsCount,
+				URL:                   "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+				CreatedAt:             NewTimestamp(time.Date(2026, 8, 1, 4, 0, 0, 0, time.UTC)),
+				ProcessedAt:           NewTimestamp(time.Date(2026, 8, 1, 4, 0, 2, 0, time.UTC)),
+				DefinitionStoredBytes: 1024,
+			},
+			{
+				UUID:                  "2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
+				State:                 "rejected",
+				Source:                "job",
+				SourceJobID:           "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+				ReplaceExistingSteps:  true,
+				RejectionType:         &rejectionType,
+				Message:               &message,
+				URL:                   "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/2e2e2e2e-1234-4b0a-8a51-b1e59a0e5b3a",
+				CreatedAt:             NewTimestamp(time.Date(2026, 8, 1, 4, 1, 0, 0, time.UTC)),
+				ProcessedAt:           NewTimestamp(time.Date(2026, 8, 1, 4, 1, 2, 0, time.UTC)),
+				DefinitionStoredBytes: 2048,
+			},
+		},
+		Links: StepUploadsListLinks{
+			Self: "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads?filter[source_job_id]=48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+			Next: "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads?after=abc123&filter[source_job_id]=48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba&per_page=2",
+		},
+	}
+
+	if diff := cmp.Diff(uploads, want); diff != "" {
+		t.Errorf("StepUploads.ListByBuild diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestStepUploadsService_Get(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		_, _ = fmt.Fprint(w, `{
+  "uuid": "1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+  "state": "applied",
+  "source": "job",
+  "source_job_id": "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+  "replace_existing_steps": false,
+  "created_jobs_count": 1,
+  "rejection_type": null,
+  "message": null,
+  "url": "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+  "created_at": "2026-08-01T04:00:00Z",
+  "processed_at": "2026-08-01T04:00:02Z",
+  "definition_stored_bytes": 1024,
+  "created_job_uuids": ["9d9d9d9d-9c3b-4b0a-8a51-b1e59a0e5b3a"],
+  "definition_bytes": 4096,
+  "definition_yaml": "steps:\n- command: echo hello\n",
+  "definition_yaml_omitted": false
+}`)
+	})
+
+	upload, _, err := client.StepUploads.Get(
+		context.Background(),
+		"my-great-org", "sup-keith", "123", "1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+	)
+	if err != nil {
+		t.Errorf("StepUploads.Get returned error: %v", err)
+	}
+
+	createdJobsCount := 1
+	definitionBytes := 4096
+	definitionYAML := "steps:\n- command: echo hello\n"
+	definitionYAMLOmitted := false
+
+	want := StepUpload{
+		UUID:                  "1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+		State:                 "applied",
+		Source:                "job",
+		SourceJobID:           "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+		ReplaceExistingSteps:  false,
+		CreatedJobsCount:      &createdJobsCount,
+		URL:                   "https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads/1f1f1f1f-9c3b-4b0a-8a51-b1e59a0e5b3a",
+		CreatedAt:             NewTimestamp(time.Date(2026, 8, 1, 4, 0, 0, 0, time.UTC)),
+		ProcessedAt:           NewTimestamp(time.Date(2026, 8, 1, 4, 0, 2, 0, time.UTC)),
+		DefinitionStoredBytes: 1024,
+		CreatedJobUUIDs:       []string{"9d9d9d9d-9c3b-4b0a-8a51-b1e59a0e5b3a"},
+		DefinitionBytes:       &definitionBytes,
+		DefinitionYAML:        &definitionYAML,
+		DefinitionYAMLOmitted: &definitionYAMLOmitted,
+	}
+
+	if diff := cmp.Diff(upload, want); diff != "" {
+		t.Errorf("StepUploads.Get diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestStepUploadsListLink_ToOptions(t *testing.T) {
+	t.Parallel()
+
+	link := StepUploadsListLink("https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads?after=abc123&filter[source_job_id]=48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba&per_page=2")
+
+	opts, err := link.ToOptions()
+	if err != nil {
+		t.Fatalf("ToOptions returned error: %v", err)
+	}
+
+	want := &StepUploadsListOptions{
+		SourceJobID: "48af33d8-2d4f-4f19-9a1c-e358c1e0f5ba",
+		After:       "abc123",
+		PerPage:     2,
+	}
+
+	if diff := cmp.Diff(opts, want); diff != "" {
+		t.Errorf("ToOptions diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestStepUploadsListLink_ToOptions_InvalidPerPage(t *testing.T) {
+	t.Parallel()
+
+	link := StepUploadsListLink("https://api.buildkite.com/v2/organizations/my-great-org/pipelines/sup-keith/builds/123/step-uploads?per_page=abc")
+
+	_, err := link.ToOptions()
+	if err == nil {
+		t.Fatal("ToOptions expected an error for per_page=abc, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `StepUploadsService` mapping the step uploads REST endpoints introduced by buildkite/buildkite#32190 — the dynamic pipeline configurations uploaded by `buildkite-agent pipeline upload` while a build runs:

- `ListByBuild(ctx, org, pipeline, buildNumber, opts)` — cursor-paginated `{items, links}` list (newest first, no definitions), filterable by the uploading job via `filter[source_job_id]`. Mirrors `JobsService.ListByBuild`, including a `StepUploadsListLink.ToOptions` helper for following `links.next`/`links.prev`.
- `Get(ctx, org, pipeline, buildNumber, uploadUUID)` — a single upload including `DefinitionYAML`. When the definition exceeds the API's render limit, `DefinitionYAML` is nil and `DefinitionYAMLOmitted` is true; `DefinitionBytes`/`DefinitionStoredBytes` still report sizes.

Semantics preserved from the API:
- `CreatedJobsCount` is `*int`: nil = not yet applied (pending/processing/rejected/failed), 0 = applied and created no jobs, N = created N jobs.
- Step uploads are only queryable while the build is within its maximum lifetime; older builds return `410 Gone` (surfaced as a regular `ErrorResponse`).

## Context

- Linear: [PB-2749 — Expose the steps upload / dynamic pipeline API as buildkite-mcp-server tool](https://linear.app/buildkite/issue/PB-2749/expose-the-steps-upload-dynamic-pipeline-api-as-buildkite-mcp-server)
- REST endpoints: buildkite/buildkite#32190 (PB-2648)

## Status

**Draft until buildkite/buildkite#32190 merges** — this encodes that PR's response contract; field names will be re-checked against the final merged shape before marking ready.

## Motivation

First consumer is buildkite-mcp-server: `list_step_uploads` / `get_step_upload` tools so MCP agents can introspect dynamically generated pipelines.

## Testing

- `go test -run StepUploads` — List (incl. filter query assertion and null-field item), Get (definition fields), `ToOptions` happy path and invalid `per_page` error branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)