### PR TITLE
feat: add ExecutionsService.ListSlowestByBuild

### DIFF
--- a/examples/executions/slowest_by_build/main.go
+++ b/examples/executions/slowest_by_build/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/alecthomas/kingpin/v2"
+	"github.com/buildkite/go-buildkite/v5"
+)
+
+var (
+	apiToken  = kingpin.Flag("token", "API token").Required().String()
+	baseURL   = kingpin.Flag("base-url", "Buildkite API base URL").Default(buildkite.DefaultBaseURL).String()
+	org       = kingpin.Flag("org", "Organization slug").Required().String()
+	buildUUID = kingpin.Flag("build-id", "Build UUID").Required().String()
+	limit     = kingpin.Flag("limit", "Maximum number of executions to return. Defaults to the API default of 20.").Int()
+	withTrace = kingpin.Flag("with-trace", "Also fetch the trace summary for the slowest execution").Bool()
+)
+
+func main() {
+	kingpin.Parse()
+
+	client, err := buildkite.NewOpts(
+		buildkite.WithTokenAuth(*apiToken),
+		buildkite.WithBaseURL(*baseURL),
+	)
+	if err != nil {
+		log.Fatalf("creating buildkite API client failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	executions, _, err := client.Executions.ListSlowestByBuild(ctx, *org, *buildUUID, &buildkite.SlowestExecutionsOptions{
+		Limit: *limit,
+	})
+	if err != nil {
+		log.Fatalf("listing slowest executions for build %s failed: %s", *buildUUID, err)
+	}
+
+	printJSON(executions)
+
+	if !*withTrace || len(executions) == 0 {
+		return
+	}
+
+	slowest := executions[0]
+	trace, _, err := client.Executions.GetTrace(ctx, *org, slowest.SuiteSlug, slowest.ID, nil)
+	if err != nil {
+		log.Fatalf("getting trace for execution %s failed: %s", slowest.ID, err)
+	}
+
+	printJSON(trace)
+}
+
+func printJSON(v any) {
+	data, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		log.Fatalf("json encode failed: %s", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(data))
+}

