### PR TITLE
Align build tests client with updated API

### DIFF
--- a/build_tests.go
+++ b/build_tests.go
@@ -13,69 +13,51 @@ type BuildTestsService struct {
 	client *Client
 }
 
-type BuildTest struct {
-	ID                      string                   `json:"id,omitempty"`
-	Scope                   string                   `json:"scope,omitempty"`
-	Name                    string                   `json:"name,omitempty"`
-	Location                string                   `json:"location,omitempty"`
-	State                   string                   `json:"state,omitempty"`
-	Labels                  []TestLabel              `json:"labels,omitempty"`
-	ExecutionsCount         int                      `json:"executions_count,omitempty"`
-	ExecutionsCountByResult BuildTestExecutionsCount `json:"executions_count_by_result"`
-	Reliability             float64                  `json:"reliability"`
-	// Executions is only populated when Include is set to "executions".
-	Executions []BuildTestExecution `json:"executions,omitempty"`
-	LatestFail *BuildTestLatestFail `json:"latest_fail,omitempty"`
-}
-
-type TestLabel struct {
-	Name  string `json:"name,omitempty"`
-	Color string `json:"color,omitempty"`
-}
-
-type BuildTestExecutionsCount struct {
-	Passed  int `json:"passed"`
-	Failed  int `json:"failed"`
-	Skipped int `json:"skipped,omitempty"`
-	Pending int `json:"pending,omitempty"`
-	Unknown int `json:"unknown,omitempty"`
-}
-
-type BuildTestLatestFail struct {
-	ID              string            `json:"id,omitempty"`
-	Timestamp       *Timestamp        `json:"timestamp,omitempty"`
-	Duration        float64           `json:"duration"`
-	FailureReason   string            `json:"failure_reason,omitempty"`
-	FailureExpanded []FailureExpanded `json:"failure_expanded,omitempty"`
-}
-
-type BuildTestExecution struct {
-	ID              string            `json:"id,omitempty"`
-	Status          string            `json:"status,omitempty"`
-	Timestamp       *Timestamp        `json:"timestamp,omitempty"`
-	Duration        float64           `json:"duration"`
-	Location        string            `json:"location,omitempty"`
-	FailureReason   string            `json:"failure_reason,omitempty"`
-	FailureExpanded []FailureExpanded `json:"failure_expanded,omitempty"`
-}
-
+// BuildTestsListOptions specifies optional parameters for
+// [BuildTestsService.List]. Invalid values and incompatible combinations are
+// validated by the API.
 type BuildTestsListOptions struct {
 	ListOptions
 
-	// Result filters by execution result.
-	// "failed" = has any failed execution, "^failed" = all executions failed.
-	// Same for "passed" / "^passed".
-	Result string `url:"result,omitempty"`
+	// Labels filters by comma-separated test labels. Prefix a label with "!" to
+	// exclude it, for example "flaky,!slow".
+	Labels string `url:"labels,omitempty"`
 
-	// State filters by test state: "enabled", "muted", etc.
+	// Branch filters the executions included in the metrics. Prefix the value
+	// with "!" to exclude an exact branch, or suffix it with "*" to match
+	// branches by prefix; for example "!main" or "feature*". Use at most one
+	// operator.
+	Branch string `url:"branch,omitempty"`
+
+	// Owners filters by comma-separated test owner slugs. Prefix an owner with
+	// "!" to exclude it, for example "payments,!platform".
+	Owners string `url:"owners,omitempty"`
+
+	// State filters by test state: "enabled", "muted", or "skipped".
 	State string `url:"state,omitempty"`
 
-	// Include set to "latest_fail" inlines the most recent failed execution per test.
-	// Include set to "executions" inlines the executions matching the current filter.
-	Include string `url:"include,omitempty"`
+	// Tags filters by comma-separated execution tags in key:value form. Prefix a
+	// value with "!" to exclude an exact value, or suffix it with "*" to match
+	// by prefix. For the result tag, prefix the value with "~" to return tests
+	// with at least one execution in the build having that result, or "^" to
+	// return tests for which every execution has that result. A build.id filter
+	// cannot override the buildUUID argument; for example
+	// "framework:!rspec,scm.branch:feature*,result:^passed".
+	Tags string `url:"tags,omitempty"`
+
+	// SortBy specifies the metric used to sort results: "duration_avg",
+	// "duration_sum", "duration_min", "duration_max", or "reliability". It
+	// defaults to "duration_avg".
+	SortBy string `url:"sort_by,omitempty"`
+
+	// Order specifies the sort direction: "asc" or "desc". It defaults to
+	// "desc".
+	Order string `url:"order,omitempty"`
 }
 
