### PR TITLE
Support min_executions when listing tests

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -76,6 +76,10 @@ type TestsListOptions struct {
 	// current time when omitted.
 	MaxTimestamp time.Time `url:"max_timestamp,omitempty"`
 
+	// MinExecutions filters out tests with fewer than this number of executions
+	// in the aggregation window.
+	MinExecutions int `url:"min_executions,omitempty"`
+
 	// Labels filters by comma-separated test labels. Prefix a label with "!" to
 	// exclude it, for example "flaky,!slow".
 	Labels string `url:"labels,omitempty"`

--- a/tests_test.go
+++ b/tests_test.go
@@ -26,17 +26,18 @@ func TestTestsService_List(t *testing.T) {
 			t.Errorf("Buildkite-Version header = %q, want %q", got, want)
 		}
 		testFormValues(t, r, values{
-			"page":          "2",
-			"per_page":      "50",
-			"min_timestamp": "2026-07-01T00:00:00Z",
-			"max_timestamp": "2026-07-23T00:00:00Z",
-			"labels":        "flaky,!slow",
-			"branch":        "main*",
-			"owners":        "payments,!platform",
-			"state":         "enabled",
-			"tags":          "framework:rspec,result:^failed",
-			"sort_by":       "reliability",
-			"order":         "asc",
+			"page":           "2",
+			"per_page":       "50",
+			"min_timestamp":  "2026-07-01T00:00:00Z",
+			"max_timestamp":  "2026-07-23T00:00:00Z",
+			"min_executions": "10",
+			"labels":         "flaky,!slow",
+			"branch":         "main*",
+			"owners":         "payments,!platform",
+			"state":          "enabled",
+			"tags":           "framework:rspec,result:^failed",
+			"sort_by":        "reliability",
+			"order":          "asc",
 		})
 
 		w.Header().Set("Link", linkHeader)
@@ -71,14 +72,15 @@ func TestTestsService_List(t *testing.T) {
 		MinTimestamp: time.Date(
 			2026, time.July, 1, 0, 0, 0, 0, time.UTC,
 		),
-		MaxTimestamp: time.Date(2026, time.July, 23, 0, 0, 0, 0, time.UTC),
-		Labels:       "flaky,!slow",
-		Branch:       "main*",
-		Owners:       "payments,!platform",
-		State:        "enabled",
-		Tags:         "framework:rspec,result:^failed",
-		SortBy:       "reliability",
-		Order:        "asc",
+		MaxTimestamp:  time.Date(2026, time.July, 23, 0, 0, 0, 0, time.UTC),
+		MinExecutions: 10,
+		Labels:        "flaky,!slow",
+		Branch:        "main*",
+		Owners:        "payments,!platform",
+		State:         "enabled",
+		Tags:          "framework:rspec,result:^failed",
+		SortBy:        "reliability",
+		Order:         "asc",
 	})
 	if err != nil {
 		t.Fatalf("TestsService.List returned error: %v", err)


### PR DESCRIPTION
## Description

Expose the Test Engine API's `min_executions` query parameter through `TestsListOptions`.

- add `MinExecutions` to `TestsListOptions`
- verify it is encoded as `min_executions` in list requests

## Context 

[TE-6729](https://linear.app/buildkite/issue/TE-6729/support-min-executions-when-listing-test-in-go-buildkite)

## Verification

- `mise exec -- go test ./...`

## Rollback

Revert this PR. The change only adds an optional request parameter and its test coverage.
