### PR TITLE
feat(tests): add Test Engine quarantine support

### DIFF
--- a/examples/tests/list_quarantined/main.go
+++ b/examples/tests/list_quarantined/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Organization slug").Required().String()
+	slug     = kingpin.Flag("slug", "Test suite slug").Required().String()
+	state    = kingpin.Flag("state", "Quarantine state to list").Required().Enum("muted", "skipped")
+	page     = kingpin.Flag("page", "Page of results to retrieve").Int()
+	perPage  = kingpin.Flag("per-page", "Number of tests to include per page").Int()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	ctx := context.Background()
+	opt := &buildkite.QuarantinedTestsListOptions{
+		ListOptions: buildkite.ListOptions{Page: *page, PerPage: *perPage},
+	}
+
+	var (
+		tests []buildkite.Test
+		resp  *buildkite.Response
+	)
+	switch *state {
+	case "muted":
+		tests, resp, err = client.Tests.ListMuted(ctx, *org, *slug, opt)
+	case "skipped":
+		tests, resp, err = client.Tests.ListSkipped(ctx, *org, *slug, opt)
+	}
+	if err != nil {
+		log.Fatalf("listing %s tests failed: %s", *state, err)
+	}
+
+	data, err := json.MarshalIndent(tests, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+
+	// These endpoints paginate, so this is one page of the quarantine list.
+	if resp.NextPage != 0 {
+		_, _ = fmt.Fprintf(os.Stderr, "\nmore results: next page %d, last page %d\n", resp.NextPage, resp.LastPage)
+	}
+}

--- a/examples/tests/set_state/main.go
+++ b/examples/tests/set_state/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
+)
+
+var (
+	apiToken = kingpin.Flag("token", "API token").Required().String()
+	org      = kingpin.Flag("org", "Organization slug").Required().String()
+	slug     = kingpin.Flag("slug", "Test suite slug").Required().String()
+	testID   = kingpin.Flag("testID", "Test ID").Required().String()
+	action   = kingpin.Flag("action", "State to move the test into").Required().Enum("skip", "mute", "enable")
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(buildkite.WithTokenAuth(*apiToken))
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	var test buildkite.Test
+	switch *action {
+	case "skip":
+		test, _, err = client.Tests.Skip(ctx, *org, *slug, *testID)
+	case "mute":
+		test, _, err = client.Tests.Mute(ctx, *org, *slug, *testID)
+	case "enable":
+		test, _, err = client.Tests.Enable(ctx, *org, *slug, *testID)
+	}
+	if err != nil {
+		log.Fatalf("%s test %s failed: %s", *action, *testID, err)
+	}
+
+	data, err := json.MarshalIndent(test, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s", string(data))
+}

--- a/tests.go
+++ b/tests.go
@@ -3,11 +3,17 @@ package buildkite
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
 )
 
 // TestsService handles communication with test related
 // methods of the Buildkite Test Analytics API.
