### PR TITLE
Add TestSuitesService.ListByPipeline

### DIFF
--- a/examples/test_suites/list_by_pipeline/main.go
+++ b/examples/test_suites/list_by_pipeline/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Organization slug").Required().String()
+	pipeline = kingpin.Flag("pipeline", "Pipeline slug").Required().String()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	suites, _, err := client.TestSuites.ListByPipeline(context.Background(), *org, *pipeline, nil)
+	if err != nil {
+		log.Fatalf("listing test suites for pipeline failed: %s", err)
+	}
+
+	data, err := json.MarshalIndent(suites, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/test_suites.go
+++ b/test_suites.go
@@ -61,6 +61,30 @@ func (tss *TestSuitesService) List(ctx context.Context, org string, opt *TestSui
 	return testSuites, resp, err
 }
 
+// ListByPipeline returns the test suites that have recorded at least one run
+// attributed to the given pipeline, ordered by creation time. Each suite is
+// returned once.
+func (tss *TestSuitesService) ListByPipeline(ctx context.Context, org, pipelineSlug string, opt *TestSuiteListOptions) ([]TestSuite, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/pipelines/%s/suites", org, pipelineSlug)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := tss.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var testSuites []TestSuite
+	resp, err := tss.client.Do(req, &testSuites)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return testSuites, resp, err
+}
+
 func (tss *TestSuitesService) Get(ctx context.Context, org, slug string) (TestSuite, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s", org, slug)
 	req, err := tss.client.NewRequest(ctx, "GET", u, nil)

--- a/test_suites_test.go
+++ b/test_suites_test.go
@@ -72,6 +72,53 @@ func TestTestSuitesService_List(t *testing.T) {
 	}
 }
 
+func TestTestSuitesService_ListByPipeline(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/pipelines/my-great-pipeline/suites", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{"page": "2"})
+		_, _ = fmt.Fprint(w,
+			`
+			[
+				{
+					"id": "7c202aaa-3165-4811-9813-173c4c285463",
+					"graphql_id": "N2MyMDJhYWEtMzE2NS00ODExLTk4MTMtMTczYzRjMjg1NDYz=",
+					"slug": "suite-1",
+					"name": "suite-1",
+					"url": "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-1",
+					"web_url": "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-1",
+					"default_branch": "main"
+				}
+			]`)
+	})
+
+	suites, _, err := client.TestSuites.ListByPipeline(context.Background(), "my-great-org", "my-great-pipeline", &TestSuiteListOptions{
+		ListOptions: ListOptions{Page: 2},
+	})
+	if err != nil {
+		t.Errorf("TestSuites.ListByPipeline returned error: %v", err)
+	}
+
+	want := []TestSuite{
+		{
+			ID:            "7c202aaa-3165-4811-9813-173c4c285463",
+			GraphQLID:     "N2MyMDJhYWEtMzE2NS00ODExLTk4MTMtMTczYzRjMjg1NDYz=",
+			Slug:          "suite-1",
+			Name:          "suite-1",
+			URL:           "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-1",
+			WebURL:        "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-1",
+			DefaultBranch: "main",
+		},
+	}
+	if diff := cmp.Diff(suites, want); diff != "" {
+		t.Errorf("TestSuites.ListByPipeline diff: (-got +want)\n%s", diff)
+	}
+}
+
 func TestTestSuitesService_Get(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Adds support for the `listPipelineSuites` operation from the [Test Engine OpenAPI spec](https://api.buildkite.com/v2/analytics/openapi.yaml).

```go
suites, _, err := client.TestSuites.ListByPipeline(ctx, org, pipelineSlug, nil)
```

`GET /v2/analytics/organizations/{org}/pipelines/{pipeline_slug}/suites` returns the suites that have recorded at least one run attributed to the pipeline. It responds with the same `Suite` schema as `listSuites`/`getSuite`, so the new method decodes into the existing `TestSuite` type and takes `TestSuiteListOptions` for pagination — mirroring how `BuildsService.ListByPipeline` reuses `BuildsListOptions`.

Also adds an `examples/test_suites/list_by_pipeline` example alongside the existing `list` one.

Two things intentionally left out:

- The `Suite` schema in the spec also carries `organization_id`, `application_name`, `color`, `emoji`, `oidc_policy`, and `api_token`, none of which are on `TestSuite` today. Adding them would change `List`/`Get` too, so it felt like a separate change.
- The spec documents no pagination parameters for this operation, but the options struct is wired up for consistency with every other list method.

Closes [TE-6802](https://linear.app/buildkite/issue/TE-6802/update-go-buildkite-with-pipelinesuites-endpoint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