-func (bts *BuildTestsService) List(ctx context.Context, org, buildUUID string, opt *BuildTestsListOptions) ([]BuildTest, *Response, error) {
+// List returns tests with execution metrics aggregated over the build's time
+// window. Pagination is available through the returned Response.
+func (bts *BuildTestsService) List(ctx context.Context, org, buildUUID string, opt *BuildTestsListOptions) ([]TestWithMetrics, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/builds/%s/tests", org, buildUUID)
 	u, err := addOptions(u, opt)
 	if err != nil {
@@ -87,7 +69,7 @@ func (bts *BuildTestsService) List(ctx context.Context, org, buildUUID string, o
 		return nil, nil, err
 	}
 
-	var buildTests []BuildTest
+	var buildTests []TestWithMetrics
 	resp, err := bts.client.Do(req, &buildTests)
 	if err != nil {
 		return nil, resp, err

--- a/build_tests_test.go
+++ b/build_tests_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -18,202 +17,101 @@ func TestBuildTestsService_List(t *testing.T) {
 	server, client, teardown := newMockServerAndClient(t)
 	t.Cleanup(teardown)
 
+	const linkHeader = `<https://api.buildkite.com/v2/analytics/organizations/my-great-org/builds/019d66fb-e8db-47eb-866c-94b85d42b9a1/tests?page=3>; rel="next", <https://api.buildkite.com/v2/analytics/organizations/my-great-org/builds/019d66fb-e8db-47eb-866c-94b85d42b9a1/tests?page=4>; rel="last"`
+
 	server.HandleFunc(fmt.Sprintf("/v2/analytics/organizations/my-great-org/builds/%s/tests", testBuildUUID), func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		if got := r.URL.Query().Get("include"); got != "" {
-			t.Errorf("query param include = %q, want empty", got)
-		}
+		testFormValues(t, r, values{
+			"page":     "2",
+			"per_page": "50",
+			"labels":   "flaky,!slow",
+			"branch":   "main*",
+			"owners":   "payments,!platform",
+			"state":    "enabled",
+			"tags":     "framework:rspec,result:^failed",
+			"sort_by":  "reliability",
+			"order":    "asc",
+		})
+
+		w.Header().Set("Link", linkHeader)
 		_, _ = fmt.Fprint(w,
 			`
 			[
 				{
 					"id": "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+					"url": "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+					"web_url": "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/tests/a915535c-a8f1-4e1a-bd6a-a5589e09f349",
 					"scope": "User#email",
-					"name": "TestExample1_Create",
-					"location": "./spec/models/text_example.rb:55",
-					"state": "enabled",
-					"labels": [{"name": "slow", "color": "#ff0000"}],
-					"executions_count": 5,
+					"name": "is correctly formatted",
+					"location": "./spec/models/user_spec.rb:42",
+					"file_name": "./spec/models/user_spec.rb",
+					"labels": ["flaky"],
+					"reliability": 0.9821,
+					"duration_avg": 0.213,
+					"duration_sum": 23.856,
+					"duration_min": 0.108,
+					"duration_max": 1.942,
+					"executions_count": 113,
 					"executions_count_by_result": {
-						"passed": 3,
-						"failed": 2
-					},
-					"reliability": 60.0,
-					"latest_fail": {
-						"id": "exec-001",
-						"timestamp": "2023-07-10T13:14:03.214Z",
-						"duration": 1.234,
-						"failure_reason": "Expected true got false",
-						"failure_expanded": [
-							{
-								"expanded": ["line 1", "line 2"]
-							}
-						]
+						"passed": 110,
+						"failed": 2,
+						"skipped": 1
 					}
-				},
-				{
-					"id": "01867216-8478-7fde-a55a-0300f88bb49b",
-					"scope": "User#email",
-					"name": "TestExample1_Delete",
-					"location": "./spec/models/text_example.rb:102",
-					"state": "muted",
-					"labels": [],
-					"executions_count": 3,
-					"executions_count_by_result": {
-						"passed": 3,
-						"failed": 0
-					},
-					"reliability": 100.0
 				}
 			]`)
 	})
 
-	buildTests, _, err := client.BuildTests.List(context.Background(), "my-great-org", testBuildUUID, nil)
-	if err != nil {
-		t.Errorf("BuildTests.List returned error: %v", err)
-	}
-
-	parsedTime := must(time.Parse(BuildKiteDateFormat, "2023-07-10T13:14:03.214Z"))
-
-	want := []BuildTest{
-		{
-			ID:              "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
-			Scope:           "User#email",
-			Name:            "TestExample1_Create",
-			Location:        "./spec/models/text_example.rb:55",
-			State:           "enabled",
-			Labels:          []TestLabel{{Name: "slow", Color: "#ff0000"}},
-			ExecutionsCount: 5,
-			ExecutionsCountByResult: BuildTestExecutionsCount{
-				Passed: 3,
-				Failed: 2,
-			},
-			Reliability: 60.0,
-			LatestFail: &BuildTestLatestFail{
-				ID:            "exec-001",
-				Timestamp:     NewTimestamp(parsedTime),
-				Duration:      1.234,
-				FailureReason: "Expected true got false",
-				FailureExpanded: []FailureExpanded{
-					{Expanded: []string{"line 1", "line 2"}},
-				},
-			},
-		},
-		{
-			ID:              "01867216-8478-7fde-a55a-0300f88bb49b",
-			Scope:           "User#email",
-			Name:            "TestExample1_Delete",
-			Location:        "./spec/models/text_example.rb:102",
-			State:           "muted",
-			Labels:          []TestLabel{},
-			ExecutionsCount: 3,
-			ExecutionsCountByResult: BuildTestExecutionsCount{
-				Passed: 3,
-				Failed: 0,
-			},
-			Reliability: 100.0,
-		},
-	}
-
-	if diff := cmp.Diff(buildTests, want); diff != "" {
-		t.Errorf("BuildTests.List diff: (-got +want)\n%s", diff)
-	}
-}
-
-func TestBuildTestsService_List_WithExecutionsIncluded(t *testing.T) {
-	t.Parallel()
-
-	server, client, teardown := newMockServerAndClient(t)
-	t.Cleanup(teardown)
-
-	server.HandleFunc(fmt.Sprintf("/v2/analytics/organizations/my-great-org/builds/%s/tests", testBuildUUID), func(w http.ResponseWriter, r *http.Request) {
-		testMethod(t, r, "GET")
-
-		if got, want := r.URL.Query().Get("result"), "^failed"; got != want {
-			t.Errorf("query param result = %q, want %q", got, want)
-		}
-		if got, want := r.URL.Query().Get("state"), "enabled"; got != want {
-			t.Errorf("query param state = %q, want %q", got, want)
-		}
-		if got, want := r.URL.Query().Get("include"), "executions"; got != want {
-			t.Errorf("query param include = %q, want %q", got, want)
-		}
-
-		_, _ = fmt.Fprint(w, `[
-			{
-				"id": "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
-				"scope": "User#email",
-				"name": "TestExample1_Create",
-				"location": "./spec/models/text_example.rb:55",
-				"state": "enabled",
-				"executions_count": 1,
-				"executions_count_by_result": {
-					"passed": 0,
-					"failed": 1
-				},
-				"reliability": 0.0,
-				"executions": [
-					{
-						"id": "exec-001",
-						"status": "failed",
-						"timestamp": "2023-07-10T13:14:03.214Z",
-						"duration": 1.234,
-						"location": "./spec/models/text_example.rb:55",
-						"failure_reason": "Expected true got false",
-						"failure_expanded": [
-							{
-								"expanded": ["line 1", "line 2"]
-							}
-						]
-					}
-				]
-			}
-		]`)
+	reliability := 0.9821
+	got, resp, err := client.BuildTests.List(context.Background(), "my-great-org", testBuildUUID, &BuildTestsListOptions{
+		ListOptions: ListOptions{Page: 2, PerPage: 50},
+		Labels:      "flaky,!slow",
+		Branch:      "main*",
+		Owners:      "payments,!platform",
+		State:       "enabled",
+		Tags:        "framework:rspec,result:^failed",
+		SortBy:      "reliability",
+		Order:       "asc",
 	})
-
-	opts := &BuildTestsListOptions{
-		Result:  "^failed",
-		State:   "enabled",
-		Include: "executions",
-	}
-
-	parsedTime := must(time.Parse(BuildKiteDateFormat, "2023-07-10T13:14:03.214Z"))
-
-	buildTests, _, err := client.BuildTests.List(context.Background(), "my-great-org", testBuildUUID, opts)
 	if err != nil {
-		t.Errorf("BuildTests.List returned error: %v", err)
+		t.Fatalf("BuildTests.List returned error: %v", err)
 	}
 
-	want := []BuildTest{
+	want := []TestWithMetrics{
 		{
-			ID:              "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
-			Scope:           "User#email",
-			Name:            "TestExample1_Create",
-			Location:        "./spec/models/text_example.rb:55",
-			State:           "enabled",
-			ExecutionsCount: 1,
-			ExecutionsCountByResult: BuildTestExecutionsCount{
-				Passed: 0,
-				Failed: 1,
+			Test: Test{
+				ID:       "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+				URL:      "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+				WebURL:   "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/tests/a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+				Scope:    "User#email",
+				Name:     "is correctly formatted",
+				Location: "./spec/models/user_spec.rb:42",
+				FileName: "./spec/models/user_spec.rb",
+				Labels:   []string{"flaky"},
 			},
-			Reliability: 0.0,
-			Executions: []BuildTestExecution{
-				{
-					ID:            "exec-001",
-					Status:        "failed",
-					Timestamp:     NewTimestamp(parsedTime),
-					Duration:      1.234,
-					Location:      "./spec/models/text_example.rb:55",
-					FailureReason: "Expected true got false",
-					FailureExpanded: []FailureExpanded{
-						{Expanded: []string{"line 1", "line 2"}},
-					},
-				},
+			Reliability:     &reliability,
+			DurationAverage: 0.213,
+			DurationTotal:   23.856,
+			DurationMinimum: 0.108,
+			DurationMaximum: 1.942,
+			ExecutionsCount: 113,
+			ExecutionsCountByResult: map[string]int{
+				"passed":  110,
+				"failed":  2,
+				"skipped": 1,
 			},
 		},
 	}
 
-	if diff := cmp.Diff(buildTests, want); diff != "" {
+	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("BuildTests.List diff: (-got +want)\n%s", diff)
+	}
+	if got, want := resp.NextPage, 3; got != want {
+		t.Errorf("response.NextPage = %d, want %d", got, want)
+	}
+	if got, want := resp.LastPage, 4; got != want {
+		t.Errorf("response.LastPage = %d, want %d", got, want)
+	}
+	if got := resp.Header.Get("Link"); got != linkHeader {
+		t.Errorf("response Link header = %q, want %q", got, linkHeader)
 	}
 }

--- a/examples/build_tests/list/main.go
+++ b/examples/build_tests/list/main.go
@@ -15,7 +15,7 @@ var (
 	apiToken  = kingpin.Flag("token", "Buildkite API token").Envar("BUILDKITE_API_TOKEN").Required().String()
 	org       = kingpin.Flag("org", "Organization slug").Required().String()
 	buildUUID = kingpin.Flag("build-id", "Build UUID").Required().String()
-	result    = kingpin.Flag("result", "Filter by execution result, for example failed, ^failed, passed, or ^passed.").String()
+	tags      = kingpin.Flag("tags", "Filter by execution tags, for example result:~failed or result:^failed.").String()
 	state     = kingpin.Flag("state", "Filter by test state, for example enabled or muted.").String()
 )
 
@@ -28,9 +28,8 @@ func main() {
 	}
 
 	opts := &buildkite.BuildTestsListOptions{
-		Result:  *result,
-		State:   *state,
-		Include: "executions",
+		Tags:  *tags,
+		State: *state,
 	}
 
 	buildTests, _, err := client.BuildTests.List(context.Background(), *org, *buildUUID, opts)

--- a/tests.go
+++ b/tests.go
@@ -29,7 +29,7 @@ type Test struct {
 }
 
 // TestWithMetrics represents a test and its execution metrics aggregated over
-// the time window requested from [TestsService.List].
+// the time window used by [TestsService.List] or [BuildTestsService.List].
 type TestWithMetrics struct {
 	Test
 


### PR DESCRIPTION
## Description

Aligns `BuildTestsService.List` with the updated build tests API, which now returns the same test metrics shape as suite test listing and supports the standard Test Engine filters.

## Context

[TE-6671](https://linear.app/buildkite/issue/TE-6671/update-go-buildkite-with-new-build-tests-structure)

## Changes

- return `TestWithMetrics` results from build test listing
- replace the old `result` and `include` options with labels, branch, owners, tags, sorting, and pagination filters
- remove response models that are no longer returned by the endpoint
- update request/response coverage and the list example

## Compatibility

This changes exported Go types and options. The endpoint has remained disabled behind a feature flag, so this won't need to be treated as a breaking change

## Verification

- `go test ./...`
- `go vet ./...`

## Rollback

Revert this PR to restore the previous client contract. The endpoint remains feature-flagged, so no server-side migration or data rollback is required.
