### PR TITLE
Return test metrics from TestsService.Get

### DIFF
--- a/examples/tests/get/main.go
+++ b/examples/tests/get/main.go
@@ -16,6 +16,7 @@ var (
 	org      = kingpin.Flag("org", "Organization slug").Required().String()
 	slug     = kingpin.Flag("slug", "Test suite slug").Required().String()
 	testID   = kingpin.Flag("testID", "Test ID").Required().String()
+	period   = kingpin.Flag("period", "Relative aggregation window for metrics").Default("7days").String()
 )
 
 func main() {
@@ -26,7 +27,9 @@ func main() {
 		log.Fatalf("creating buildkite API client failed: %v", err)
 	}
 
-	test, _, err := client.Tests.Get(context.Background(), *org, *slug, *testID)
+	test, _, err := client.Tests.Get(context.Background(), *org, *slug, *testID, &buildkite.TestsGetOptions{
+		Period: *period,
+	})
 	if err != nil {
 		log.Fatalf("Getting test %s failed: %s", *testID, err)
 	}

--- a/tests.go
+++ b/tests.go
@@ -14,7 +14,9 @@ type TestsService struct {
 	client *Client
 }
 
-const testsListAPIVersion = "2026-08-01"
+// testsMetricsAPIVersion opts requests in to the versioned response that
+// includes test execution metrics.
+const testsMetricsAPIVersion = "2026-08-01"
 
 // Test represents a test in a Buildkite Test Engine suite.
 type Test struct {
@@ -29,7 +31,8 @@ type Test struct {
 }
 
 // TestWithMetrics represents a test and its execution metrics aggregated over
-// the time window used by [TestsService.List] or [BuildTestsService.List].
+// the time window used by [TestsService.List], [TestsService.Get], or
+// [BuildTestsService.List].
 type TestWithMetrics struct {
 	Test
 
@@ -133,7 +136,7 @@ func (ts *TestsService) List(ctx context.Context, org, slug string, opt *TestsLi
 	if err != nil {
 		return nil, nil, err
 	}
-	req.Header.Set("Buildkite-Version", testsListAPIVersion)
+	req.Header.Set("Buildkite-Version", testsMetricsAPIVersion)
 
 	var tests []TestWithMetrics
 	resp, err := ts.client.Do(req, &tests)
@@ -144,17 +147,42 @@ func (ts *TestsService) List(ctx context.Context, org, slug string, opt *TestsLi
 	return tests, resp, err
 }
 
-func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (Test, *Response, error) {
+// TestsGetOptions specifies optional parameters for [TestsService.Get].
+// Invalid values and incompatible combinations are validated by the API.
+type TestsGetOptions struct {
+	// Period sets a relative aggregation window, such as "7days" or "28days".
+	// Available periods depend on the organization's maximum time window. Period
+	// cannot be combined with MinTimestamp or MaxTimestamp.
+	Period string `url:"period,omitempty"`
+
+	// MinTimestamp sets the start of the aggregation window. When omitted, it
+	// defaults to the organization's default period before the current time.
+	MinTimestamp time.Time `url:"min_timestamp,omitempty"`
+
+	// MaxTimestamp sets the end of the aggregation window. It defaults to the
+	// current time when omitted.
+	MaxTimestamp time.Time `url:"max_timestamp,omitempty"`
+}
+
+// Get returns a single test with its execution metrics aggregated over the
+// requested time window. It opts in to the versioned metrics response.
+func (ts *TestsService) Get(ctx context.Context, org, slug, testID string, opt *TestsGetOptions) (TestWithMetrics, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/%s", org, slug, testID)
-	req, err := ts.client.NewRequest(ctx, "GET", u, nil)
+	u, err := addOptions(u, opt)
 	if err != nil {
-		return Test{}, nil, err
+		return TestWithMetrics{}, nil, err
 	}
 
-	var t Test
+	req, err := ts.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return TestWithMetrics{}, nil, err
+	}
+	req.Header.Set("Buildkite-Version", testsMetricsAPIVersion)
+
+	var t TestWithMetrics
 	resp, err := ts.client.Do(req, &t)
 	if err != nil {
-		return Test{}, resp, err
+		return TestWithMetrics{}, resp, err
 	}
 
 	return t, resp, err

--- a/tests_test.go
+++ b/tests_test.go
@@ -22,7 +22,7 @@ func TestTestsService_List(t *testing.T) {
 
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
-		if got, want := r.Header.Get("Buildkite-Version"), testsListAPIVersion; got != want {
+		if got, want := r.Header.Get("Buildkite-Version"), testsMetricsAPIVersion; got != want {
 			t.Errorf("Buildkite-Version header = %q, want %q", got, want)
 		}
 		testFormValues(t, r, values{
@@ -153,7 +153,7 @@ func TestTestsService_List_NilOptionsAndReliability(t *testing.T) {
 		if got := r.URL.RawQuery; got != "" {
 			t.Errorf("request query = %q, want empty", got)
 		}
-		if got, want := r.Header.Get("Buildkite-Version"), testsListAPIVersion; got != want {
+		if got, want := r.Header.Get("Buildkite-Version"), testsMetricsAPIVersion; got != want {
 			t.Errorf("Buildkite-Version header = %q, want %q", got, want)
 		}
 		_, _ = fmt.Fprint(w, `[
@@ -229,6 +229,14 @@ func TestTestsService_Get(t *testing.T) {
 
 	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f", func(w http.ResponseWriter, r *http.Request) {
 		testMethod(t, r, "GET")
+		if got, want := r.Header.Get("Buildkite-Version"), testsMetricsAPIVersion; got != want {
+			t.Errorf("Buildkite-Version header = %q, want %q", got, want)
+		}
+		testFormValues(t, r, values{
+			"min_timestamp": "2026-07-01T00:00:00Z",
+			"max_timestamp": "2026-07-23T00:00:00Z",
+		})
+
 		_, _ = fmt.Fprint(w,
 			`
 			{
@@ -239,27 +247,89 @@ func TestTestsService_Get(t *testing.T) {
 				"scope": "User#email",
 				"location": "./resources/test_example_test.go:123",
 				"file_name": "./resources/test_example_test.go",
-				"labels": ["flaky"]
+				"labels": ["flaky"],
+				"reliability": 0.9821,
+				"duration_avg": 0.213,
+				"duration_sum": 23.856,
+				"duration_min": 0.108,
+				"duration_max": 1.942,
+				"executions_count": 113,
+				"executions_count_by_result": {
+					"passed": 110,
+					"failed": 2,
+					"skipped": 1
+				}
 			}`)
 	})
 
-	got, _, err := client.Tests.Get(context.Background(), "my-great-org", "suite-example", "b3abe2e9-35c5-4905-85e1-8c9f2da3240f")
+	got, _, err := client.Tests.Get(context.Background(), "my-great-org", "suite-example", "b3abe2e9-35c5-4905-85e1-8c9f2da3240f", &TestsGetOptions{
+		MinTimestamp: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+		MaxTimestamp: time.Date(2026, time.July, 23, 0, 0, 0, 0, time.UTC),
+	})
 	if err != nil {
-		t.Errorf("TestSuites.Get returned error: %v", err)
+		t.Errorf("TestsService.Get returned error: %v", err)
 	}
 
-	want := Test{
-		ID:       "b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
-		URL:      "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
-		WebURL:   "https://buildkite.com/organizations/my-great-org/analytics/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
-		Name:     "TestExample1_Create",
-		Scope:    "User#email",
-		Location: "./resources/test_example_test.go:123",
-		FileName: "./resources/test_example_test.go",
-		Labels:   []string{"flaky"},
+	reliability := 0.9821
+	want := TestWithMetrics{
+		Test: Test{
+			ID:       "b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+			URL:      "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+			WebURL:   "https://buildkite.com/organizations/my-great-org/analytics/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+			Name:     "TestExample1_Create",
+			Scope:    "User#email",
+			Location: "./resources/test_example_test.go:123",
+			FileName: "./resources/test_example_test.go",
+			Labels:   []string{"flaky"},
+		},
+		Reliability:     &reliability,
+		DurationAverage: 0.213,
+		DurationTotal:   23.856,
+		DurationMinimum: 0.108,
+		DurationMaximum: 1.942,
+		ExecutionsCount: 113,
+		ExecutionsCountByResult: map[string]int{
+			"passed":  110,
+			"failed":  2,
+			"skipped": 1,
+		},
 	}
 
 	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("TestsService.Get diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestTestsService_Get_NilOptionsAndPeriod(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/nil-options", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.RawQuery; got != "" {
+			t.Errorf("request query = %q, want empty", got)
+		}
+		_, _ = fmt.Fprint(w, `{"id": "nil-options", "reliability": null, "executions_count": 0}`)
+	})
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/period", func(w http.ResponseWriter, r *http.Request) {
+		testFormValues(t, r, values{"period": "28days"})
+		_, _ = fmt.Fprint(w, `{"id": "period", "reliability": null, "executions_count": 0}`)
+	})
+
+	got, _, err := client.Tests.Get(context.Background(), "my-great-org", "suite-example", "nil-options", nil)
+	if err != nil {
+		t.Fatalf("TestsService.Get returned error: %v", err)
+	}
+	if diff := cmp.Diff(got, TestWithMetrics{Test: Test{ID: "nil-options"}}); diff != "" {
+		t.Errorf("TestsService.Get diff: (-got +want)\n%s", diff)
+	}
+
+	got, _, err = client.Tests.Get(context.Background(), "my-great-org", "suite-example", "period", &TestsGetOptions{Period: "28days"})
+	if err != nil {
+		t.Fatalf("TestsService.Get returned error: %v", err)
+	}
+	if diff := cmp.Diff(got, TestWithMetrics{Test: Test{ID: "period"}}); diff != "" {
 		t.Errorf("TestsService.Get diff: (-got +want)\n%s", diff)
 	}
 }


### PR DESCRIPTION
`TestsService.Get` now opts in to the versioned get-test response (`Buildkite-Version: 2026-08-01`) and returns `TestWithMetrics` — reliability, duration statistics, and execution counts alongside the test attributes. This matches what `TestsService.List` already does.

The endpoint also accepts `period`, `min_timestamp`, and `max_timestamp` to control the aggregation window (the other List filters are not supported here), so `Get` takes a new `*TestsGetOptions`.

### Breaking changes

```go
// before
func (ts *TestsService) Get(ctx context.Context, org, slug, testID string) (Test, *Response, error)

// after
func (ts *TestsService) Get(ctx context.Context, org, slug, testID string, opt *TestsGetOptions) (TestWithMetrics, *Response, error)
```

`TestWithMetrics` embeds `Test`, so field access on the result is unaffected; callers assigning the result to a `Test` and callers of the 4-argument form need updating. Passing `nil` options preserves the previous request shape apart from the version header.

### Also

- Renamed the unexported `testsListAPIVersion` to `testsMetricsAPIVersion`, since both `List` and `Get` use it.
- `examples/tests/get` gained a `--period` flag.

### Testing

`TestTestsService_Get` asserts the version header, the timestamp query params, and the full metrics payload. `TestTestsService_Get_NilOptionsAndPeriod` covers nil options (empty query string) and `period`. `go test ./...` and `go vet ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)