+//
+// Every method escapes the org, suite and test values it interpolates into the
+// request path. An unescaped "#" would truncate the path at that point, because
+// url.Parse strips everything after it into a fragment that is never sent — so
+// a Skip would reach the Enable endpoint, and a List the suite endpoint.
 //
 // Buildkite API docs: https://buildkite.com/docs/apis/rest-api/analytics/tests
 type TestsService struct {
@@ -97,7 +103,10 @@ type TestsListOptions struct {
 	// "!" to exclude it, for example "payments,!platform".
 	Owners string `url:"owners,omitempty"`
 
-	// State filters by test state: "enabled", "muted", or "skipped".
+	// State filters by test state: "enabled", "muted", or "skipped". It filters
+	// the aggregation, so it reports only tests that ran within the window; for
+	// the complete quarantine list use [TestsService.ListMuted] or
+	// [TestsService.ListSkipped].
 	State string `url:"state,omitempty"`
 
 	// Tags filters by comma-separated execution tags in key:value form. Prefix a
@@ -130,7 +139,8 @@ type FindTestOptions struct {
 // tests with executions in that window. Pagination is available through the
 // returned Response.
 func (ts *TestsService) List(ctx context.Context, org, slug string, opt *TestsListOptions) ([]TestWithMetrics, *Response, error) {
-	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests", org, slug)
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests",
+		url.PathEscape(org), url.PathEscape(slug))
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return nil, nil, err
@@ -171,7 +181,8 @@ type TestsGetOptions struct {
 // Get returns a single test with its execution metrics aggregated over the
 // requested time window. It opts in to the versioned metrics response.
 func (ts *TestsService) Get(ctx context.Context, org, slug, testID string, opt *TestsGetOptions) (TestWithMetrics, *Response, error) {
-	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/%s", org, slug, testID)
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/%s",
+		url.PathEscape(org), url.PathEscape(slug), url.PathEscape(testID))
 	u, err := addOptions(u, opt)
 	if err != nil {
 		return TestWithMetrics{}, nil, err
@@ -193,7 +204,8 @@ func (ts *TestsService) Get(ctx context.Context, org, slug, testID string, opt *
 }
 
 func (ts *TestsService) Find(ctx context.Context, org, slug string, find FindTestOptions) (Test, *Response, error) {
-	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/find", org, slug)
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/find",
+		url.PathEscape(org), url.PathEscape(slug))
 	req, err := ts.client.NewRequest(ctx, "POST", u, find)
 	if err != nil {
 		return Test{}, nil, err
@@ -204,4 +216,121 @@ func (ts *TestsService) Find(ctx context.Context, org, slug string, find FindTes
 		return Test{}, resp, err
 	}
 	return t, resp, err
+}
+
+// QuarantinedTestsListOptions specifies optional parameters for
+// [TestsService.ListMuted] and [TestsService.ListSkipped].
+type QuarantinedTestsListOptions struct {
+	ListOptions
+}
+
+// changeState moves a test into the state reached by action, which is one of
+// "skip", "mute" or "enable", and returns the updated test.
+func (ts *TestsService) changeState(ctx context.Context, org, slug, testID, action string) (Test, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/%s/%s",
+		url.PathEscape(org), url.PathEscape(slug), url.PathEscape(testID), action)
+	req, err := ts.client.NewRequest(ctx, "PUT", u, nil)
+	if err != nil {
+		return Test{}, nil, err
+	}
+
+	var t Test
+	resp, err := ts.client.Do(req, &t)
+	if err != nil {
+		return Test{}, resp, err
+	}
+
+	return t, resp, nil
+}
+
+// listByState returns the tests in the given quarantine state, which is one of
+// "muted" or "skipped". Pagination is available through the returned Response.
+func (ts *TestsService) listByState(ctx context.Context, org, slug, state string, opt *QuarantinedTestsListOptions) ([]Test, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/suites/%s/tests/%s",
+		url.PathEscape(org), url.PathEscape(slug), state)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := ts.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var tests []Test
+	resp, err := ts.client.Do(req, &tests)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return tests, resp, nil
+}
+
+// Skip quarantines a test by skipping it, so that supported test runners do not
+// execute it. It requires the write_suites scope.
+//
+// The response carries no state field, so callers confirming the new state
+// should use [TestsService.ListSkipped].
+//
+// It returns 404 when the suite does not have test state management enabled.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/rest-api/test-engine/quarantine#update-test-state-skip-test
+func (ts *TestsService) Skip(ctx context.Context, org, slug, testID string) (Test, *Response, error) {
+	return ts.changeState(ctx, org, slug, testID, "skip")
+}
+
+// Mute quarantines a test by muting it, so that its failures do not fail the
+// build. It requires the write_suites scope.
+//
+// The response carries no state field, so callers confirming the new state
+// should use [TestsService.ListMuted].
+//
+// It returns 404 when the suite does not have test state management enabled.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/rest-api/test-engine/quarantine#update-test-state-mute-test
+func (ts *TestsService) Mute(ctx context.Context, org, slug, testID string) (Test, *Response, error) {
+	return ts.changeState(ctx, org, slug, testID, "mute")
+}
+
+// Enable removes a test from quarantine, undoing a previous skip or mute. It
+// requires the write_suites scope.
+//
+// An enabled test appears in neither [TestsService.ListMuted] nor
+// [TestsService.ListSkipped], so confirming the new state means checking for
+// its absence from both, or listing with [TestsListOptions.State] "enabled".
+//
+// It returns 404 when the suite does not have test state management enabled.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/rest-api/test-engine/quarantine#update-test-state-enable-test
+func (ts *TestsService) Enable(ctx context.Context, org, slug, testID string) (Test, *Response, error) {
+	return ts.changeState(ctx, org, slug, testID, "enable")
+}
+
+// ListMuted returns every muted test in a suite, for configuring a test runner
+// to ignore their failures. It requires the read_suites scope, and returns 404
+// when the suite does not have test state management enabled.
+//
+// Unlike [TestsService.List] with [TestsListOptions.State] "muted", which
+// reports only tests that ran within the aggregation window, this is the
+// complete quarantine list. Pagination is available through the returned
+// Response.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/rest-api/test-engine/quarantine#list-quarantined-tests-muted-tests
+func (ts *TestsService) ListMuted(ctx context.Context, org, slug string, opt *QuarantinedTestsListOptions) ([]Test, *Response, error) {
+	return ts.listByState(ctx, org, slug, "muted", opt)
+}
+
+// ListSkipped returns every skipped test in a suite, for configuring a test
+// runner to skip them. It requires the read_suites scope, and returns 404 when
+// the suite does not have test state management enabled.
+//
+// Unlike [TestsService.List] with [TestsListOptions.State] "skipped", which
+// reports only tests that ran within the aggregation window, this is the
+// complete quarantine list. Pagination is available through the returned
+// Response.
+//
+// Buildkite API docs: https://buildkite.com/docs/apis/rest-api/test-engine/quarantine#list-quarantined-tests-skipped-tests
+func (ts *TestsService) ListSkipped(ctx context.Context, org, slug string, opt *QuarantinedTestsListOptions) ([]Test, *Response, error) {
+	return ts.listByState(ctx, org, slug, "skipped", opt)
 }

--- a/tests_test.go
+++ b/tests_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -383,5 +385,351 @@ func TestTestsService_Find(t *testing.T) {
 
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("TestsService.Find diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestTestsService_ChangeState(t *testing.T) {
+	t.Parallel()
+
+	const testID = "b3abe2e9-35c5-4905-85e1-8c9f2da3240f"
+
+	tests := []struct {
+		name string
+		call func(*Client) (Test, *Response, error)
+		path string
+	}{
+		{
+			name: "skip",
+			call: func(c *Client) (Test, *Response, error) {
+				return c.Tests.Skip(context.Background(), "my-great-org", "suite-example", testID)
+			},
+			path: "/v2/analytics/organizations/my-great-org/suites/suite-example/tests/" + testID + "/skip",
+		},
+		{
+			name: "mute",
+			call: func(c *Client) (Test, *Response, error) {
+				return c.Tests.Mute(context.Background(), "my-great-org", "suite-example", testID)
+			},
+			path: "/v2/analytics/organizations/my-great-org/suites/suite-example/tests/" + testID + "/mute",
+		},
+		{
+			name: "enable",
+			call: func(c *Client) (Test, *Response, error) {
+				return c.Tests.Enable(context.Background(), "my-great-org", "suite-example", testID)
+			},
+			path: "/v2/analytics/organizations/my-great-org/suites/suite-example/tests/" + testID + "/enable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server, client, teardown := newMockServerAndClient(t)
+			t.Cleanup(teardown)
+
+			server.HandleFunc(tc.path, func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "PUT")
+
+				// The quarantine endpoints take no request body; sending one
+				// would be a change the API never asked for.
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					t.Errorf("reading request body: %v", err)
+				}
+				if len(body) != 0 {
+					t.Errorf("request body = %q, want empty", body)
+				}
+				if got := r.Header.Get("Content-Type"); got != "" {
+					t.Errorf("Content-Type header = %q, want empty", got)
+				}
+
+				_, _ = fmt.Fprint(w, `
+			{
+				"id": "b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+				"url": "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+				"web_url": "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+				"scope": "Flaky test",
+				"name": "passes only on the second try on BK CI",
+				"location": "./spec/flaky_spec.rb:6",
+				"file_name": "./spec/flaky_spec.rb",
+				"labels": ["flaky"]
+			}`)
+			})
+
+			got, resp, err := tc.call(client)
+			if err != nil {
+				t.Fatalf("TestsService.%s returned error: %v", tc.name, err)
+			}
+
+			want := Test{
+				ID:       testID,
+				URL:      "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+				WebURL:   "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f",
+				Scope:    "Flaky test",
+				Name:     "passes only on the second try on BK CI",
+				Location: "./spec/flaky_spec.rb:6",
+				FileName: "./spec/flaky_spec.rb",
+				Labels:   []string{"flaky"},
+			}
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("TestsService.%s diff: (-got +want)\n%s", tc.name, diff)
+			}
+			if resp == nil || resp.StatusCode != http.StatusOK {
+				t.Errorf("TestsService.%s response = %#v, want status %d", tc.name, resp, http.StatusOK)
+			}
+		})
+	}
+}
+
+// A suite without test state management enabled 404s the quarantine endpoints,
+// which must surface as an error rather than an empty test.
+func TestTestsService_ChangeState_StateManagementDisabled(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9-35c5-4905-85e1-8c9f2da3240f/mute", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"message":"Not Found"}`)
+	})
+
+	got, resp, err := client.Tests.Mute(context.Background(), "my-great-org", "suite-example", "b3abe2e9-35c5-4905-85e1-8c9f2da3240f")
+	if err == nil {
+		t.Fatal("TestsService.Mute returned nil error, want API error")
+	}
+	if diff := cmp.Diff(got, Test{}); diff != "" {
+		t.Errorf("TestsService.Mute returned test diff: (-got +want)\n%s", diff)
+	}
+	if resp == nil || resp.StatusCode != http.StatusNotFound {
+		t.Errorf("TestsService.Mute response = %#v, want status %d", resp, http.StatusNotFound)
+	}
+	var apiErr *ErrorResponse
+	if !errors.As(err, &apiErr) {
+		t.Errorf("TestsService.Mute error type = %T, want *ErrorResponse", err)
+	}
+}
+
+func TestTestsService_ListByState(t *testing.T) {
+	t.Parallel()
+
+	const linkHeader = `<https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/muted?page=3>; rel="next", <https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/muted?page=4>; rel="last"`
+
+	tests := []struct {
+		name string
+		call func(*Client, *QuarantinedTestsListOptions) ([]Test, *Response, error)
+		path string
+	}{
+		{
+			name: "muted",
+			call: func(c *Client, opt *QuarantinedTestsListOptions) ([]Test, *Response, error) {
+				return c.Tests.ListMuted(context.Background(), "my-great-org", "suite-example", opt)
+			},
+			path: "/v2/analytics/organizations/my-great-org/suites/suite-example/tests/muted",
+		},
+		{
+			name: "skipped",
+			call: func(c *Client, opt *QuarantinedTestsListOptions) ([]Test, *Response, error) {
+				return c.Tests.ListSkipped(context.Background(), "my-great-org", "suite-example", opt)
+			},
+			path: "/v2/analytics/organizations/my-great-org/suites/suite-example/tests/skipped",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			server, client, teardown := newMockServerAndClient(t)
+			t.Cleanup(teardown)
+
+			server.HandleFunc(tc.path, func(w http.ResponseWriter, r *http.Request) {
+				testMethod(t, r, "GET")
+				testFormValues(t, r, values{"page": "2", "per_page": "50"})
+
+				w.Header().Set("Link", linkHeader)
+				_, _ = fmt.Fprint(w, `[
+			{
+				"id": "160988e4-836e-88ab-af45-22170a169e23",
+				"url": "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/160988e4-836e-88ab-af45-22170a169e23",
+				"web_url": "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/tests/160988e4-836e-88ab-af45-22170a169e23",
+				"scope": "Flaky test",
+				"name": "passes only on the second try on BK CI",
+				"location": "flaky.spec.js:1",
+				"file_name": "flaky.spec.js",
+				"labels": []
+			}
+		]`)
+			})
+
+			got, resp, err := tc.call(client, &QuarantinedTestsListOptions{
+				ListOptions: ListOptions{Page: 2, PerPage: 50},
+			})
+			if err != nil {
+				t.Fatalf("TestsService.%s returned error: %v", tc.name, err)
+			}
+
+			want := []Test{
+				{
+					ID:       "160988e4-836e-88ab-af45-22170a169e23",
+					URL:      "https://api.buildkite.com/v2/analytics/organizations/my-great-org/suites/suite-example/tests/160988e4-836e-88ab-af45-22170a169e23",
+					WebURL:   "https://buildkite.com/organizations/my-great-org/analytics/suites/suite-example/tests/160988e4-836e-88ab-af45-22170a169e23",
+					Scope:    "Flaky test",
+					Name:     "passes only on the second try on BK CI",
+					Location: "flaky.spec.js:1",
+					FileName: "flaky.spec.js",
+					Labels:   []string{},
+				},
+			}
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("TestsService.%s diff: (-got +want)\n%s", tc.name, diff)
+			}
+			if got, want := resp.NextPage, 3; got != want {
+				t.Errorf("response.NextPage = %d, want %d", got, want)
+			}
+			if got, want := resp.LastPage, 4; got != want {
+				t.Errorf("response.LastPage = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestTestsService_ListByState_NilOptions(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/skipped", func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		if got := r.URL.RawQuery; got != "" {
+			t.Errorf("request query = %q, want empty", got)
+		}
+		_, _ = fmt.Fprint(w, `[]`)
+	})
+
+	got, _, err := client.Tests.ListSkipped(context.Background(), "my-great-org", "suite-example", nil)
+	if err != nil {
+		t.Fatalf("TestsService.ListSkipped returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("TestsService.ListSkipped returned %d items, want 0", len(got))
+	}
+}
+
+func TestTestsService_ListByState_ServerError(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc("/v2/analytics/organizations/my-great-org/suites/suite-example/tests/muted", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"message":"Not Found"}`)
+	})
+
+	got, resp, err := client.Tests.ListMuted(context.Background(), "my-great-org", "suite-example", nil)
+	if err == nil {
+		t.Fatal("TestsService.ListMuted returned nil error, want API error")
+	}
+	if got != nil {
+		t.Errorf("TestsService.ListMuted returned items %v, want nil", got)
+	}
+	if resp == nil || resp.StatusCode != http.StatusNotFound {
+		t.Errorf("TestsService.ListMuted response = %#v, want status %d", resp, http.StatusNotFound)
+	}
+}
+
+// A test ID or suite slug carrying path metacharacters must not be able to
+// redirect the request to a different endpoint. Unescaped, a trailing "#"
+// truncates the path at that point: a Skip reaches the Enable endpoint, a List
+// reaches the suite endpoint, and a Get reaches a different test.
+//
+// Escaping makes the value inert, not verbatim: resolveURL decodes "%2F" back
+// to a separator, so an escaped slash arrives as extra path segments rather
+// than as one literal segment. Either way no route matches and the API 404s,
+// which is why the expectations below are the paths this client really sends.
+func TestTestsService_PathInjection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		call     func(*Client) error
+		wantPath string
+		body     string // the shape the method under test decodes
+	}{
+		{
+			name: "test id escaping an action onto the path",
+			call: func(c *Client) error {
+				_, _, err := c.Tests.Skip(context.Background(), "my-great-org", "suite-example", "b3abe2e9/enable#")
+				return err
+			},
+			// The escaped slash decodes back to a separator, but the "#" stays
+			// escaped and the action stays "skip" — no route matches, so the API
+			// 404s instead of enabling the test.
+			wantPath: "/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9/enable%23/skip",
+			body:     "{}",
+		},
+		{
+			name: "slug truncating a list onto the suite endpoint",
+			call: func(c *Client) error {
+				_, _, err := c.Tests.List(context.Background(), "my-great-org", "suite-example#", nil)
+				return err
+			},
+			wantPath: "/v2/analytics/organizations/my-great-org/suites/suite-example%23/tests",
+			body:     "[]",
+		},
+		{
+			name: "test id truncating a get onto a different test",
+			call: func(c *Client) error {
+				_, _, err := c.Tests.Get(context.Background(), "my-great-org", "suite-example", "b3abe2e9#", nil)
+				return err
+			},
+			wantPath: "/v2/analytics/organizations/my-great-org/suites/suite-example/tests/b3abe2e9%23",
+			body:     "{}",
+		},
+		{
+			name: "slug truncating a find onto the suite endpoint",
+			call: func(c *Client) error {
+				_, _, err := c.Tests.Find(context.Background(), "my-great-org", "suite-example#", FindTestOptions{Scope: "s", Name: "n"})
+				return err
+			},
+			wantPath: "/v2/analytics/organizations/my-great-org/suites/suite-example%23/tests/find",
+			body:     "{}",
+		},
+		{
+			name: "percent-encoded separator in a test id",
+			call: func(c *Client) error {
+				_, _, err := c.Tests.Mute(context.Background(), "my-great-org", "suite-example", "a%2Fb")
+				return err
+			},
+			wantPath: "/v2/analytics/organizations/my-great-org/suites/suite-example/tests/a%252Fb/mute",
+			body:     "{}",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotPath string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotPath = r.URL.EscapedPath()
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := NewOpts(WithBaseURL(server.URL))
+			if err != nil {
+				t.Fatalf("unexpected NewOpts() error: %v", err)
+			}
+			if err := tc.call(client); err != nil {
+				t.Fatalf("call returned error: %v", err)
+			}
+			if gotPath != tc.wantPath {
+				t.Errorf("request path = %q, want %q", gotPath, tc.wantPath)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add Skip, Mute, Enable, ListMuted and ListSkipped to TestsService, and escape the org, suite and test values interpolated into request paths.