### PR TITLE
Add JobStateCounts to Build

### DIFF
--- a/builds.go
+++ b/builds.go
@@ -97,6 +97,13 @@ type TestEngineProperty struct {
 	Runs []TestEngineRun `json:"runs,omitempty"`
 }
 
+// JobStateCounts is a tally of a build's jobs grouped by state, as returned
+// by the get-build API endpoint.
+type JobStateCounts struct {
+	Total  int            `json:"total"`
+	States map[string]int `json:"states,omitempty"`
+}
+
 // Build represents a build which has run in buildkite
 type Build struct {
 	ID          string            `json:"id,omitempty"`
@@ -136,6 +143,10 @@ type Build struct {
 	TriggeredFrom *TriggeredFrom `json:"triggered_from,omitempty"`
 
 	TestEngine *TestEngineProperty `json:"test_engine,omitempty"`
+
+	// every job in the build counted by state, regardless of any job filters
+	// applied to the request; nil when the API omits it
+	JobStateCounts *JobStateCounts `json:"job_state_counts,omitempty"`
 }
 
 type MetaDataFilters struct {

--- a/builds_test.go
+++ b/builds_test.go
@@ -172,6 +172,35 @@ func TestBuildsService_Get(t *testing.T) {
 		}
 	})
 
+	t.Run("returns job state counts", func(t *testing.T) {
+		t.Parallel()
+
+		server, client, teardown := newMockServerAndClient(t)
+		t.Cleanup(teardown)
+
+		server.HandleFunc(requestSlug,
+			func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				_, _ = fmt.Fprintf(w, `{"id":"%s", "job_state_counts": {"total": 4, "states": {"passed": 2, "failed": 1, "running": 1}}}`, buildNumber)
+			})
+
+		build, _, err := client.Builds.Get(context.Background(), orgName, pipelineName, buildNumber, nil)
+		if err != nil {
+			t.Errorf("Builds.Get (job state counts) returned error: %v", err)
+		}
+
+		want := Build{
+			ID: buildNumber,
+			JobStateCounts: &JobStateCounts{
+				Total:  4,
+				States: map[string]int{"passed": 2, "failed": 1, "running": 1},
+			},
+		}
+		if diff := cmp.Diff(build, want); diff != "" {
+			t.Errorf("Builds.Get (job state counts) diff: (-got +want)\n%s", diff)
+		}
+	})
+
 	t.Run("includes test engine data when option is set", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
### Description

The get-build API endpoint now returns a `job_state_counts` property (buildkite/buildkite#32263):

```json
"job_state_counts": { "total": 4, "states": { "passed": 2, "failed": 1, "running": 1 } }
```

It tallies every job in the build by state, regardless of any job filters applied to the request, so consumers can confirm a build's problem jobs are complete without a follow-up jobs listing. This PR decodes it into a new `Build.JobStateCounts` field (`*JobStateCounts`, nil when the API omits the property — it is only returned by builds#show).

First consumer: buildkite-mcp-server's `get_build_failure_summary` (PB-2566), which will propagate the counts once this ships.

### Changes

- `builds.go`: new `JobStateCounts` type (`total` + per-state `states` map); `Build.JobStateCounts *JobStateCounts` decoded from `job_state_counts`.
- `builds_test.go`: `TestBuildsService_Get` subtest decoding the property.

Additive only — no behavior change for existing fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)