--- a/examples/executions/slowest_by_build/main.go
+++ b/examples/executions/slowest_by_build/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/buildkite/go-buildkite/v5"
@@ -16,8 +15,8 @@ var (
 	baseURL   = kingpin.Flag("base-url", "Buildkite API base URL").Default(buildkite.DefaultBaseURL).String()
 	org       = kingpin.Flag("org", "Organization slug").Required().String()
 	buildUUID = kingpin.Flag("build-id", "Build UUID").Required().String()
-	limit     = kingpin.Flag("limit", "Maximum number of executions to return. Defaults to the API default of 20.").Int()
-	withTrace = kingpin.Flag("with-trace", "Also fetch the trace summary for the slowest execution").Bool()
+	limit     = kingpin.Flag("limit", "Maximum number of executions to return (API default: 20)").Int()
+	withTrace = kingpin.Flag("with-trace", "Also fetch the trace of the slowest execution").Bool()
 )
 
 func main() {
@@ -33,11 +32,9 @@ func main() {
 
 	ctx := context.Background()
 
-	executions, _, err := client.Executions.ListSlowestByBuild(ctx, *org, *buildUUID, &buildkite.SlowestExecutionsOptions{
-		Limit: *limit,
-	})
+	executions, _, err := client.Executions.ListSlowestByBuild(ctx, *org, *buildUUID, &buildkite.SlowestExecutionsOptions{Limit: *limit})
 	if err != nil {
-		log.Fatalf("listing slowest executions for build %s failed: %s", *buildUUID, err)
+		log.Fatalf("listing slowest executions for build %s failed: %v", *buildUUID, err)
 	}
 
 	printJSON(executions)
@@ -49,7 +46,7 @@ func main() {
 	slowest := executions[0]
 	trace, _, err := client.Executions.GetTrace(ctx, *org, slowest.SuiteSlug, slowest.ID, nil)
 	if err != nil {
-		log.Fatalf("getting trace for execution %s failed: %s", slowest.ID, err)
+		log.Fatalf("getting trace for execution %s failed: %v", slowest.ID, err)
 	}
 
 	printJSON(trace)
@@ -58,8 +55,8 @@ func main() {
 func printJSON(v any) {
 	data, err := json.MarshalIndent(v, "", "\t")
 	if err != nil {
-		log.Fatalf("json encode failed: %s", err)
+		log.Fatalf("json encode failed: %v", err)
 	}
 
-	_, _ = fmt.Fprintf(os.Stdout, "%s\n", string(data))
+	fmt.Println(string(data))
 }

--- a/examples/executions/slowest_by_build/main.go
+++ b/examples/executions/slowest_by_build/main.go
@@ -16,7 +16,7 @@ var (
 	org       = kingpin.Flag("org", "Organization slug").Required().String()
 	buildUUID = kingpin.Flag("build-id", "Build UUID").Required().String()
 	limit     = kingpin.Flag("limit", "Maximum number of executions to return (API default: 20)").Int()
-	withTrace = kingpin.Flag("with-trace", "Also fetch the trace of the slowest execution").Bool()
+	withTrace = kingpin.Flag("with-trace", "Also fetch the trace of the slowest execution if it has one").Bool()
 )
 
 func main() {
@@ -44,6 +44,11 @@ func main() {
 	}
 
 	slowest := executions[0]
+	if !slowest.HasTrace {
+		log.Printf("execution %s has no trace within retention", slowest.ID)
+		return
+	}
+
 	trace, _, err := client.Executions.GetTrace(ctx, *org, slowest.SuiteSlug, slowest.ID, nil)
 	if err != nil {
 		log.Fatalf("getting trace for execution %s failed: %v", slowest.ID, err)

--- a/executions.go
+++ b/executions.go
@@ -182,3 +182,60 @@ func (es *ExecutionsService) GetTrace(ctx context.Context, org, slug, executionI
 
 	return trace, resp, err
 }
+
+// BuildExecution is a single test execution recorded against a build. SuiteSlug
+// and ID are the arguments to [ExecutionsService.GetTrace].
+type BuildExecution struct {
+	ID        string `json:"id"`
+	SuiteSlug string `json:"suite_slug"`
+	TestID    string `json:"test_id"`
+
+	// Duration is the most recently recorded duration of the execution in
+	// seconds. Trace spans report time as [time.Duration]; convert with
+	// time.Duration(Duration * float64(time.Second)) before comparing the two.
+	Duration float64 `json:"duration"`
+}
+
+// SlowestExecutionsOptions specifies optional parameters for
+// [ExecutionsService.ListSlowestByBuild].
+type SlowestExecutionsOptions struct {
+	// Limit is the maximum number of executions to return. It defaults to 20
+	// and is capped by the organization's slowest executions quota; the API
+	// rejects values outside that range.
+	Limit int `url:"limit,omitempty"`
+}
+
+// ListSlowestByBuild returns the slowest test executions recorded against a
+// build, across every suite the caller can view. Executions are ordered slowest
+// first, with ties broken by execution ID newest first. The result is a top-N
+// list rather than a paginated collection; use Limit to control its size. While
+// the build is still running, the list reflects the executions uploaded so far.
+//
+// buildUUID is the build's UUID, not the pipeline's build number.
+//
+// Each result's SuiteSlug and ID identify the execution to
+// [ExecutionsService.GetTrace], whose default summary view returns the test's
+// name, location and result alongside where its time went. Not every listed
+// execution still has a trace: spans are retained for a shorter window than
+// executions, so GetTrace returns an empty trace for those rather than an
+// error.
+func (es *ExecutionsService) ListSlowestByBuild(ctx context.Context, org, buildUUID string, opt *SlowestExecutionsOptions) ([]BuildExecution, *Response, error) {
+	u := fmt.Sprintf("v2/analytics/organizations/%s/builds/%s/executions/slowest", org, buildUUID)
+	u, err := addOptions(u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	req, err := es.client.NewRequest(ctx, "GET", u, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var executions []BuildExecution
+	resp, err := es.client.Do(req, &executions)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return executions, resp, err
+}

--- a/executions.go
+++ b/executions.go
@@ -183,16 +183,14 @@ func (es *ExecutionsService) GetTrace(ctx context.Context, org, slug, executionI
 	return trace, resp, err
 }
 
-// BuildExecution is a single test execution recorded against a build. SuiteSlug
-// and ID are the arguments to [ExecutionsService.GetTrace].
+// BuildExecution is a test execution recorded against a build. SuiteSlug and ID
+// are the arguments to [ExecutionsService.GetTrace].
 type BuildExecution struct {
 	ID        string `json:"id"`
 	SuiteSlug string `json:"suite_slug"`
 	TestID    string `json:"test_id"`
 
-	// Duration is the most recently recorded duration of the execution in
-	// seconds. Trace spans report time as [time.Duration]; convert with
-	// time.Duration(Duration * float64(time.Second)) before comparing the two.
+	// Duration is the execution's duration in seconds.
 	Duration float64 `json:"duration"`
 }
 
@@ -200,25 +198,16 @@ type BuildExecution struct {
 // [ExecutionsService.ListSlowestByBuild].
 type SlowestExecutionsOptions struct {
 	// Limit is the maximum number of executions to return. It defaults to 20
-	// and is capped by the organization's slowest executions quota; the API
-	// rejects values outside that range.
+	// and is capped by the organization's slowest executions quota.
 	Limit int `url:"limit,omitempty"`
 }
 
 // ListSlowestByBuild returns the slowest test executions recorded against a
-// build, across every suite the caller can view. Executions are ordered slowest
-// first, with ties broken by execution ID newest first. The result is a top-N
-// list rather than a paginated collection; use Limit to control its size. While
-// the build is still running, the list reflects the executions uploaded so far.
+// build, across every suite the caller can view, slowest first. It is a top-N
+// list rather than a paginated collection. While the build is still running it
+// reflects the executions uploaded so far.
 //
 // buildUUID is the build's UUID, not the pipeline's build number.
-//
-// Each result's SuiteSlug and ID identify the execution to
-// [ExecutionsService.GetTrace], whose default summary view returns the test's
-// name, location and result alongside where its time went. Not every listed
-// execution still has a trace: spans are retained for a shorter window than
-// executions, so GetTrace returns an empty trace for those rather than an
-// error.
 func (es *ExecutionsService) ListSlowestByBuild(ctx context.Context, org, buildUUID string, opt *SlowestExecutionsOptions) ([]BuildExecution, *Response, error) {
 	u := fmt.Sprintf("v2/analytics/organizations/%s/builds/%s/executions/slowest", org, buildUUID)
 	u, err := addOptions(u, opt)

--- a/executions.go
+++ b/executions.go
@@ -192,6 +192,10 @@ type BuildExecution struct {
 
 	// Duration is the execution's duration in seconds.
 	Duration float64 `json:"duration"`
+
+	// HasTrace indicates a trace was recorded and is within span retention.
+	// Even when true, GetTrace may return an empty trace if spans were sampled away.
+	HasTrace bool `json:"has_trace"`
 }
 
 // SlowestExecutionsOptions specifies optional parameters for

--- a/executions_test.go
+++ b/executions_test.go
@@ -396,7 +396,7 @@ func TestExecutionsService_ListSlowestByBuild_ServerError(t *testing.T) {
 
 	server.HandleFunc(fmt.Sprintf("/v2/analytics/organizations/my-great-org/builds/%s/executions/slowest", testBuildUUID), func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnprocessableEntity)
-		_, _ = fmt.Fprint(w, "{\"message\":\"limit must be an integer between 1 and 100\"}")
+		_, _ = fmt.Fprint(w, `{"message": "limit must be an integer between 1 and 100"}`)
 	})
 
 	got, resp, err := client.Executions.ListSlowestByBuild(context.Background(), "my-great-org", testBuildUUID, &SlowestExecutionsOptions{Limit: 500})

--- a/executions_test.go
+++ b/executions_test.go
@@ -311,3 +311,108 @@ func TestExecutionsService_GetTrace_NotFound(t *testing.T) {
 		t.Errorf("response.StatusCode = %d, want %d", got, want)
 	}
 }
+
+func TestExecutionsService_ListSlowestByBuild(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc(fmt.Sprintf("/v2/analytics/organizations/my-great-org/builds/%s/executions/slowest", testBuildUUID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{
+			"limit": "2",
+		})
+
+		_, _ = fmt.Fprint(w,
+			`
+			[
+				{
+					"id": "019d66fc-1a2b-7c3d-8e4f-5a6b7c8d9e0f",
+					"suite_slug": "suite-example",
+					"test_id": "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+					"duration": 12.345
+				},
+				{
+					"id": "019d66fc-0000-7c3d-8e4f-5a6b7c8d9e0f",
+					"suite_slug": "other-suite",
+					"test_id": "b0e3a5b8-2b7c-4a4e-9d9e-1f2a3b4c5d6e",
+					"duration": 2.5
+				}
+			]`)
+	})
+
+	got, _, err := client.Executions.ListSlowestByBuild(context.Background(), "my-great-org", testBuildUUID, &SlowestExecutionsOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("ExecutionsService.ListSlowestByBuild returned error: %v", err)
+	}
+
+	want := []BuildExecution{
+		{
+			ID:        "019d66fc-1a2b-7c3d-8e4f-5a6b7c8d9e0f",
+			SuiteSlug: "suite-example",
+			TestID:    "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
+			Duration:  12.345,
+		},
+		{
+			ID:        "019d66fc-0000-7c3d-8e4f-5a6b7c8d9e0f",
+			SuiteSlug: "other-suite",
+			TestID:    "b0e3a5b8-2b7c-4a4e-9d9e-1f2a3b4c5d6e",
+			Duration:  2.5,
+		},
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("ExecutionsService.ListSlowestByBuild diff: (-got +want)\n%s", diff)
+	}
+}
+
+func TestExecutionsService_ListSlowestByBuild_ZeroLimitOmitted(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc(fmt.Sprintf("/v2/analytics/organizations/my-great-org/builds/%s/executions/slowest", testBuildUUID), func(w http.ResponseWriter, r *http.Request) {
+		testMethod(t, r, "GET")
+		testFormValues(t, r, values{})
+
+		_, _ = fmt.Fprint(w, `[]`)
+	})
+
+	got, _, err := client.Executions.ListSlowestByBuild(context.Background(), "my-great-org", testBuildUUID, &SlowestExecutionsOptions{})
+	if err != nil {
+		t.Fatalf("ExecutionsService.ListSlowestByBuild returned error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ExecutionsService.ListSlowestByBuild returned %v, want no executions", got)
+	}
+}
+
+func TestExecutionsService_ListSlowestByBuild_ServerError(t *testing.T) {
+	t.Parallel()
+
+	server, client, teardown := newMockServerAndClient(t)
+	t.Cleanup(teardown)
+
+	server.HandleFunc(fmt.Sprintf("/v2/analytics/organizations/my-great-org/builds/%s/executions/slowest", testBuildUUID), func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = fmt.Fprint(w, "{\"message\":\"limit must be an integer between 1 and 100\"}")
+	})
+
+	got, resp, err := client.Executions.ListSlowestByBuild(context.Background(), "my-great-org", testBuildUUID, &SlowestExecutionsOptions{Limit: 500})
+	if err == nil {
+		t.Fatal("ExecutionsService.ListSlowestByBuild returned nil error, want API error")
+	}
+	if got != nil {
+		t.Errorf("ExecutionsService.ListSlowestByBuild returned items %v, want nil", got)
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("ExecutionsService.ListSlowestByBuild response = %#v, want status %d", resp, http.StatusUnprocessableEntity)
+	}
+	var apiErr *ErrorResponse
+	if !errors.As(err, &apiErr) {
+		t.Errorf("ExecutionsService.ListSlowestByBuild error type = %T, want *ErrorResponse", err)
+	} else if got, want := apiErr.Message, "limit must be an integer between 1 and 100"; got != want {
+		t.Errorf("ExecutionsService.ListSlowestByBuild error message = %q, want %q", got, want)
+	}
+}

--- a/executions_test.go
+++ b/executions_test.go
@@ -331,13 +331,15 @@ func TestExecutionsService_ListSlowestByBuild(t *testing.T) {
 					"id": "019d66fc-1a2b-7c3d-8e4f-5a6b7c8d9e0f",
 					"suite_slug": "suite-example",
 					"test_id": "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
-					"duration": 12.345
+					"duration": 12.345,
+					"has_trace": true
 				},
 				{
 					"id": "019d66fc-0000-7c3d-8e4f-5a6b7c8d9e0f",
 					"suite_slug": "other-suite",
 					"test_id": "b0e3a5b8-2b7c-4a4e-9d9e-1f2a3b4c5d6e",
-					"duration": 2.5
+					"duration": 2.5,
+					"has_trace": false
 				}
 			]`)
 	})
@@ -353,12 +355,14 @@ func TestExecutionsService_ListSlowestByBuild(t *testing.T) {
 			SuiteSlug: "suite-example",
 			TestID:    "a915535c-a8f1-4e1a-bd6a-a5589e09f349",
 			Duration:  12.345,
+			HasTrace:  true,
 		},
 		{
 			ID:        "019d66fc-0000-7c3d-8e4f-5a6b7c8d9e0f",
 			SuiteSlug: "other-suite",
 			TestID:    "b0e3a5b8-2b7c-4a4e-9d9e-1f2a3b4c5d6e",
 			Duration:  2.5,
+			HasTrace:  false,
 		},
 	}
 	if diff := cmp.Diff(got, want); diff != "" {


### PR DESCRIPTION
Adds `client.Executions.ListSlowestByBuild`, which answers "which tests took the longest in this build?" It returns the slowest executions first, across every suite the caller can see. Each result has the `SuiteSlug` and `ID` that `GetTrace` needs, so finding a slow test and seeing where its time went is two calls:

```go
executions, _, err := client.Executions.ListSlowestByBuild(ctx, org, buildUUID, &buildkite.SlowestExecutionsOptions{Limit: 5})
if err == nil && len(executions) > 0 && executions[0].HasTrace {
    trace, _, err := client.Executions.GetTrace(ctx, org, executions[0].SuiteSlug, executions[0].ID, nil)
    // Handle err and use trace.
}
```

`HasTrace` reflects the endpoint's `has_trace` hint added in [buildkite/buildkite#33970](https://github.com/buildkite/buildkite/pull/33970): a trace was recorded and is still within span retention. Check it before fetching a trace; even when true, the trace may be empty if spans were sampled away. The `--with-trace` example skips the request when the slowest execution has no trace.

The response is a top-N list, not a paginated collection, so the method returns a plain slice. `Limit` defaults to the server's 20 when left zero.

Includes tests, and an example under `examples/executions/slowest_by_build`.

Stacked on #378, which adds `ExecutionsService`. Closes TE-6981.
