### PR TITLE
Add Teams to CreatePipeline

### DIFF
--- a/pipelines.go
+++ b/pipelines.go
@@ -15,6 +15,10 @@ type PipelinesService struct {
 }
 
 // CreatePipeline - Create a Pipeline.
+//
+// Teams maps a team UUID to its access level on the pipeline: read_only,
+// build_and_read or manage_build_and_read. It supersedes TeamUuids, which is
+// deprecated because it cannot carry an access level.
 type CreatePipeline struct {
 	Name       string `json:"name"`
 	Repository string `json:"repository"`
@@ -37,6 +41,7 @@ type CreatePipeline struct {
 	CancelRunningBranchBuilds       bool              `json:"cancel_running_branch_builds"`
 	CancelRunningBranchBuildsFilter string            `json:"cancel_running_branch_builds_filter,omitempty"`
 	TeamUuids                       []string          `json:"team_uuids,omitempty"`
+	Teams                           map[string]string `json:"teams,omitempty"`
 	Visibility                      string            `json:"visibility,omitempty"`
 	Tags                            []string          `json:"tags,omitempty"`
 }

--- a/pipelines_test.go
+++ b/pipelines_test.go
@@ -585,3 +585,43 @@ func TestPluginsUnmarshal(t *testing.T) {
 		})
 	}
 }
+
+func TestPipelinesService_CreateWithTeams(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	input := CreatePipeline{
+		Name:          "my-great-pipeline",
+		Repository:    "my-great-repo",
+		ClusterID:     "528000d8-4ee1-4479-8af1-032b143185f0",
+		Configuration: "steps:\n  - command: \"script/release.sh\"",
+		Teams: map[string]string{
+			"b3a1c8f4-1f2e-4f0e-9d8c-0a1b2c3d4e5f": "build_and_read",
+		},
+	}
+
+	server.HandleFunc("/v2/organizations/my-great-org/pipelines", func(w http.ResponseWriter, r *http.Request) {
+		var v map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&v); err != nil {
+			t.Fatalf("Error parsing json body: %v", err)
+		}
+
+		testMethod(t, r, "POST")
+
+		want := map[string]any{"b3a1c8f4-1f2e-4f0e-9d8c-0a1b2c3d4e5f": "build_and_read"}
+		if diff := cmp.Diff(v["teams"], want); diff != "" {
+			t.Errorf("teams diff: (-got +want)\n%s", diff)
+		}
+		if _, ok := v["team_uuids"]; ok {
+			t.Error("team_uuids should be omitted when unset")
+		}
+
+		_, _ = fmt.Fprint(w, `{"name":"my-great-pipeline","repository":"my-great-repo"}`)
+	})
+
+	if _, _, err := client.Pipelines.Create(context.Background(), "my-great-org", input); err != nil {
+		t.Errorf("Pipelines.Create returned error: %v", err)
+	}
+}


### PR DESCRIPTION
`CreatePipeline` only carries `team_uuids`. The [REST API docs](https://buildkite.com/docs/apis/rest-api/pipelines#create-a-yaml-pipeline) mark that parameter deprecated and replace it with `teams`, which maps each team UUID to an access level (`read_only`, `build_and_read`, `manage_build_and_read`). Callers cannot set an access level today.

Adds `Teams map[string]string`. `TeamUuids` stays, so existing callers still compile.

The deprecation note sits in the `CreatePipeline` doc comment, not on the field. A `// Deprecated:` marker on the field would be machine-readable, but any full-line comment inside a struct ends gofmt's field alignment group and splits the block. Prose in the struct doc keeps one aligned block, at the cost of the staticcheck/gopls warning.

`teams` also accepts a plain array of UUIDs, which takes the organization default access level. The map form is the one that needs the client change, so this adds only that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)